### PR TITLE
add yet codebuild ci and latest test runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.phony: ci
+
+ci:
+	clojure -Xdb-h2:test

--- a/deps.edn
+++ b/deps.edn
@@ -25,9 +25,9 @@
   ;; {:extra-deps {}}
   :test
   {:extra-paths ["src/test"]
-   :extra-deps {org.clojure/test.check {:mvn/version "1.0.0"}}}
-  :runner
-  {:extra-deps
-   {com.cognitect/test-runner
-    {:git/url "https://github.com/cognitect-labs/test-runner.git"
-     :sha     "b6b3193fcc42659d7e46ecd1884a228993441182"}}}}}
+   :extra-deps {org.clojure/test.check {:mvn/version "1.0.0"}
+                io.github.cognitect-labs/test-runner
+                {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                 :sha "2d69f33d7980c3353b246c28f72ffeafbd9f2fab"}}
+   :exec-fn cognitect.test-runner.api/test
+   :exec-args {:dirs ["src/test"]}}}}


### PR DESCRIPTION
Adds a simple `Makefile` and uses the new `-X` invocation in `tools.cli` like depstar does.
Looks like tests are not passing, but that shouldn't bar a merge of this if you're happy with how to run it.