### PR TITLE
[SQL-17] `format` property

### DIFF
--- a/src/main/lrsql/hugsql/input/statement.clj
+++ b/src/main/lrsql/hugsql/input/statement.clj
@@ -387,6 +387,7 @@
     limit       :limit
     asc?        :ascending
     atts?       :attachments
+    format      :format
     ;; page                :page
     ;; from                :from
     }]
@@ -398,6 +399,7 @@
         rel-actors? (boolean rel-actors?)
         rel-activs? (boolean rel-activs?)
         actor-ifi   (when actor (ua/actor->ifi actor))
+        format      (when format (keyword format))
         limit       (when (and (int? limit) (not (zero? limit)))
                       limit)] ; "0" = no limit
     (cond-> {}
@@ -411,4 +413,5 @@
       act-iri   (merge {:activity-iri act-iri :related-activities? rel-activs?})
       limit     (assoc :limit limit)
       asc?      (assoc :ascending asc?)
-      atts?     (assoc :attachments? atts?))))
+      atts?     (assoc :attachments? atts?)
+      format    (assoc :format format))))

--- a/src/main/lrsql/hugsql/spec/statement.clj
+++ b/src/main/lrsql/hugsql/spec/statement.clj
@@ -57,6 +57,7 @@
 (s/def ::until inst?)
 (s/def ::limit nat-int?)
 (s/def ::ascending? boolean?)
+(s/def ::format #{:ids :exact :canonical})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Statements and Attachment Args
@@ -232,4 +233,5 @@
                    ::related-actors?
                    ::related-activities?
                    ::hs-actor/actor-ifi
-                   ::hs-activ/activity-iri]))
+                   ::hs-activ/activity-iri
+                   ::format]))

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -47,7 +47,7 @@
    (let [conn   (:conn-pool lrs)
          inputs (stmt-input/statement-query-input params)]
      (jdbc/with-transaction [tx (conn)]
-       (stmt-command/query-statements tx inputs))))
+       (stmt-command/query-statements tx inputs ltags))))
   (-consistent-through
    [this ctx auth-identity]
     ;; TODO: review, this should be OK because of transactions, but we may want

--- a/src/test/lrsql/lrs_test.clj
+++ b/src/test/lrsql/lrs_test.clj
@@ -123,52 +123,63 @@
     (testing "statement ID queries"
       ;; Statement ID queries
       (is (= {:statement stmt-1}
-             (-> (lrsp/-get-statements lrs {} {:voidedStatementId id-1} {})
+             (-> (lrsp/-get-statements lrs {} {:voidedStatementId id-1} #{})
+                 (update :statement remove-props))))
+      (is (= {:statement stmt-1}
+             (-> (lrsp/-get-statements lrs {} {:voidedStatementId id-1 :format "canonical"} #{"en-US"})
+                 (update :statement remove-props))))
+      (is (= {:statement
+              {"id"     "030e001f-b32a-4361-b701-039a3d9fceb1"
+               "actor"  {"objectType" "Agent"
+                         "mbox"       "mailto:sample.agent@example.com"}
+               "verb"   {"id" "http://adlnet.gov/expapi/verbs/answered"}
+               "object" {"id" "http://www.example.com/tincan/activities/multipart"}}}
+             (-> (lrsp/-get-statements lrs {} {:voidedStatementId id-1 :format "ids"} #{})
                  (update :statement remove-props))))
       (is (= {:statement stmt-2}
-             (-> (lrsp/-get-statements lrs {} {:statementId id-2} {})
+             (-> (lrsp/-get-statements lrs {} {:statementId id-2} #{})
                  (update :statement remove-props))))
       (is (= {:statement stmt-3}
-             (-> (lrsp/-get-statements lrs {} {:statementId id-3} {})
+             (-> (lrsp/-get-statements lrs {} {:statementId id-3} #{})
                  (update :statement remove-props)))))
     (testing "statement property queries"
       (is (= {:statement-result {:statements [] :more ""}
               :attachments      []}
-             (lrsp/-get-statements lrs {} {:since ts} {})))
+             (lrsp/-get-statements lrs {} {:since ts} #{})))
       (is (= {:statement-result {:statements [stmt-1 stmt-2 stmt-3 stmt-4] :more ""}
               :attachments      []}
-             (-> (lrsp/-get-statements lrs {} {:until ts} {})
+             (-> (lrsp/-get-statements lrs {} {:until ts} #{})
                  (update-in [:statement-result :statements]
                             (partial map remove-props)))))
       (is (= {:statement-result {:statements [stmt-1] :more ""}
               :attachments      []}
-             (-> (lrsp/-get-statements lrs {} {:agent agt-1} {})
+             (-> (lrsp/-get-statements lrs {} {:agent agt-1} #{})
                  (update-in [:statement-result :statements]
                             (partial map remove-props)))))
       (is (= {:statement-result {:statements [stmt-1 stmt-3] :more ""}
               :attachments      []}
-             (-> (lrsp/-get-statements lrs {} {:agent agt-1 :related_agents true} {})
+             (-> (lrsp/-get-statements lrs {} {:agent agt-1 :related_agents true} #{})
                  (update-in [:statement-result :statements]
                             (partial map remove-props)))))
       (is (= {:statement-result {:statements [stmt-1 stmt-3] :more ""}
               :attachments      []}
-             (-> (lrsp/-get-statements lrs {} {:verb vrb-1} {})
+             (-> (lrsp/-get-statements lrs {} {:verb vrb-1} #{})
                  (update-in [:statement-result :statements]
                             (partial map remove-props)))))
       (is (= {:statement-result {:statements [stmt-1] :more ""}
               :attachments      []}
-             (-> (lrsp/-get-statements lrs {} {:activity act-1} {})
+             (-> (lrsp/-get-statements lrs {} {:activity act-1} #{})
                  (update-in [:statement-result :statements]
                             (partial map remove-props)))))
       (is (= {:statement-result {:statements [stmt-1 stmt-3] :more ""}
               :attachments      []}
-             (-> (lrsp/-get-statements lrs {} {:activity act-1 :related_activities true} {})
+             (-> (lrsp/-get-statements lrs {} {:activity act-1 :related_activities true} #{})
                  (update-in [:statement-result :statements]
                             (partial map remove-props))))))
     (testing "querying with attachments"
       (is (= {:statement-result {:statements [stmt-4] :more ""}
               :attachments      [(update stmt-4-attach :content #(String. %))]}
-             (-> (lrsp/-get-statements lrs {} {:activity act-4 :attachments true} {})
+             (-> (lrsp/-get-statements lrs {} {:activity act-4 :attachments true} #{})
                  (update-in [:statement-result :statements]
                             (partial map remove-props))
                  (update-in [:attachments]


### PR DESCRIPTION
Add support for `format` property, particularly `ids` and `canonical` modes. However, DON'T add support for the following:
> The LRS MAY maintain canonical versions of language maps against any IRI identifying an object containing language maps.