### PR TITLE
Update ephemeral target for new ns layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,12 @@ config/keystore.jks:
 
 keystore: config/keystore.jks
 
-ci: keystore 
+ci: keystore
 	clojure -X:test
 
-ephemeral:
-	ENV=:dev \
-        LRSQL_DB_TYPE=h2:mem \
+ephemeral: keystore
+	LRSQL_DB_TYPE=h2:mem \
         LRSQL_DB_NAME=ephemeral \
         LRSQL_SEED_API_KEY=username \
         LRSQL_SEED_API_SECRET=password \
-        clojure -Mdb-h2 -m lrsql.main
+        clojure -Mdb-h2 -m lrsql.h2.main


### PR DESCRIPTION
Now that h2 has its own entrypoint, we'd use that for ephemeral. Also demonstrates loading and running a single alias slice from cli.