### PR TITLE
Fix call to `person` function

### DIFF
--- a/src/main/lrsql/util/actor.clj
+++ b/src/main/lrsql/util/actor.clj
@@ -26,4 +26,7 @@
   "Given the Agent or Group `actor`, return an equivalent Person object with
    the IFI and name wrapped in vectors."
   [actor]
-  (agnt/person actor))
+  ;; agnt/person takes zero or more args
+  (if actor
+    (agnt/person actor)
+    (agnt/person)))


### PR DESCRIPTION
The function `com.yetanalytics.lrs.xapi.agents/person` takes variable args, including zero, so this hotfix is applied to avoid passing in `nil` agents.