### PR TITLE
Docker Release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/target/bundle/runtimes/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,13 @@ jobs:
     - name: Setup CI Environment
       uses: yetanalytics/actions/setup-env@v0
 
+    - name: Log in to Docker Hub (Tag Pushes)
+      #if: ${{ startsWith(github.ref, 'refs/tags') }}
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+
     - name: Build Bundle
       run: make bundle
 
@@ -47,3 +54,20 @@ jobs:
       with:
         branch: gh-pages
         folder: target/bundle/doc
+
+    - name: Extract metadata (tags, labels) for Docker
+      #if: ${{ startsWith(github.ref, 'refs/tags') }}
+      id: meta
+      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      with:
+        images: yetanalytics/lrsql
+
+    - name: Echo docker meta
+      run: echo '${{ steps.meta.outputs.tags }}'
+    # - name: Build and push Docker image
+    #   if: ${{ startsWith(github.ref, 'refs/tags') }}
+    #   uses: docker/build-push-action@v2
+    #   with:
+    #     context: .
+    #     push: true
+    #     tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,6 @@ jobs:
     - name: Setup CI Environment
       uses: yetanalytics/actions/setup-env@v0
 
-    - name: Log in to Docker Hub (Tag Pushes)
-      #if: ${{ startsWith(github.ref, 'refs/tags') }}
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_TOKEN }}
-
     - name: Build Bundle
       run: make bundle
 
@@ -55,19 +48,24 @@ jobs:
         branch: gh-pages
         folder: target/bundle/doc
 
-    - name: Extract metadata (tags, labels) for Docker
-      #if: ${{ startsWith(github.ref, 'refs/tags') }}
+    - name: Log in to Docker Hub (Tag Pushes)
+      if: ${{ startsWith(github.ref, 'refs/tags') }}
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker (Tag Pushes)
+      if: ${{ startsWith(github.ref, 'refs/tags') }}
       id: meta
-      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      uses: docker/metadata-action@v3
       with:
         images: yetanalytics/lrsql
 
-    - name: Echo docker meta
-      run: echo '${{ steps.meta.outputs.tags }}'
-    # - name: Build and push Docker image
-    #   if: ${{ startsWith(github.ref, 'refs/tags') }}
-    #   uses: docker/build-push-action@v2
-    #   with:
-    #     context: .
-    #     push: true
-    #     tags: ${{ steps.meta.outputs.tags }}
+    - name: Build and push Docker image (Tag Pushes)
+      if: ${{ startsWith(github.ref, 'refs/tags') }}
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ ADD target/bundle /lrsql
 WORKDIR /lrsql
 EXPOSE 8080
 EXPOSE 8443
-CMD ["bin/run_sqlite.sh"]
+CMD ["/lrsql/bin/run_sqlite.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,18 @@
-FROM openjdk:11-slim
+FROM alpine:3.14
+
 ADD target/bundle /lrsql
+
+# replace the linux runtime via jlink
+RUN apk update \
+        && apk upgrade \
+        && apk add ca-certificates \
+        && update-ca-certificates \
+        && apk add --no-cache openjdk11 \
+        && mkdir -p /lrsql/runtimes \
+        && jlink --output /lrsql/runtimes/linux/ --add-modules java.base,java.logging,java.naming,java.xml,java.sql,java.transaction.xa,java.security.sasl,java.management \
+        && apk del openjdk11 \
+        && rm -rf /var/cache/apk/*
+
 WORKDIR /lrsql
 EXPOSE 8080
 EXPOSE 8443

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ ADD target/bundle /lrsql
 WORKDIR /lrsql
 EXPOSE 8080
 EXPOSE 8443
-CMD ["bin/run_h2.sh"]
+CMD ["bin/run_sqlite.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-slim
-ADD target/bundle /bundle
-WORKDIR /bundle
+ADD target/bundle /lrsql
+WORKDIR /lrsql
 EXPOSE 8080
 EXPOSE 8443
 CMD ["bin/run_h2.sh"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For releases and release notes, see the [Releases](https://github.com/yetanalyti
 - [Getting Started](doc/startup.md)
 - [Setting up TLS/HTTPS](doc/https.md)
 - [Authority Configuration](doc/authority.md)
+- [Docker Image](docker.md)
 
 ### DBMS-specific Sections
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For releases and release notes, see the [Releases](https://github.com/yetanalyti
 - [Getting Started](doc/startup.md)
 - [Setting up TLS/HTTPS](doc/https.md)
 - [Authority Configuration](doc/authority.md)
-- [Docker Image](docker.md)
+- [Docker Image](doc/docker.md)
 
 ### DBMS-specific Sections
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -2,7 +2,7 @@
 
 # Docker Image
 
-Yet Analytics publishes Docker container images of SQL LRS on [DockerHub](https://hub.docker.com/repository/docker/yetanalytics/lrsql).
+Yet Analytics publishes Docker container images of SQL LRS on [DockerHub](https://hub.docker.com/repository/docker/yetanalytics/lrsql) in the format `yetanalytics/lrsql:<release version | latest>`.
 
 ## Usage
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -47,6 +47,8 @@ docker run \
     /lrsql/bin/run_postgres.sh
 ```
 
+Note that you will also need to ensure that a PostgreSQL instance is accessible to the container for this command to work.
+
 ### Customization
 
 The SQL LRS image can be used as a base image for a customized docker image.

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -9,7 +9,6 @@ Yet Analytics publishes Docker container images of SQL LRS on [DockerHub](https:
 You can run SQL LRS directly from the Docker CLI in its default SQLite configuration:
 
 ``` shell
-
 $ docker run \
     -p 8080:8080 \
     -e LRSQL_API_KEY_DEFAULT=my_key \
@@ -17,7 +16,6 @@ $ docker run \
     -e LRSQL_ADMIN_USER_DEFAULT=my_username \
     -e LRSQL_ADMIN_PASS_DEFAULT=my_password \
     yetanalytics/lrsql:latest
-
 ```
 
 ### Other DBMSs
@@ -25,7 +23,6 @@ $ docker run \
 The SQL LRS Dockerfile uses the SQLite run script in `bin` as the default `CMD`. To change to another DBMS use the corresponding script. For instance to use PostgreSQL:
 
 ``` shell
-
 $ docker run \
     -p 8080:8080 \
     -e LRSQL_API_KEY_DEFAULT=my_key \
@@ -40,7 +37,22 @@ $ docker run \
     -e LRSQL_DB_SCHEMA=lrsql \
     yetanalytics/lrsql:latest \
     bin/run_postgres.sh
-
 ```
+
+### Customization
+
+The SQL LRS image can be used as a base image for a customized docker image.
+
+For instance, to make an image with a custom configuration:
+
+``` dockerfile
+FROM yetanalytics/lrsql:latest
+ADD my_lrsql.json /lrsql/config/lrsql.json
+EXPOSE 8080
+EXPOSE 8443
+CMD ["bin/run_postgres.sh"]
+```
+
+The resulting image will use the provided configuration file and run PostgreSQL.
 
 [<- Back to Index](index.md)

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -10,6 +10,7 @@ You can run SQL LRS directly from the Docker CLI in its default SQLite configura
 
 ``` shell
 docker run \
+    -it \
     -p 8080:8080 \
     -e LRSQL_API_KEY_DEFAULT=my_key \
     -e LRSQL_API_SECRET_DEFAULT=my_secret \
@@ -17,6 +18,8 @@ docker run \
     -e LRSQL_ADMIN_PASS_DEFAULT=my_password \
     yetanalytics/lrsql:latest
 ```
+
+Note that the `-it` option will give you a pseudo-TTY and attach you to the container, allowing you to stop the SQL LRS container with ^C. It is not needed for production use, where `-d` would be preferable. See the [docker run docs](https://docs.docker.com/engine/reference/commandline/run/) for more information.
 
 See [Configuration Variables](env_vars.md) for more options.
 
@@ -26,6 +29,7 @@ The SQL LRS Dockerfile uses the SQLite run script in `bin` as the default `CMD`.
 
 ``` shell
 docker run \
+    -it \
     -p 8080:8080 \
     -e LRSQL_API_KEY_DEFAULT=my_key \
     -e LRSQL_API_SECRET_DEFAULT=my_secret \
@@ -38,7 +42,7 @@ docker run \
     -e LRSQL_DB_PASSWORD=my_password \
     -e LRSQL_DB_SCHEMA=lrsql \
     yetanalytics/lrsql:latest \
-    bin/run_postgres.sh
+    /lrsql/bin/run_postgres.sh
 ```
 
 ### Customization
@@ -52,7 +56,7 @@ FROM yetanalytics/lrsql:latest
 ADD my_lrsql.json /lrsql/config/lrsql.json
 EXPOSE 8080
 EXPOSE 8443
-CMD ["bin/run_postgres.sh"]
+CMD ["/lrsql/bin/run_postgres.sh"]
 ```
 
 The resulting image will use the provided configuration file and run PostgreSQL. See [Getting Started](startup.md) for more configuration information.

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -4,7 +4,7 @@
 
 Yet Analytics publishes Docker container images of SQL LRS on [DockerHub](https://hub.docker.com/repository/docker/yetanalytics/lrsql) in the format `yetanalytics/lrsql:<release version | latest>`.
 
-## Usage
+### Usage
 
 You can run SQL LRS directly from the Docker CLI in its default SQLite configuration:
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -41,8 +41,7 @@ docker run \
     -e LRSQL_DB_PORT=5432 \
     -e LRSQL_DB_NAME=lrsql_db \
     -e LRSQL_DB_USER=lrsql_user \
-    -e LRSQL_DB_PASSWORD=my_password \
-    -e LRSQL_DB_SCHEMA=lrsql \
+    -e LRSQL_DB_PASSWORD=lrsql_password \
     yetanalytics/lrsql:latest \
     /lrsql/bin/run_postgres.sh
 ```

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -19,6 +19,8 @@ docker run \
     yetanalytics/lrsql:latest
 ```
 
+After SQL LRS starts and you see the logo, navigate to [http://0.0.0.0:8080/admin](http://0.0.0.0:8080/admin) to access the UI.
+
 Note that the `-it` option will give you a pseudo-TTY and attach you to the container, allowing you to stop the SQL LRS container with ^C. It is not needed for production use, where `-d` would be preferable. See the [docker run docs](https://docs.docker.com/engine/reference/commandline/run/) for more information.
 
 See [Configuration Variables](env_vars.md) for more options.

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -56,13 +56,24 @@ Docker will start Postgres and then SQL LRS. Note that Postgres can sometimes ta
 
 ### Customization
 
-The SQL LRS image can be used as a base image for a customized docker image.
+The SQL LRS image can be used as a base image for a customized docker image. This is how you would accomplish customizations such as a TLS certificate, configuration file, or custom authority.
 
-For instance, to make an image with a custom configuration:
+For instance, to make an image with custom configuration, certs and authority:
 
 ``` dockerfile
 FROM yetanalytics/lrsql:latest
-ADD my_lrsql.json /lrsql/config/lrsql.json
+
+# custom configuration
+ADD my_lrsql.json              /lrsql/config/lrsql.json
+
+# custom certs
+ADD my_server.key.pem          /lrsql/config/server.key.pem
+ADD my_server.crt.pem          /lrsql/config/server.crt.pem
+ADD my_cacert.pem              /lrsql/config/cacert.pem
+
+# custom authority
+ADD my_authority.json.template /lrsql/config/authority.json.template
+
 EXPOSE 8080
 EXPOSE 8443
 CMD ["/lrsql/bin/run_postgres.sh"]

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -27,7 +27,7 @@ See [Configuration Variables](env_vars.md) for more options.
 
 #### Other DBMSs
 
-The SQL LRS Dockerfile uses the SQLite run script in `bin` as the default `CMD`. To change to another DBMS use the corresponding script. For instance to use PostgreSQL:
+The SQL LRS Dockerfile uses the SQLite run script in `bin` as the default `CMD`. To change to another DBMS use the corresponding script. For instance to use Postgres:
 
 ``` shell
 docker run \
@@ -46,13 +46,13 @@ docker run \
     /lrsql/bin/run_postgres.sh
 ```
 
-Note that you will also need to ensure that a PostgreSQL instance is accessible to the container for this command to work. For a demonstration of containerized SQL LRS with PostgreSQL you can use the `docker-compose.yml` file in the project root:
+Note that you will also need to ensure that a Postgres instance is accessible to the container for this command to work. For a demonstration of containerized SQL LRS with Postgres you can use the `docker-compose.yml` file in the project root:
 
 ``` shell
 docker compose up
 ```
 
-Docker will start PostgreSQL and then SQL LRS. Note that PostgreSQL can sometimes take a while to start causing SQL LRS initialization to fail. If this happens, stop the system with ctrl-C and run the command again.
+Docker will start Postgres and then SQL LRS. Note that Postgres can sometimes take a while to start causing SQL LRS initialization to fail. If this happens, stop the system with ctrl-C and run the command again.
 
 ### Customization
 
@@ -68,6 +68,6 @@ EXPOSE 8443
 CMD ["/lrsql/bin/run_postgres.sh"]
 ```
 
-The resulting image will use the provided configuration file and run PostgreSQL. See [Getting Started](startup.md) for more configuration information.
+The resulting image will use the provided configuration file and run Postgres. See [Getting Started](startup.md) for more configuration information.
 
 [<- Back to Index](index.md)

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -18,6 +18,8 @@ docker run \
     yetanalytics/lrsql:latest
 ```
 
+See [Configuration Variables](env_vars.md) for more options.
+
 ### Other DBMSs
 
 The SQL LRS Dockerfile uses the SQLite run script in `bin` as the default `CMD`. To change to another DBMS use the corresponding script. For instance to use PostgreSQL:
@@ -53,6 +55,6 @@ EXPOSE 8443
 CMD ["bin/run_postgres.sh"]
 ```
 
-The resulting image will use the provided configuration file and run PostgreSQL.
+The resulting image will use the provided configuration file and run PostgreSQL. See [Getting Started](startup.md) for more configuration information.
 
 [<- Back to Index](index.md)

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -46,7 +46,13 @@ docker run \
     /lrsql/bin/run_postgres.sh
 ```
 
-Note that you will also need to ensure that a PostgreSQL instance is accessible to the container for this command to work. For a demonstration of containerized SQL LRS with PostgreSQL please see the `docker-compose.yml` file in the project root.
+Note that you will also need to ensure that a PostgreSQL instance is accessible to the container for this command to work. For a demonstration of containerized SQL LRS with PostgreSQL you can use the `docker-compose.yml` file in the project root:
+
+``` shell
+docker compose up
+```
+
+Docker will start PostgreSQL and then SQL LRS. Note that PostgreSQL can sometimes take a while to start causing SQL LRS initialization to fail. If this happens, stop the system with ctrl-C and run the command again.
 
 ### Customization
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -47,7 +47,7 @@ docker run \
     /lrsql/bin/run_postgres.sh
 ```
 
-Note that you will also need to ensure that a PostgreSQL instance is accessible to the container for this command to work.
+Note that you will also need to ensure that a PostgreSQL instance is accessible to the container for this command to work. For a demonstration of containerized SQL LRS with PostgreSQL please see the `docker-compose.yml` file in the project root.
 
 ### Customization
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -52,7 +52,7 @@ Note that you will also need to ensure that a Postgres instance is accessible to
 docker compose up
 ```
 
-Docker will start Postgres and then SQL LRS. Note that Postgres can sometimes take a while to start causing SQL LRS initialization to fail. If this happens, stop the system with ctrl-C and run the command again.
+Docker will start Postgres and then SQL LRS. Note that Postgres can sometimes take a while to start causing SQL LRS initialization to fail. If this happens, stop the system with ctrl-C and run the command again, optionally increasing the value of `LRSQL_POOL_INITIALIZATION_FAIL_TIMEOUT` to allow more time before the SQL LRS declares a connection failure (see `docker-compose.yml` file).
 
 ### Customization
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -12,10 +12,10 @@ You can run SQL LRS directly from the Docker CLI in its default SQLite configura
 
 $ docker run \
     -p 8080:8080 \
-    -e LRSQL_API_KEY_DEFAULT=key \
-    -e LRSQL_API_SECRET_DEFAULT=secret \
-    -e LRSQL_ADMIN_USER_DEFAULT=username \
-    -e LRSQL_ADMIN_PASS_DEFAULT=password \
+    -e LRSQL_API_KEY_DEFAULT=my_key \
+    -e LRSQL_API_SECRET_DEFAULT=my_secret \
+    -e LRSQL_ADMIN_USER_DEFAULT=my_username \
+    -e LRSQL_ADMIN_PASS_DEFAULT=my_password \
     yetanalytics/lrsql:latest
 
 ```
@@ -27,7 +27,17 @@ The SQL LRS Dockerfile uses the SQLite run script in `bin` as the default `CMD`.
 ``` shell
 
 $ docker run \
-    ...args + env... \
+    -p 8080:8080 \
+    -e LRSQL_API_KEY_DEFAULT=my_key \
+    -e LRSQL_API_SECRET_DEFAULT=my_secret \
+    -e LRSQL_ADMIN_USER_DEFAULT=my_username \
+    -e LRSQL_ADMIN_PASS_DEFAULT=my_password \
+    -e LRSQL_DB_HOST=0.0.0.0 \
+    -e LRSQL_DB_PORT=5432 \
+    -e LRSQL_DB_NAME=lrsql_db \
+    -e LRSQL_DB_USER=lrsql_user \
+    -e LRSQL_DB_PASSWORD=my_password \
+    -e LRSQL_DB_SCHEMA=lrsql \
     yetanalytics/lrsql:latest \
     bin/run_postgres.sh
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -23,7 +23,7 @@ Note that the `-it` option will give you a pseudo-TTY and attach you to the cont
 
 See [Configuration Variables](env_vars.md) for more options.
 
-### Other DBMSs
+#### Other DBMSs
 
 The SQL LRS Dockerfile uses the SQLite run script in `bin` as the default `CMD`. To change to another DBMS use the corresponding script. For instance to use PostgreSQL:
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -1,0 +1,36 @@
+[<- Back to Index](index.md)
+
+# Docker Image
+
+Yet Analytics publishes Docker container images of SQL LRS on [DockerHub](https://hub.docker.com/repository/docker/yetanalytics/lrsql).
+
+## Usage
+
+You can run SQL LRS directly from the Docker CLI in its default SQLite configuration:
+
+``` shell
+
+$ docker run \
+    -p 8080:8080 \
+    -e LRSQL_API_KEY_DEFAULT=key \
+    -e LRSQL_API_SECRET_DEFAULT=secret \
+    -e LRSQL_ADMIN_USER_DEFAULT=username \
+    -e LRSQL_ADMIN_PASS_DEFAULT=password \
+    yetanalytics/lrsql:latest
+
+```
+
+### Other DBMSs
+
+The SQL LRS Dockerfile uses the SQLite run script in `bin` as the default `CMD`. To change to another DBMS use the corresponding script. For instance to use PostgreSQL:
+
+``` shell
+
+$ docker run \
+    ...args + env... \
+    yetanalytics/lrsql:latest \
+    bin/run_postgres.sh
+
+```
+
+[<- Back to Index](index.md)

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -9,7 +9,7 @@ Yet Analytics publishes Docker container images of SQL LRS on [DockerHub](https:
 You can run SQL LRS directly from the Docker CLI in its default SQLite configuration:
 
 ``` shell
-$ docker run \
+docker run \
     -p 8080:8080 \
     -e LRSQL_API_KEY_DEFAULT=my_key \
     -e LRSQL_API_SECRET_DEFAULT=my_secret \
@@ -23,7 +23,7 @@ $ docker run \
 The SQL LRS Dockerfile uses the SQLite run script in `bin` as the default `CMD`. To change to another DBMS use the corresponding script. For instance to use PostgreSQL:
 
 ``` shell
-$ docker run \
+docker run \
     -p 8080:8080 \
     -e LRSQL_API_KEY_DEFAULT=my_key \
     -e LRSQL_API_SECRET_DEFAULT=my_secret \

--- a/doc/index.md
+++ b/doc/index.md
@@ -7,6 +7,7 @@
 - [Getting Started](startup.md)
 - [Setting up TLS/HTTPS](https.md)
 - [Authority Configuration](authority.md)
+- [Docker Image](docker.md)
 
 ### DBMS-specific Sections
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 # Runs SQL LRS with PostgreSQL - Provided for demonstration purposes only!
 # To run: docker compose up
 # See the Docker Compose docs for more info: https://docs.docker.com/compose/
-
 services:
   db:
     image: postgres
@@ -29,3 +28,4 @@ services:
       LRSQL_DB_NAME: lrsql_db
       LRSQL_DB_USER: lrsql_user
       LRSQL_DB_PASSWORD: lrsql_password
+      LRSQL_POOL_INITIALIZATION_FAIL_TIMEOUT: 10000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: my_db_user
-      POSTGRES_PASSWORD: my_db_password
+      POSTGRES_USER: lrsql_user
+      POSTGRES_PASSWORD: lrsql_password
       POSTGRES_DB: lrsql_db
   lrs:
     # build: . # switch to this for active dev
@@ -27,5 +27,5 @@ services:
       LRSQL_ADMIN_PASS_DEFAULT: my_password
       LRSQL_DB_HOST: db
       LRSQL_DB_NAME: lrsql_db
-      LRSQL_DB_USER: my_db_user
-      LRSQL_DB_PASSWORD: my_db_password
+      LRSQL_DB_USER: lrsql_user
+      LRSQL_DB_PASSWORD: lrsql_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+# Runs SQL LRS with PostgreSQL
+# Provided for demonstration purposes only
+services:
+  db:
+    image: postgres
+    volumes:
+      - ./tmp/db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: my_db_user
+      POSTGRES_PASSWORD: my_db_password
+      POSTGRES_DB: lrsql_db
+  lrs:
+    # build: . # switch to this for active dev
+    image: yetanalytics/lrsql:latest
+    command:
+      - /lrsql/bin/run_postgres.sh
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+    environment:
+      LRSQL_API_KEY_DEFAULT: my_key
+      LRSQL_API_SECRET_DEFAULT: my_secret
+      LRSQL_ADMIN_USER_DEFAULT: my_username
+      LRSQL_ADMIN_PASS_DEFAULT: my_password
+      LRSQL_DB_HOST: db
+      LRSQL_DB_NAME: lrsql_db
+      LRSQL_DB_USER: my_db_user
+      LRSQL_DB_PASSWORD: my_db_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,4 +28,5 @@ services:
       LRSQL_DB_NAME: lrsql_db
       LRSQL_DB_USER: lrsql_user
       LRSQL_DB_PASSWORD: lrsql_password
+      # If PostgreSQL is too slow to start, increase this
       LRSQL_POOL_INITIALIZATION_FAIL_TIMEOUT: 10000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
-# Runs SQL LRS with PostgreSQL
-# Provided for demonstration purposes only
+# Runs SQL LRS with PostgreSQL - Provided for demonstration purposes only!
+# To run: docker compose up
+# See the Docker Compose docs for more info: https://docs.docker.com/compose/
+
 services:
   db:
     image: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# Runs SQL LRS with PostgreSQL - Provided for demonstration purposes only!
+# Runs SQL LRS with Postgres - Provided for demonstration purposes only!
 # To run: docker compose up
 # See the Docker Compose docs for more info: https://docs.docker.com/compose/
 services:
@@ -28,5 +28,5 @@ services:
       LRSQL_DB_NAME: lrsql_db
       LRSQL_DB_USER: lrsql_user
       LRSQL_DB_PASSWORD: lrsql_password
-      # If PostgreSQL is too slow to start, increase this
+      # If Postgres is too slow to start, increase this
       LRSQL_POOL_INITIALIZATION_FAIL_TIMEOUT: 10000


### PR DESCRIPTION
[SQL-121] Prepare for public Docker Release

Please review the docs page here: https://github.com/yetanalytics/lrsql/blob/docker_release/doc/docker.md

Note that the current image is pushed to `yetanalytics/lrsql:latest` so you can follow along with the doc instructions.

[SQL-121]: https://yet.atlassian.net/browse/SQL-121