### PR TITLE
Change docker badge color from orange to blue

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/yetanalytics/lrsql/actions/workflows/test.yml/badge.svg)](https://github.com/yetanalytics/lrsql/actions/workflows/test.yml)
 [![CD](https://github.com/yetanalytics/lrsql/actions/workflows/build.yml/badge.svg)](https://github.com/yetanalytics/lrsql/actions/workflows/build.yml)
-[![Docker Image Version (latest semver)](https://img.shields.io/docker/v/yetanalytics/lrsql?label=docker&style=plastic)](https://hub.docker.com/r/yetanalytics/lrsql)
+[![Docker Image Version (latest semver)](https://img.shields.io/docker/v/yetanalytics/lrsql?label=docker&style=plastic&color=blue)](https://hub.docker.com/r/yetanalytics/lrsql)
 
 A SQL-based Learning Record Store.
 


### PR DESCRIPTION
Make the Docker badge more consistent with the Docker(hub) color scheme, and also because blue is a nicer color than orange in my opinion.