### PR TITLE
Update lrs and xapi-schema deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -34,14 +34,14 @@
   ;; Yet Analytics deps
   com.yetanalytics/lrs
   {:git/url    "https://github.com/yetanalytics/lrs.git"
-   :git/sha    "25bcc158c0b008301242aae5f8eec97da11aa7b3"
-   :git/tag    "v1.1.0"
+   :git/sha    "5fea5b953ae3a919d69641f26acec39481cf3457"
+   :git/tag    "v1.1.1"
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript
                 com.yetanalytics/xapi-schema]}
   com.yetanalytics/xapi-schema
   {:git/url    "https://github.com/yetanalytics/xapi-schema.git"
-   :git/sha    "4b97122d839e895b9111e6ed62ae68bc0fdee723"
+   :git/sha    "13b4e1a0da7676f61edb2344c47d6b71e32e846d"
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript]}
   com.yetanalytics/colossal-squuid

--- a/deps.edn
+++ b/deps.edn
@@ -34,8 +34,8 @@
   ;; Yet Analytics deps
   com.yetanalytics/lrs
   {:git/url    "https://github.com/yetanalytics/lrs.git"
-   :git/sha    "5fea5b953ae3a919d69641f26acec39481cf3457"
-   :git/tag    "v1.1.1"
+   :git/sha    "a76dcf2ad0b1280ceff9e5f75597bd36fce0a28b"
+   :git/tag    "v1.1.2"
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript
                 com.yetanalytics/xapi-schema]}


### PR DESCRIPTION
Update the lrs and xapi-schema deps to fix the following bugs:
- IOException on POSTing Statements with Attachments
- CI failure due to `:result/score` spec generation failure