### PR TITLE
latest LRS v1.1.3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -34,8 +34,8 @@
   ;; Yet Analytics deps
   com.yetanalytics/lrs
   {:git/url    "https://github.com/yetanalytics/lrs.git"
-   :git/sha    "a76dcf2ad0b1280ceff9e5f75597bd36fce0a28b"
-   :git/tag    "v1.1.2"
+   :git/sha    "8fd39674de436b9b1e2ac87f656d8e40d2743c41"
+   :git/tag    "v1.1.3"
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript
                 com.yetanalytics/xapi-schema]}


### PR DESCRIPTION
Update core LRS lib to 1.1.3, which includes updates to multipart handling + statement unsigning. See the [changelog](https://github.com/yetanalytics/lrs/blob/master/CHANGELOG.md#113---2021-11-10) for more info

## Problem(s) Resolved

* Multipart handling fails if two attachments in the same POST share a SHA
* Multipart handling fails if two attachments in the same GET share a SHA
* Statement Signature unsigning comparison doesn't use immut statement comparison

See:

* https://github.com/yetanalytics/lrs/pull/67
* https://github.com/yetanalytics/lrs/pull/65

## Reproduction

1. Start a lrsql instance at port 8080
2. Start a second instance at port 8081
3. run an xapipe connection between them:
```shell
bin/run.sh --source-url http://0.0.0.0:8080/xapi \
                  --source-username <key> \
                  --source-password <secret> \
                  --target-url http://0.0.0.0:8081/xapi \
                  --target-username <key> \
                  --target-password <secret>
```
4. Run the conformance tests on the LRS at port 8080. Xapipe will fail citing a POST error to the LRS at 8081.