### PR TITLE
[SQL-126] Change `url-prefix` to `path-prefix`

### DIFF
--- a/resources/lrsql/config/test/default/webserver.edn
+++ b/resources/lrsql/config/test/default/webserver.edn
@@ -9,6 +9,6 @@
  :ssl-port          8443
  :http-host         "0.0.0.0"
  :http-port         8080
- :url-prefix        "/yet/xapi"
+ :url-prefix        "/xapi"
  :enable-admin-ui   true
  :enable-stmt-html  true}

--- a/resources/lrsql/config/test/default/webserver.edn
+++ b/resources/lrsql/config/test/default/webserver.edn
@@ -9,6 +9,6 @@
  :ssl-port          8443
  :http-host         "0.0.0.0"
  :http-port         8080
- :url-prefix        "/xapi"
+ :url-prefix        "/yet/xapi"
  :enable-admin-ui   true
  :enable-stmt-html  true}

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -32,7 +32,8 @@
                 private-key]} (cu/init-keystore config)
 
         ;; Make routes
-        routes (->> (build {:lrs lrs})
+        routes (->> (build {:lrs         lrs
+                            :path-prefix url-prefix})
                     (add-admin-routes {:lrs    lrs
                                        :exp    jwt-exp
                                        :leeway jwt-lwy

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -46,7 +46,7 @@
      ::http/host               http-host
      ::http/port               (when enable-http http-port) ; nil = no HTTP
      ::http/join?              false
-     ::i/url-prefix            url-prefix ; TODO: This is never used in lrs
+     ::i/path-prefix           url-prefix
      ::i/enable-statement-html enable-stmt-html
      ::http/allowed-origins
      {:creds           true

--- a/src/test/lrsql/concurrency_test.clj
+++ b/src/test/lrsql/concurrency_test.clj
@@ -54,7 +54,7 @@
                     "X-Experience-API-Version" "1.0.3"}
         basic-auth ["username" "password"]
         ;; Parameters
-        endpoint    "http://localhost:8080/yet/xapi/statements"
+        endpoint    "http://localhost:8080/xapi/statements"
         num-stmts   100
         batch-size  5
         num-threads 5

--- a/src/test/lrsql/concurrency_test.clj
+++ b/src/test/lrsql/concurrency_test.clj
@@ -49,12 +49,13 @@
 (deftest concurrency-test
   (let [sys        (support/test-system)
         sys'       (component/start sys)
+        url-prefix (-> sys' :webserver :config :url-prefix)
         ;; Curl
         headers    {"Content-Type"             "application/json"
                     "X-Experience-API-Version" "1.0.3"}
         basic-auth ["username" "password"]
         ;; Parameters
-        endpoint    "http://localhost:8080/xapi/statements"
+        endpoint    (format "http://localhost:8080%s/statements" url-prefix)
         num-stmts   100
         batch-size  5
         num-threads 5

--- a/src/test/lrsql/concurrency_test.clj
+++ b/src/test/lrsql/concurrency_test.clj
@@ -54,7 +54,7 @@
                     "X-Experience-API-Version" "1.0.3"}
         basic-auth ["username" "password"]
         ;; Parameters
-        endpoint    "http://localhost:8080/xapi/statements"
+        endpoint    "http://localhost:8080/yet/xapi/statements"
         num-stmts   100
         batch-size  5
         num-threads 5

--- a/src/test/lrsql/conformance_test.clj
+++ b/src/test/lrsql/conformance_test.clj
@@ -19,7 +19,7 @@
         (let [sys  (support/test-system)
               sys' (component/start sys)]
           (is (conf/conformant?
-               "-e" "http://localhost:8080/xapi" "-b" "-z" "-a"
+               "-e" "http://localhost:8080/yet/xapi" "-b" "-z" "-a"
                "-u" "username"
                "-p" "password"))
           (component/stop sys'))))))

--- a/src/test/lrsql/conformance_test.clj
+++ b/src/test/lrsql/conformance_test.clj
@@ -19,7 +19,7 @@
         (let [sys  (support/test-system)
               sys' (component/start sys)]
           (is (conf/conformant?
-               "-e" "http://localhost:8080/yet/xapi" "-b" "-z" "-a"
+               "-e" "http://localhost:8080/xapi" "-b" "-z" "-a"
                "-u" "username"
                "-p" "password"))
           (component/stop sys'))))))

--- a/src/test/lrsql/conformance_test.clj
+++ b/src/test/lrsql/conformance_test.clj
@@ -17,9 +17,11 @@
     (binding [conf/*print-logs* true]
       (testing "no regressions"
         (let [sys  (support/test-system)
-              sys' (component/start sys)]
+              sys' (component/start sys)
+              pre  (-> sys' :webserver :config :url-prefix)
+              url  (str "http://localhost:8080" pre)]
           (is (conf/conformant?
-               "-e" "http://localhost:8080/xapi" "-b" "-z" "-a"
+               "-e" url "-b" "-z" "-a"
                "-u" "username"
                "-p" "password"))
           (component/stop sys'))))))

--- a/src/test/lrsql/https_test.clj
+++ b/src/test/lrsql/https_test.clj
@@ -22,7 +22,7 @@
              (:status (curl/get "https://0.0.0.0:8443/health"
                                 {:raw-args ["--insecure"]}))))
       (is (some?
-           (:body (curl/get "https://0.0.0.0:8443/xapi/about"
+           (:body (curl/get "https://0.0.0.0:8443/yet/xapi/about"
                             {:raw-args ["--insecure"]}))))
       (testing "is not over the HTTP port"
         (is (thrown-with-msg?

--- a/src/test/lrsql/https_test.clj
+++ b/src/test/lrsql/https_test.clj
@@ -22,7 +22,7 @@
              (:status (curl/get "https://0.0.0.0:8443/health"
                                 {:raw-args ["--insecure"]}))))
       (is (some?
-           (:body (curl/get "https://0.0.0.0:8443/yet/xapi/about"
+           (:body (curl/get "https://0.0.0.0:8443/xapi/about"
                             {:raw-args ["--insecure"]}))))
       (testing "is not over the HTTP port"
         (is (thrown-with-msg?

--- a/src/test/lrsql/https_test.clj
+++ b/src/test/lrsql/https_test.clj
@@ -15,14 +15,15 @@
 (deftest https-test
   (testing "HTTPS connection"
     (let [sys  (support/test-system)
-          sys' (component/start sys)]
+          sys' (component/start sys)
+          pre  (-> sys' :webserver :config :url-prefix)]
       ;; We need to pass the `--insecure` arg because curl would otherwise
       ;; not accept our generate selfie certs
       (is (= 200
              (:status (curl/get "https://0.0.0.0:8443/health"
                                 {:raw-args ["--insecure"]}))))
       (is (some?
-           (:body (curl/get "https://0.0.0.0:8443/xapi/about"
+           (:body (curl/get (format "https://0.0.0.0:8443%s/about" pre)
                             {:raw-args ["--insecure"]}))))
       (testing "is not over the HTTP port"
         (is (thrown-with-msg?

--- a/src/test/lrsql/lrs_test.clj
+++ b/src/test/lrsql/lrs_test.clj
@@ -268,7 +268,7 @@
       (testing "(descending)"
         (is (= {:statement-result
                 {:statements [stmt-4 stmt-3]
-                 :more       "/xapi/statements?limit=2&from="}
+                 :more       "/yet/xapi/statements?limit=2&from="}
                 :attachments []}
                (-> (get-ss lrs auth-ident {:limit 2} #{})
                    (update-in [:statement-result :more]
@@ -282,7 +282,7 @@
     (testing "(ascending)"
       (is (= {:statement-result
               {:statements [stmt-1 stmt-2]
-               :more       "/xapi/statements?limit=2&ascending=true&from="}
+               :more       "/yet/xapi/statements?limit=2&ascending=true&from="}
               :attachments []}
              (-> (get-ss lrs auth-ident {:limit 2 :ascending true} #{})
                  (update-in [:statement-result :more]
@@ -304,7 +304,7 @@
                     :related_agents true}]
         (is (= {:statement-result
                 {:statements [stmt-3]
-                 :more       (str "/xapi/statements"
+                 :more       (str "/yet/xapi/statements"
                                   "?" "limit=1"
                                   "&" "agent=%7B%22name%22%3A%22Sample+Agent+1%22%2C%22mbox%22%3A%22mailto%3Asample.agent%40example.com%22%7D"
                                   "&" "related_agents=true"

--- a/src/test/lrsql/lrs_test.clj
+++ b/src/test/lrsql/lrs_test.clj
@@ -268,7 +268,7 @@
       (testing "(descending)"
         (is (= {:statement-result
                 {:statements [stmt-4 stmt-3]
-                 :more       "/yet/xapi/statements?limit=2&from="}
+                 :more       "/xapi/statements?limit=2&from="}
                 :attachments []}
                (-> (get-ss lrs auth-ident {:limit 2} #{})
                    (update-in [:statement-result :more]
@@ -282,7 +282,7 @@
     (testing "(ascending)"
       (is (= {:statement-result
               {:statements [stmt-1 stmt-2]
-               :more       "/yet/xapi/statements?limit=2&ascending=true&from="}
+               :more       "/xapi/statements?limit=2&ascending=true&from="}
               :attachments []}
              (-> (get-ss lrs auth-ident {:limit 2 :ascending true} #{})
                  (update-in [:statement-result :more]
@@ -304,7 +304,7 @@
                     :related_agents true}]
         (is (= {:statement-result
                 {:statements [stmt-3]
-                 :more       (str "/yet/xapi/statements"
+                 :more       (str "/xapi/statements"
                                   "?" "limit=1"
                                   "&" "agent=%7B%22name%22%3A%22Sample+Agent+1%22%2C%22mbox%22%3A%22mailto%3Asample.agent%40example.com%22%7D"
                                   "&" "related_agents=true"

--- a/src/test/lrsql/lrs_test.clj
+++ b/src/test/lrsql/lrs_test.clj
@@ -134,7 +134,9 @@
 (deftest test-statement-fns
   (let [sys   (support/test-system)
         sys'  (component/start sys)
-        lrs   (:lrs sys')
+        lrs   (-> sys' :lrs)
+        pre   (-> sys' :webserver :config :url-prefix)
+        _     (println pre)
         id-0  (get stmt-0 "id")
         id-1  (get stmt-1 "id")
         id-2  (get stmt-2 "id")
@@ -268,7 +270,7 @@
       (testing "(descending)"
         (is (= {:statement-result
                 {:statements [stmt-4 stmt-3]
-                 :more       "/xapi/statements?limit=2&from="}
+                 :more       (format "%s/statements?limit=2&from=" pre)}
                 :attachments []}
                (-> (get-ss lrs auth-ident {:limit 2} #{})
                    (update-in [:statement-result :more]
@@ -282,7 +284,8 @@
     (testing "(ascending)"
       (is (= {:statement-result
               {:statements [stmt-1 stmt-2]
-               :more       "/xapi/statements?limit=2&ascending=true&from="}
+               :more       (format "%s/statements?limit=2&ascending=true&from="
+                                   pre)}
               :attachments []}
              (-> (get-ss lrs auth-ident {:limit 2 :ascending true} #{})
                  (update-in [:statement-result :more]
@@ -304,7 +307,8 @@
                     :related_agents true}]
         (is (= {:statement-result
                 {:statements [stmt-3]
-                 :more       (str "/xapi/statements"
+                 :more       (str pre
+                                  "/statements"
                                   "?" "limit=1"
                                   "&" "agent=%7B%22name%22%3A%22Sample+Agent+1%22%2C%22mbox%22%3A%22mailto%3Asample.agent%40example.com%22%7D"
                                   "&" "related_agents=true"


### PR DESCRIPTION
`add-xapi-interceptors` accepts `path-prefix`, not `url-prefix` as the arg to change the URL path prefix (e.g. `host:port/xapi`).