### PR TITLE
LRS-60 Chrome Crash issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Version of LRS Admin UI to use
 
-LRS_ADMIN_UI_VERSION ?= v0.1.3
+LRS_ADMIN_UI_VERSION ?= v0.1.4
 LRS_ADMIN_UI_LOCATION ?= https://github.com/yetanalytics/lrs-admin-ui/releases/download/${LRS_ADMIN_UI_VERSION}/lrs-admin-ui.zip
 LRS_ADMIN_ZIPFILE ?= lrs-admin-ui-${LRS_ADMIN_UI_VERSION}.zip
 

--- a/deps.edn
+++ b/deps.edn
@@ -34,8 +34,8 @@
   ;; Yet Analytics deps
   com.yetanalytics/lrs
   {:git/url    "https://github.com/yetanalytics/lrs.git"
-   :git/sha    "df64ade872d2892d521aa9d0df7ba8eb967eb788"
-   :git/tag    "v1.2.0"
+   :git/sha    "c4ddd589a1559bcaeee256857eed7516cf05d6e2"
+   :git/tag    "v1.2.1"
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript
                 com.yetanalytics/xapi-schema]}


### PR DESCRIPTION
fixed an issue in chrome 95+ that froze because of a CSS attr. Updated lrs and admin-ui deps