### PR TITLE
[SQL-125] Redact sensitive information from traces

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -34,8 +34,9 @@
   ;; Yet Analytics deps
   com.yetanalytics/lrs
   {:git/url    "https://github.com/yetanalytics/lrs.git"
-   :git/sha    "c4ddd589a1559bcaeee256857eed7516cf05d6e2"
-   :git/tag    "v1.2.1"
+   :git/sha    "69aa67e5345f9101002dc4880621180fa8ac4390"
+   ; :git/sha    "c4ddd589a1559bcaeee256857eed7516cf05d6e2"
+   ; :git/tag    "v1.2.1"
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript
                 com.yetanalytics/xapi-schema]}

--- a/deps.edn
+++ b/deps.edn
@@ -34,9 +34,8 @@
   ;; Yet Analytics deps
   com.yetanalytics/lrs
   {:git/url    "https://github.com/yetanalytics/lrs.git"
-   :git/sha    "d940f9264455ef083e37e7f216a576debaded4d9"
-   ; :git/sha    "c4ddd589a1559bcaeee256857eed7516cf05d6e2"
-   ; :git/tag    "v1.2.1"
+   :git/sha    "31af5d99bb1d7cc636f6074b9c2efe3e185dde4b"
+   :git/tag    "v1.2.2"
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript
                 com.yetanalytics/xapi-schema]}

--- a/deps.edn
+++ b/deps.edn
@@ -34,7 +34,7 @@
   ;; Yet Analytics deps
   com.yetanalytics/lrs
   {:git/url    "https://github.com/yetanalytics/lrs.git"
-   :git/sha    "69aa67e5345f9101002dc4880621180fa8ac4390"
+   :git/sha    "d940f9264455ef083e37e7f216a576debaded4d9"
    ; :git/sha    "c4ddd589a1559bcaeee256857eed7516cf05d6e2"
    ; :git/tag    "v1.2.1"
    :exclusions [org.clojure/clojure

--- a/src/main/logback.xml
+++ b/src/main/logback.xml
@@ -19,11 +19,4 @@
     <appender-ref ref="FILE" />
   </root>
   <logger name="io.pedestal.http" level="warn" />
-  <!--IMPORTANT: We need to turn Pedestal logging off because on an
-      error, Pedestal will spew out the entire request/response map,
-      which may contain sensitive info.-->
-  <!--TODO: Perhaps we can create a custom error logger to replace
-      Pedestal's logger that applies redaction to the request/response
-      map before logging?-->
-  <logger name="io.pedestal.http.impl.servlet-interceptor" level="off" />
 </configuration>

--- a/src/main/logback.xml
+++ b/src/main/logback.xml
@@ -14,9 +14,16 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
-  <root level="info">
+  <root level="debug">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="FILE" />
   </root>
   <logger name="io.pedestal.http" level="warn" />
+  <!--IMPORTANT: We need to turn Pedestal logging off because on an
+      error, Pedestal will spew out the entire request/response map,
+      which may contain sensitive info.-->
+  <!--TODO: Perhaps we can create a custom error logger to replace
+      Pedestal's logger that applies redaction to the request/response
+      map before logging?-->
+  <logger name="io.pedestal.http.impl.servlet-interceptor" level="off" />
 </configuration>

--- a/src/main/logback.xml
+++ b/src/main/logback.xml
@@ -14,7 +14,7 @@
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
-  <root level="debug">
+  <root level="info">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="FILE" />
   </root>

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -10,9 +10,9 @@
 
 (defn- make-common-interceptors
   [lrs]
-  [i/x-forwarded-for-interceptor
+  [i/error-interceptor
+   i/x-forwarded-for-interceptor
    json-body
-   i/error-interceptor
    (body-params)
    (i/lrs-interceptor lrs)])
 

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -6,11 +6,13 @@
             [lrsql.admin.interceptors.account :as ai]
             [lrsql.admin.interceptors.credentials :as ci]
             [lrsql.admin.interceptors.ui :as ui]
-            [lrsql.admin.interceptors.jwt :as ji]))
+            [lrsql.admin.interceptors.jwt :as ji]
+            [lrsql.util.interceptor :as util-i]))
 
 (defn- make-common-interceptors
   [lrs]
   [i/error-interceptor
+   (util-i/handle-json-parse-exn true)
    i/x-forwarded-for-interceptor
    json-body
    (body-params)

--- a/src/main/lrsql/input/statement.clj
+++ b/src/main/lrsql/input/statement.clj
@@ -340,8 +340,8 @@
 (defn- warn-on-dupe-shas
   [attachments shas]
   (when (not= (count attachments) (count shas))
-    (log/warnf "%s\nAttachments: %s"
-               duplicate-sha-emsg
+    (log/warn duplicate-sha-emsg)
+    (log/debug "Attachments: %s"
                (mapv #(dissoc % :content) attachments))))
 
 (defn add-insert-attachment-inputs

--- a/src/main/lrsql/system/database.clj
+++ b/src/main/lrsql/system/database.clj
@@ -3,7 +3,7 @@
             [com.stuartsierra.component :as component]
             [lrsql.backend.protocol :as bp]
             [lrsql.spec.config :as cs]
-            [lrsql.system.util :refer [assert-config make-jdbc-url]])
+            [lrsql.system.util :as cu :refer [assert-config make-jdbc-url]])
   (:import [com.zaxxer.hikari HikariConfig HikariDataSource]
            [com.codahale.metrics MetricRegistry]
            [com.codahale.metrics.jmx JmxReporter]))
@@ -97,7 +97,7 @@
       (if-not ?conn-pool
         (let [conn-pool (make-conn-pool backend config)]
           (log/infof "Starting new connection for %s database..." db-type)
-          (log/debugf "Config: %s" config)
+          (log/debugf "Config: %s" (cu/redact-config-vars config))
           (assoc conn :conn-pool conn-pool))
         (do
           (log/info "Connection already started; do nothing.")

--- a/src/main/lrsql/system/util.clj
+++ b/src/main/lrsql/system/util.clj
@@ -1,16 +1,44 @@
 (ns lrsql.system.util
   (:require [clojure.spec.alpha :as s]
+            [clojure.walk :as w]
             [clojure.tools.logging :as log]
             [next.jdbc.connection :as jdbc-conn]
             [ring.util.codec :refer [form-encode form-decode]]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Macros
+;; Helpers and Macros
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def redactable-config-vars
+  #{:db-password
+    :admin-pass-default
+    :api-secret-default
+    :key-password})
+
+(defn redact-config-vars
+  "Given a `config` map, replace redactable values with \"[REDACTED]\"
+   (if it is a string; keywords and symbols are treated similarly).
+   See `redactable-config-vars` for which vars are redactable."
+  [config]
+  (w/postwalk (fn [node]
+                (if (map-entry? node)
+                  (let [[k v] node]
+                    (if (contains? redactable-config-vars k)
+                      ;; We only consider strings and similar because
+                      ;; other vals should immediately cause an assertion
+                      ;; error and never be meaningful passwords.
+                      (cond
+                        (string? v)  [k "[REDACTED]"]
+                        (keyword? v) [k :redacted]
+                        (symbol? v)  [k 'redacted]
+                        :else        [k v])
+                      [k v]))
+                  node))
+              config))
 
 (defmacro assert-config
   [spec component-name config]
-  `(when-some [err# (s/explain-data ~spec ~config)]
+  `(when-some [err# (s/explain-data ~spec ~(redact-config-vars config))]
      (do
        (log/errorf "Configuration errors:\n%s"
                    (with-out-str (s/explain-out err#)))
@@ -18,6 +46,17 @@
                                ~component-name)
                        {:type ::invalid-config
                         :error-data err#})))))
+
+(comment ; TODO: Turn these into tests
+  (s/explain :lrsql.spec.config/database
+             (redact-config-vars {:db-type     "h2:mem"
+                             :db-name     "foo"
+                             :db-password 100}))
+  (assert-config :lrsql.spec.config/database
+                 "database"
+                 {:db-type     "h2:mem"
+                  :db-name     "foo"
+                  :db-password "swordfish"}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; JDBC Config

--- a/src/main/lrsql/system/util.clj
+++ b/src/main/lrsql/system/util.clj
@@ -15,26 +15,28 @@
     :api-secret-default
     :key-password})
 
+(defn- redact-at-node
+  [node]
+  (if (map-entry? node)
+    (let [[k v] node]
+      (if (contains? redactable-config-vars k)
+        ;; We only consider strings and similar because
+        ;; other vals should immediately cause an assertion
+        ;; error and never be meaningful passwords.
+        (cond
+          (string? v)  [k "[REDACTED]"]
+          (keyword? v) [k :redacted]
+          (symbol? v)  [k 'redacted]
+          :else        [k v])
+        [k v]))
+    node))
+
 (defn redact-config-vars
   "Given a `config` map, replace redactable values with \"[REDACTED]\"
    (if it is a string; keywords and symbols are treated similarly).
    See `redactable-config-vars` for which vars are redactable."
   [config]
-  (w/postwalk (fn [node]
-                (if (map-entry? node)
-                  (let [[k v] node]
-                    (if (contains? redactable-config-vars k)
-                      ;; We only consider strings and similar because
-                      ;; other vals should immediately cause an assertion
-                      ;; error and never be meaningful passwords.
-                      (cond
-                        (string? v)  [k "[REDACTED]"]
-                        (keyword? v) [k :redacted]
-                        (symbol? v)  [k 'redacted]
-                        :else        [k v])
-                      [k v]))
-                  node))
-              config))
+  (w/postwalk redact-at-node config))
 
 (defmacro assert-config
   [spec component-name config]
@@ -46,17 +48,6 @@
                                ~component-name)
                        {:type ::invalid-config
                         :error-data err#})))))
-
-(comment ; TODO: Turn these into tests
-  (s/explain :lrsql.spec.config/database
-             (redact-config-vars {:db-type     "h2:mem"
-                             :db-name     "foo"
-                             :db-password 100}))
-  (assert-config :lrsql.spec.config/database
-                 "database"
-                 {:db-type     "h2:mem"
-                  :db-name     "foo"
-                  :db-password "swordfish"}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; JDBC Config

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -30,10 +30,11 @@
         ;; The private key is used as the JWT symmetric secret
         {:keys [keystore
                 private-key]} (cu/init-keystore config)
-
-        ;; Make routes
-        routes (->> (build {:lrs         lrs
-                            :path-prefix url-prefix})
+        ;; Make routes - the lrs error interceptor is appended to the
+        ;; start to all lrs routes
+        routes (->> (build {:lrs               lrs
+                            :path-prefix       url-prefix
+                            :wrap-interceptors [i/error-interceptor]})
                     (add-admin-routes {:lrs    lrs
                                        :exp    jwt-exp
                                        :leeway jwt-lwy

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -7,7 +7,7 @@
             [com.yetanalytics.lrs.pedestal.interceptor :as i]
             [lrsql.admin.routes :refer [add-admin-routes]]
             [lrsql.spec.config :as cs]
-            [lrsql.system.util :refer [assert-config]]
+            [lrsql.system.util :refer [assert-config redact-config-vars]]
             [lrsql.util.cert :as cu]))
 
 (defn- service-map
@@ -70,7 +70,7 @@
    (assert-config ::cs/webserver "webserver" config)
    (if server
      (do (log/info "Webserver already started; do nothing.")
-         (log/debugf "Server map: %s" server)
+         (log/debugf "Server map: %s" (redact-config-vars server))
          this)
      (if lrs
        (let [service (or service ;; accept passed in
@@ -92,7 +92,7 @@
                         host
                         ssl-port)))
          (log/info logo)
-         (log/debugf "Server map: %s" server)
+         (log/debugf "Server map: %s" (redact-config-vars server))
          ;; Return new webserver
          (assoc this
                 :service service

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -8,7 +8,8 @@
             [lrsql.admin.routes :refer [add-admin-routes]]
             [lrsql.spec.config :as cs]
             [lrsql.system.util :refer [assert-config redact-config-vars]]
-            [lrsql.util.cert :as cu]))
+            [lrsql.util.cert :as cu]
+            [lrsql.util.interceptor :refer [handle-json-parse-exn]]))
 
 (defn- service-map
   "Create a new service map for the webserver."
@@ -34,7 +35,8 @@
         ;; start to all lrs routes
         routes (->> (build {:lrs               lrs
                             :path-prefix       url-prefix
-                            :wrap-interceptors [i/error-interceptor]})
+                            :wrap-interceptors [i/error-interceptor
+                                                (handle-json-parse-exn)]})
                     (add-admin-routes {:lrs    lrs
                                        :exp    jwt-exp
                                        :leeway jwt-lwy

--- a/src/main/lrsql/util/interceptor.clj
+++ b/src/main/lrsql/util/interceptor.clj
@@ -1,0 +1,44 @@
+(ns lrsql.util.interceptor
+  "Common interceptors shared by LRS and admin routes."
+  (:require [clojure.string :as cstr]
+            [io.pedestal.interceptor.error :refer [error-dispatch]]
+            [io.pedestal.interceptor.chain :as chain]))
+
+(defn- get-message
+  [ex]
+  (.getMessage ^Throwable ex))
+
+;; clj-kondo/VSCode does not recognize complex `error-dispatch` macro
+#_{:clj-kondo/ignore [:unresolved-symbol]}
+(defn handle-json-parse-exn
+  "Return an interceptor to handle Jackson JsonParseExceptions (which
+   are thrown by the `body-params` Pedestal interceptor). `redact?`,
+   if true, will attempt to redact any personal identifying info."
+  ([]
+   (handle-json-parse-exn false))
+  ([redact?]
+   (error-dispatch
+    [ctx ex]
+    ;; JSON Parse failure
+    [{:exception-type :com.fasterxml.jackson.core.JsonParseException
+      :exception      exception}]
+    (let [msg (cond-> exception
+                true    get-message
+                redact? (cstr/replace #"Unrecognized token '.*'"
+                                      "Unrecognized token '[REDACTED]'"))]
+      (assoc ctx
+             :response
+             {:status 400
+              :body   {:error msg}}))
+    ;; JSON EOF failure (subclass of the above)
+    [{:exception-type :com.fasterxml.jackson.core.io.JsonEOFException
+      :exception      exception}]
+    (let [msg (get-message exception)]
+      (assoc ctx
+             :response
+             {:status 400
+              :body   {:error msg}}))
+    ;; Other error (incl. non-parsing-related Jackson errors);
+    ;; continue as need be.
+    :else
+    (assoc ctx ::chain/error ex))))

--- a/src/test/lrsql/admin/route_test.clj
+++ b/src/test/lrsql/admin/route_test.clj
@@ -113,16 +113,27 @@
                  (catch Exception _ false)))
         (is (re-matches #".*\..*\..*"
                         (get edn-body "json-web-token"))))
+      ;; Parse errors
+      (testing "- failure due to JSONEOFException"
+        (let [bad-body "{\"username\": \"foo\", \"password\": \"bar}"]
+          (is-err-code (login-account content-type bad-body) 400)))
+      (testing "- failure due to JSONParseException"
+        (let [bad-body "{\"username\": \"foo\", \"password\": bar\"}"]
+          (is-err-code (login-account content-type bad-body) 400)))
+      ;; Other errors
       (let [bad-body (String. (u/write-json
                                {"username" "foo"
                                 "password" "swordfish"}))]
-        (is-err-code (login-account content-type bad-body) 401))  ; Bad User 401
+        ;; Bad User 401
+        (is-err-code (login-account content-type bad-body) 401))
       (let [bad-body (String. (u/write-json
                                {"username" "myname"
                                 "password" "badpass"}))]
-        (is-err-code (login-account content-type bad-body) 401))  ; Bad Pass 401
+        ;; Bad Pass 401
+        (is-err-code (login-account content-type bad-body) 401))
+      ;; Bad Request
       (let [bad-body ""]
-        (is-err-code (login-account content-type bad-body) 400))) ; Bad Request
+        (is-err-code (login-account content-type bad-body) 400)))
     (testing "delete the `myname` account using the seed account"
       (let [del-jwt  (-> (login-account content-type req-body)
                          :body

--- a/src/test/lrsql/util/config_test.clj
+++ b/src/test/lrsql/util/config_test.clj
@@ -1,0 +1,103 @@
+(ns lrsql.util.config-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure.spec.alpha :as s]
+            [lrsql.spec.config :as cs]
+            [lrsql.system.util :as su]))
+
+(deftest config-var-redact-test
+  (testing "Config var redaction"
+    (is (= {:db-type     "h2:mem"
+            :db-name     "foo"
+            :db-password "[REDACTED]"}
+           (su/redact-config-vars
+            {:db-type     "h2:mem"
+             :db-name     "foo"
+             :db-password "swordfish"})))
+    (is (= {:database {:db-type     "h2:mem"
+                       :db-name     "foo"
+                       :db-password "[REDACTED]"}
+            :admin-user-default "user-default"
+            :admin-pass-default "[REDACTED]"
+            :api-key-default    "api-key-default"
+            :api-secret-default "[REDACTED]"}
+           (su/redact-config-vars
+            {:database {:db-type     "h2:mem"
+                        :db-name     "foo"
+                        :db-password "swordfish"}
+             :admin-user-default "user-default"
+             :admin-pass-default "pass-default"
+             :api-key-default    "api-key-default"
+             :api-secret-default "api-secret-default"})))
+    (testing "in a server map"
+      (is (= {:io.pedestal.http/port 8080
+              :io.pedestal.http/host "0.0.0.0"
+              :io.pedestal.http/type :jetty
+              :io.pedestal.http/container-options
+              {:h2c? true
+               :h2? true
+               :ssl? true
+               :ssl-port 8443
+               :keystore {}
+               :key-password "[REDACTED]"}}
+             (su/redact-config-vars
+              {:io.pedestal.http/port 8080
+               :io.pedestal.http/host "0.0.0.0"
+               :io.pedestal.http/type :jetty
+               :io.pedestal.http/container-options
+               {:h2c? true
+                :h2? true
+                :ssl? true
+                :ssl-port 8443
+                :keystore {}
+                :key-password "this-is-my-oh-so-secure-password"}}))))
+    (testing "on keywords"
+      (is (= {:db-type     "h2:mem"
+              :db-name     "foo"
+              :db-password :redacted}
+             (su/redact-config-vars
+              {:db-type     "h2:mem"
+               :db-name     "foo"
+               :db-password :swordfish}))))
+    (testing "on symbols"
+      (is (= {:db-type     "h2:mem"
+              :db-name     "foo"
+              :db-password 'redacted}
+             (su/redact-config-vars
+              {:db-type     "h2:mem"
+               :db-name     "foo"
+               :db-password 'swordfish}))))
+    (testing "not on ints"
+      (is (= {:db-type     "h2:mem"
+              :db-name     "foo"
+              :db-password 100}
+             (su/redact-config-vars
+              {:db-type     "h2:mem"
+               :db-name     "foo"
+               :db-password 100}))))
+    (testing "propgates through spec errors"
+      (is (= {::s/problems '({:path [:no-jdbc-url :db-type]
+                              :pred #{"h2"
+                                      "h2:mem"
+                                      "sqlite"
+                                      "postgres"
+                                      "postgresql"}
+                              :val  "h2-mem"
+                              :via  [::cs/database ::cs/db-type]
+                              :in   [:db-type]}
+                             {:path [:jdbc-url]
+                              :pred (clojure.core/fn [%]
+                                      (clojure.core/contains? % :db-jdbc-url))
+                              :val {:db-type     "h2-mem"
+                                    :db-name     "foo"
+                                    :db-password "[REDACTED]"}
+                              :via [::cs/database]
+                              :in []})
+              ::s/spec ::cs/database
+              ::s/value {:db-type     "h2-mem"
+                         :db-name     "foo"
+                         :db-password "[REDACTED]"}}
+           (s/explain-data ::cs/database
+                             (su/redact-config-vars
+                              {:db-type     "h2-mem"
+                               :db-name     "foo"
+                               :db-password "swordfish"})))))))


### PR DESCRIPTION
- Redact sensitive info before logging config var maps
- ~Turn off Pedestal logging since we can't redact info from that~ (Made redundant by https://github.com/yetanalytics/lrs/pull/71)
- Return 400 instead of 500 error (which spews out exn info) upon JSONParseException
- ~TODO: Write tests for the above~ Done!