### PR TITLE
updated module list. upgraded runtimer usage to reusable workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,15 +8,58 @@ on:
       - 'v*.*.*' # Enforce Semantic Versioning
 
 jobs:
+  get_modules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: echo-modules
+        run: echo "::set-output name=modules::$(cat .java_modules)"
+    outputs:
+      modules: ${{ steps.echo-modules.outputs.modules }}
+  build_jre:
+    needs: get_modules
+    uses: yetanalytics/runtimer/.github/workflows/runtimer.yml@3c6a902caaf0c6db272842055d9f8cca5cb3fcbc
+    with:
+      java-version: '11'
+      java-distribution: 'temurin'
+      java-modules: ${{ needs.get_modules.outputs.modules }}
   build:
     runs-on: ubuntu-latest
-
+    needs: build_jre
     steps:
     - name: Setup CI Environment
       uses: yetanalytics/actions/setup-env@v0
 
+    # BUILD WITHOUT RUNTIME
     - name: Build Bundle
-      run: make bundle
+      run: make bundle BUNDLE_RUNTIMES=false
+
+    # GET RUNTIMES FROM ARTIFACTS
+    - name: Download ubuntu-latest Artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-20.04-jre
+
+    - name: Download macOS-latest Artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: macos-10.15-jre
+
+    - name: Download windows-latest Artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-2019-jre
+
+    # UNZIP RUNTIMES INTO OS-SPECIFIC RUNTIME DIRS
+    - name: Unzip the runtimes
+      run: |
+        mkdir -p target/bundle/runtimes
+        unzip ubuntu-20.04-jre.zip -d target/bundle/runtimes
+        mv target/bundle/runtimes/ubuntu-20.04 target/bundle/runtimes/linux
+        unzip macos-10.15-jre.zip -d target/bundle/runtimes
+        mv target/bundle/runtimes/macos-10.15 target/bundle/runtimes/macos
+        unzip windows-2019-jre.zip -d target/bundle/runtimes
+        mv target/bundle/runtimes/windows-2019 target/bundle/runtimes/windows
 
     - name: Compress Bundle
       run: | # Need to cd so that the zip file doesn't contain the parent dirs

--- a/.java_modules
+++ b/.java_modules
@@ -1,0 +1,1 @@
+java.base,java.logging,java.naming,java.xml,java.sql,java.transaction.xa,java.security.sasl,java.management,jdk.crypto.ec

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.14
 
 ADD target/bundle /lrsql
+ADD .java_modules /xapipe/.java_modules
 
 # replace the linux runtime via jlink
 RUN apk update \
@@ -9,7 +10,7 @@ RUN apk update \
         && update-ca-certificates \
         && apk add --no-cache openjdk11 \
         && mkdir -p /lrsql/runtimes \
-        && jlink --output /lrsql/runtimes/linux/ --add-modules java.base,java.logging,java.naming,java.xml,java.sql,java.transaction.xa,java.security.sasl,java.management \
+        && jlink --output /lrsql/runtimes/linux/ --add-modules $(cat /xapipe/.java_modules) \
         && apk del openjdk11 \
         && rm -rf /var/cache/apk/*
 

--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,6 @@ else
 target/bundle: target/bundle/config target/bundle/doc target/bundle/bin target/bundle/lrsql.jar target/bundle/admin target/bundle/lrsql.exe target/bundle/lrsql_pg.exe target/bundle/LICENSE target/bundle/NOTICE
 endif
 
-target/bundle:
-
 bundle: target/bundle
 
 # *** Build Windows EXEs with launch4j ***

--- a/Makefile
+++ b/Makefile
@@ -138,35 +138,14 @@ target/bundle/config: target/bundle/config/lrsql.json.example target/bundle/conf
 
 # Make Runtime Environment (i.e. JREs)
 
-# The given tag to pull down from yetanalytics/runtimer release
-RUNTIME_TAG ?= 0.1.1-java-11-temurin
-RUNTIME_MACHINE ?= macos
-RUNTIME_MACHINE_BUILD ?= macos-10.15
-RUNTIME_ZIP_DIR ?= tmp/runtimes/${RUNTIME_TAG}
-RUNTIME_ZIP ?= ${RUNTIME_ZIP_DIR}/${RUNTIME_MACHINE}.zip
+JAVA_MODULES ?= $(shell cat .java_modules)
 
-# DEBUG: Kept here for reference
-# target/bundle/runtimes: target/bundle/bin
-# 	mkdir target/bundle/runtimes
-# 	jlink --output target/bundle/runtimes/$(MACHINE_TYPE) --add-modules java.base,java.logging,java.naming,java.xml,java.sql,java.transaction.xa,java.security.sasl,java.management
+# Will only produce a single jre for macos/linux matching your machine
+MACHINE ?= $(shell bin/machine.sh)
 
-target/bundle/runtimes/%:
-	mkdir -p ${RUNTIME_ZIP_DIR}
+target/bundle/runtimes:
 	mkdir -p target/bundle/runtimes
-	[ ! -f ${RUNTIME_ZIP} ] && curl -L -o ${RUNTIME_ZIP} https://github.com/yetanalytics/runtimer/releases/download/${RUNTIME_TAG}/${RUNTIME_MACHINE_BUILD}-jre.zip || echo 'already present'
-	unzip ${RUNTIME_ZIP} -d target/bundle/runtimes/
-	mv target/bundle/runtimes/${RUNTIME_MACHINE_BUILD} target/bundle/runtimes/${RUNTIME_MACHINE}
-
-target/bundle/runtimes/macos: RUNTIME_MACHINE = macos
-target/bundle/runtimes/macos: RUNTIME_MACHINE_BUILD = macos-10.15
-
-target/bundle/runtimes/linux: RUNTIME_MACHINE = linux
-target/bundle/runtimes/linux: RUNTIME_MACHINE_BUILD = ubuntu-20.04
-
-target/bundle/runtimes/windows: RUNTIME_MACHINE = windows
-target/bundle/runtimes/windows: RUNTIME_MACHINE_BUILD = windows-2019
-
-target/bundle/runtimes: target/bundle/runtimes/macos target/bundle/runtimes/linux target/bundle/runtimes/windows
+	jlink --output target/bundle/runtimes/${MACHINE}/ --add-modules ${JAVA_MODULES}
 
 # Copy Windows EXEs
 
@@ -186,7 +165,15 @@ target/bundle/admin: resources/public/admin
 
 # Create entire bundle
 
-target/bundle: target/bundle/config target/bundle/doc target/bundle/bin target/bundle/runtimes target/bundle/lrsql.jar target/bundle/admin target/bundle/lrsql.exe target/bundle/lrsql_pg.exe target/bundle/LICENSE target/bundle/NOTICE
+BUNDLE_RUNTIMES ?= true
+
+ifeq ($(BUNDLE_RUNTIMES),true)
+target/bundle: target/bundle/config target/bundle/doc target/bundle/bin target/bundle/lrsql.jar target/bundle/admin target/bundle/lrsql.exe target/bundle/lrsql_pg.exe target/bundle/LICENSE target/bundle/NOTICE target/bundle/runtimes
+else
+target/bundle: target/bundle/config target/bundle/doc target/bundle/bin target/bundle/lrsql.jar target/bundle/admin target/bundle/lrsql.exe target/bundle/lrsql_pg.exe target/bundle/LICENSE target/bundle/NOTICE
+endif
+
+target/bundle:
 
 bundle: target/bundle
 


### PR DESCRIPTION
- Added crypto module to java modules for custom JREs because of SSL issue
- Added `.java_modules` list
- Updated runtimer usage to use re-usable workflow
- Switched to locally generated runtime for dev
- Updated Dockerfile to use modules list
