### PR TITLE
[SQL-129] Update H2 from v1.4.200 to v2.0.202

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -60,7 +60,7 @@
  :aliases
  {:db-h2
   {:extra-paths ["src/db/h2"]
-   :extra-deps  {com.h2database/h2 {:mvn/version "1.4.200"}}}
+   :extra-deps  {com.h2database/h2 {:mvn/version "2.0.202"}}}
   :db-sqlite
   {:extra-paths ["src/db/sqlite"]
    :extra-deps  {org.xerial/sqlite-jdbc {:mvn/version "3.36.0"}}}
@@ -93,7 +93,7 @@
                  "src/test"
                  "dev-resources"]
    :extra-deps  {;; DB deps
-                 com.h2database/h2             {:mvn/version "1.4.200"}
+                 com.h2database/h2             {:mvn/version "2.0.202"}
                  org.xerial/sqlite-jdbc        {:mvn/version "3.36.0"}
                  org.postgresql/postgresql     {:mvn/version "42.2.23"}
                  org.testcontainers/postgresql {:mvn/version "1.16.0"}

--- a/doc/sqlite.md
+++ b/doc/sqlite.md
@@ -18,7 +18,7 @@ If you wish to change the name of the db file that SQL LRS connects to, you can 
 ```
 
 ### Deleting the Database
-Since the database is just a file, it should be no surprise that you can delete it and this will reset the LRS, starting over again from scratch. Alternatively changing the dbName variable as in the section above will keep the old file around but similarly allow you to start over fresh with a new one.
+Since the database is just a file, it should be no surprise that you can delete it and this will reset the LRS, starting over again from scratch. Alternatively changing the `dbName` variable as in the section above will keep the old file around but similarly allow you to start over fresh with a new one.
 
 *WARNING:* Keep in mind there will be no ability to recover the LRS data if the file is deleted! This includes xAPI data as well as all accounts and credentials.
 

--- a/doc/startup.md
+++ b/doc/startup.md
@@ -54,6 +54,7 @@ The LRS uses a slightly different startup procedure depending on what SQL databa
 | H2 In-Memory | `bin/run_h2.sh` | `n/a` | In-memory H2 db mostly used for development. This will not save your data after a restart. There is not a windows executable for this mode. |
 | H2 Persistent | `bin/run_h2_persistent.sh` | `n/a` | H2 db mostly used for development. There is not a windows executable for this mode. |
 
+*NOTE:* All attachments and documents have a maximum size of 1 megabyte in H2 (the maximum size of a [variable byte array](http://www.h2database.com/html/datatypes.html#binary_varying_type) in H2). As such, we strongly recommend using SQLite over H2 for a non-external database.
 
 ##### Mac or Linux
 - In terminal/shell navigate to the root of the SQL LRS directory

--- a/doc/startup.md
+++ b/doc/startup.md
@@ -54,7 +54,7 @@ The LRS uses a slightly different startup procedure depending on what SQL databa
 | H2 In-Memory | `bin/run_h2.sh` | `n/a` | In-memory H2 db mostly used for development. This will not save your data after a restart. There is not a windows executable for this mode. |
 | H2 Persistent | `bin/run_h2_persistent.sh` | `n/a` | H2 db mostly used for development. There is not a windows executable for this mode. |
 
-*NOTE:* All attachments and documents have a maximum size of 1 megabyte in H2 (the maximum size of a [variable byte array](http://www.h2database.com/html/datatypes.html#binary_varying_type) in H2). As such, we strongly recommend using SQLite over H2 for a non-external database.
+*NOTE:* All attachments and documents have a maximum size of 1 megabyte in H2 (the maximum size of a [variable byte array](http://www.h2database.com/html/datatypes.html#binary_varying_type) in H2). As such, we strongly recommend using SQLite over H2 in production contexts.
 
 ##### Mac or Linux
 - In terminal/shell navigate to the root of the SQL LRS directory

--- a/src/db/h2/lrsql/h2/sql/ddl.sql
+++ b/src/db/h2/lrsql/h2/sql/ddl.sql
@@ -156,6 +156,7 @@ CREATE TABLE IF NOT EXISTS lrs_credential (
   api_key    VARCHAR(255) NOT NULL,
   secret_key VARCHAR(255) NOT NULL,
   account_id UUID NOT NULL,
+  UNIQUE (api_key, secret_key),
   FOREIGN KEY (account_id)
     REFERENCES admin_account(id)
     ON DELETE CASCADE

--- a/src/db/h2/lrsql/h2/sql/ddl.sql
+++ b/src/db/h2/lrsql/h2/sql/ddl.sql
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS attachment (
   attachment_sha VARCHAR(255) NOT NULL,
   content_type   VARCHAR(255) NOT NULL,
   content_length INTEGER NOT NULL,
-  contents       BINARY NOT NULL, -- TODO: Switch to BLOB?
+  contents       BINARY VARYING NOT NULL, -- TODO: Switch to BLOB?
   FOREIGN KEY (statement_id) REFERENCES xapi_statement(statement_id)
 )
 
@@ -103,7 +103,7 @@ CREATE TABLE IF NOT EXISTS state_document (
   last_modified  TIMESTAMP NOT NULL,
   content_type   VARCHAR(255) NOT NULL,
   content_length INTEGER NOT NULL,
-  contents       BINARY NOT NULL,
+  contents       BINARY VARYING NOT NULL,
   UNIQUE (state_id, activity_iri, agent_ifi, registration)
 )
 
@@ -117,7 +117,7 @@ CREATE TABLE IF NOT EXISTS agent_profile_document (
   last_modified  TIMESTAMP NOT NULL,
   content_type   VARCHAR(255) NOT NULL,
   content_length INTEGER NOT NULL,
-  contents       BINARY NOT NULL,
+  contents       BINARY VARYING NOT NULL,
   UNIQUE (profile_id, agent_ifi)
 )
 
@@ -131,7 +131,7 @@ CREATE TABLE IF NOT EXISTS activity_profile_document (
   last_modified  TIMESTAMP NOT NULL,
   content_type   VARCHAR(255) NOT NULL,
   content_length INTEGER NOT NULL,
-  contents       BINARY NOT NULL,
+  contents       BINARY VARYING NOT NULL,
   UNIQUE (profile_id, activity_iri)
 )
 

--- a/src/test/lrsql/lrs_test.clj
+++ b/src/test/lrsql/lrs_test.clj
@@ -136,7 +136,6 @@
         sys'  (component/start sys)
         lrs   (-> sys' :lrs)
         pre   (-> sys' :webserver :config :url-prefix)
-        _     (println pre)
         id-0  (get stmt-0 "id")
         id-1  (get stmt-1 "id")
         id-2  (get stmt-2 "id")


### PR DESCRIPTION
Update since v1.4.200 is no longer supported and to address CVE-2021-23463.

**NOTE:** This update is **not** backwards compatible (if using H2) due to changes in SQL syntax and to the underlying database file.