### PR TITLE
Update H2 to version 2.1.210 to fix vulnerabilities

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -51,7 +51,7 @@
  :aliases
  {:db-h2
   {:extra-paths ["src/db/h2"]
-   :extra-deps  {com.h2database/h2 {:mvn/version "2.0.202"}}}
+   :extra-deps  {com.h2database/h2 {:mvn/version "2.1.210"}}}
   :db-sqlite
   {:extra-paths ["src/db/sqlite"]
    :extra-deps  {org.xerial/sqlite-jdbc {:mvn/version "3.36.0"}}}
@@ -84,7 +84,7 @@
                  "src/test"
                  "dev-resources"]
    :extra-deps  {;; DB deps
-                 com.h2database/h2             {:mvn/version "2.0.202"}
+                 com.h2database/h2             {:mvn/version "2.1.210"}
                  org.xerial/sqlite-jdbc        {:mvn/version "3.36.0"}
                  org.postgresql/postgresql     {:mvn/version "42.2.23"}
                  org.testcontainers/postgresql {:mvn/version "1.16.0"}


### PR DESCRIPTION
Addresses CVE-2021-42392 and CVE-2022-23221 