### PR TITLE
SQL-132 remove clojure.main from all invocations

### DIFF
--- a/bin/run_h2.sh
+++ b/bin/run_h2.sh
@@ -2,4 +2,4 @@
 
 MACHINE=`bin/machine.sh`
 
-runtimes/$MACHINE/bin/java -server -cp lrsql.jar clojure.main -m lrsql.h2.main $@
+runtimes/$MACHINE/bin/java -server -cp lrsql.jar lrsql.h2.main $@

--- a/bin/run_h2_persistent.sh
+++ b/bin/run_h2_persistent.sh
@@ -2,4 +2,4 @@
 
 MACHINE=`bin/machine.sh`
 
-runtimes/$MACHINE/bin/java -server -cp lrsql.jar clojure.main -m lrsql.h2.main --persistent true $@
+runtimes/$MACHINE/bin/java -server -cp lrsql.jar lrsql.h2.main --persistent true $@

--- a/bin/run_postgres.sh
+++ b/bin/run_postgres.sh
@@ -2,4 +2,4 @@
 
 MACHINE=`bin/machine.sh`
 
-runtimes/$MACHINE/bin/java -server -cp lrsql.jar clojure.main -m lrsql.postgres.main $@
+runtimes/$MACHINE/bin/java -server -cp lrsql.jar lrsql.postgres.main $@

--- a/bin/run_sqlite.sh
+++ b/bin/run_sqlite.sh
@@ -2,4 +2,4 @@
 
 MACHINE=`bin/machine.sh`
 
-runtimes/$MACHINE/bin/java -server -cp lrsql.jar clojure.main -m lrsql.sqlite.main $@
+runtimes/$MACHINE/bin/java -server -cp lrsql.jar lrsql.sqlite.main $@

--- a/exe/config.xml
+++ b/exe/config.xml
@@ -3,12 +3,11 @@
   <dontWrapJar>true</dontWrapJar>
   <headerType>console</headerType>
   <classPath>
-    <mainClass>clojure.main</mainClass>
+    <mainClass>lrsql.sqlite.main</mainClass>
     <cp>lrsql.jar</cp>
   </classPath>
   <outfile>lrsql.exe</outfile>
   <errTitle>You must have Java 11+ installed to run SQL LRS</errTitle>
-  <cmdLine>-m lrsql.sqlite.main</cmdLine>
   <chdir>.</chdir>
   <priority>normal</priority>
   <downloadUrl>http://java.com/download</downloadUrl>

--- a/exe/config_pg.xml
+++ b/exe/config_pg.xml
@@ -3,12 +3,11 @@
   <dontWrapJar>true</dontWrapJar>
   <headerType>console</headerType>
   <classPath>
-    <mainClass>clojure.main</mainClass>
+    <mainClass>lrsql.postgres.main</mainClass>
     <cp>lrsql.jar</cp>
   </classPath>
   <outfile>lrsql_pg.exe</outfile>
   <errTitle>You must have Java 11+ installed to run SQL LRS</errTitle>
-  <cmdLine>-m lrsql.postgres.main</cmdLine>
   <chdir>.</chdir>
   <priority>normal</priority>
   <downloadUrl>http://java.com/download</downloadUrl>


### PR DESCRIPTION
[SQL-132] For some reason (maybe the old depstar docs?) we always invoke lrsql through clojure.main, but all of our entrypoints are AOT'd so this is superfluous. Removing them simplifies things and likely gives a little speed-up to startup.

This should also apply to the exe's, but someone with windows will have to tell me if that works ;)