### PR TITLE
Allow configuration of tc container version

### DIFF
--- a/src/test/lrsql/test_support.clj
+++ b/src/test/lrsql/test_support.clj
@@ -89,7 +89,8 @@
 ;; `tc`-prefixed DB types.
 
 (defn fresh-postgres-fixture
-  [f]
+  [f & {:keys [version]
+        :or {version "latest"}}]
   (let [id-str (str (UUID/randomUUID))
         pg-cfg (let [{{{:keys [db-type db-host db-port]}
                        :database} :connection :as raw-cfg}
@@ -102,7 +103,9 @@
                        :host   db-host
                        :port   db-port}
                       jdbc-url
-                      (cstr/replace #"postgresql:" "tc:postgresql:"))))]
+                      (cstr/replace #"postgresql:"
+                                    (format "tc:postgresql:%s:"
+                                            version)))))]
     (with-redefs
      [read-config (constantly pg-cfg)
       test-system (fn []


### PR DESCRIPTION
This shows the jdbc uri method for specifying container version. I don't feel strongly that it should be implemented the way it is here, could be passed in the config map itself, just a demonstration.