### PR TITLE
add tc version via config

### DIFF
--- a/resources/lrsql/config/config.edn
+++ b/resources/lrsql/config/config.edn
@@ -22,7 +22,7 @@
                    ;; :db-properties "currentSchema=lrsql"
 
                    ;; Testing Only! Specify the version used with testcontainers
-                   :test-db-version "latest"}
+                   :test-db-version "11.9"}
    ;; Production
    :prod-h2-mem   #include "prod/h2_mem/database.edn"
    :prod-h2       #include "prod/h2/database.edn"

--- a/resources/lrsql/config/config.edn
+++ b/resources/lrsql/config/config.edn
@@ -9,18 +9,20 @@
                    :db-port 9001}
    :test-sqlite   {:db-type "sqlite"
                    :db-name "example.sqlite.db"}
-   :test-postgres {:db-type       "postgres"
-                   :db-name       "lrsql_pg"
-                   :db-host       "0.0.0.0"
-                   :db-port       5432
-                   :db-user       "lrsql_user"
-                   :db-password   "swordfish"
+   :test-postgres {:db-type         "postgres"
+                   :db-name         "lrsql_pg"
+                   :db-host         "0.0.0.0"
+                   :db-port         5432
+                   :db-user         "lrsql_user"
+                   :db-password     "swordfish"
                    ;; Schemas are commented out for testing (since all tests
                    ;; happen in the default `public` schema). We can uncomment
                    ;; these properties for manual schema testing.
                    ;; :db-schema     "lrsql"
                    ;; :db-properties "currentSchema=lrsql"
-                   }
+
+                   ;; Testing Only! Specify the version used with testcontainers
+                   :test-db-version "latest"}
    ;; Production
    :prod-h2-mem   #include "prod/h2_mem/database.edn"
    :prod-h2       #include "prod/h2/database.edn"

--- a/src/main/lrsql/spec/config.clj
+++ b/src/main/lrsql/spec/config.clj
@@ -20,6 +20,7 @@
 (s/def ::db-schema string?)
 (s/def ::db-catalog string?)
 
+;; This is used in testing only, not configurable for production
 (s/def ::test-db-version string?)
 
 (s/def ::database

--- a/src/main/lrsql/spec/config.clj
+++ b/src/main/lrsql/spec/config.clj
@@ -20,6 +20,8 @@
 (s/def ::db-schema string?)
 (s/def ::db-catalog string?)
 
+(s/def ::test-db-version string?)
+
 (s/def ::database
   (s/and (s/conformer u/remove-nil-vals)
          (s/conformer u/remove-neg-vals)
@@ -32,13 +34,15 @@
                                 ::db-user
                                 ::db-password
                                 ::db-schema
-                                ::db-catalog])
+                                ::db-catalog
+                                ::test-db-version])
                :jdbc-url
                (s/keys :req-un [::db-jdbc-url]
                        :opt-un [::db-user
                                 ::db-password
                                 ::db-schema
-                                ::db-catalog]))))
+                                ::db-catalog
+                                ::test-db-version]))))
 
 (s/def ::pool-auto-commit boolean?)
 (s/def ::pool-initialization-fail-timeout int?)

--- a/src/test/lrsql/test_support.clj
+++ b/src/test/lrsql/test_support.clj
@@ -91,7 +91,8 @@
 (defn fresh-postgres-fixture
   [f]
   (let [id-str (str (UUID/randomUUID))
-        pg-cfg (let [{{{:keys [db-type db-host db-port]}
+        pg-cfg (let [{{{:keys [db-type db-host db-port
+                               test-db-version]}
                        :database} :connection :as raw-cfg}
                      (read-config :test-postgres)]
                  (assoc-in
@@ -102,7 +103,9 @@
                        :host   db-host
                        :port   db-port}
                       jdbc-url
-                      (cstr/replace #"postgresql:" "tc:postgresql:"))))]
+                      (cstr/replace #"postgresql:"
+                                    (format "tc:postgresql:%s:"
+                                            test-db-version)))))]
     (with-redefs
      [read-config (constantly pg-cfg)
       test-system (fn []


### PR DESCRIPTION
This PR adds a key to the `:database` config called `:test-db-version` which will be used (in tests ONLY) to set the version of PG testcontainers provides for fixtures.