### PR TITLE
[SQL-132] OIDC Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Version of LRS Admin UI to use
 
-LRS_ADMIN_UI_VERSION ?= v0.1.6-pre3
+LRS_ADMIN_UI_VERSION ?= v0.1.6
 
 LRS_ADMIN_UI_LOCATION ?= https://github.com/yetanalytics/lrs-admin-ui/releases/download/${LRS_ADMIN_UI_VERSION}/lrs-admin-ui.zip
 LRS_ADMIN_ZIPFILE ?= lrs-admin-ui-${LRS_ADMIN_UI_VERSION}.zip

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 # Version of LRS Admin UI to use
 
-LRS_ADMIN_UI_VERSION ?= v0.1.5
+LRS_ADMIN_UI_VERSION ?= v0.1.6-pre3
+
 LRS_ADMIN_UI_LOCATION ?= https://github.com/yetanalytics/lrs-admin-ui/releases/download/${LRS_ADMIN_UI_VERSION}/lrs-admin-ui.zip
 LRS_ADMIN_ZIPFILE ?= lrs-admin-ui-${LRS_ADMIN_UI_VERSION}.zip
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ resources/public/admin:
 # All other phony targets run lrsql instances that can be used and tested
 # during development. All start up with fixed DB properties and seed creds.
 
-.phony: clean-dev, ci, ephemeral, ephemeral-prod, persistent, sqlite, postgres, bench, bench-async, check-vuln
+.phony: clean-dev, ci, ephemeral, ephemeral-prod, persistent, sqlite, postgres, bench, bench-async, check-vuln, keycloak-demo, ephemeral-oidc
 
 clean-dev:
 	rm -rf *.db *.log resources/public tmp target/nvd
@@ -50,6 +50,10 @@ ephemeral: resources/public/admin
 # like ephemeral, but takes env vars
 ephemeral-prod: resources/public/admin
 	clojure -M:db-h2 -m lrsql.h2.main --persistent false
+
+# like ephemeral, but includes OIDC config for use with `keycloak-demo`
+ephemeral-oidc: resources/public/admin
+	clojure -X:db-h2 lrsql.h2.main/run-test-h2 :persistent? false :override-profile :test-oidc
 
 persistent: resources/public/admin
 	clojure -X:db-h2 lrsql.h2.main/run-test-h2 :persistent? true
@@ -83,6 +87,11 @@ target/nvd:
 	clojure -Xnvd check :classpath '"'"$$(clojure -Spath -A:db-h2:db-sqlite:db-postgres)"'"'
 
 check-vuln: target/nvd
+
+# Demo instance of Keycloak used for interactive development
+
+keycloak-demo:
+	cd dev-resources/keycloak_demo; docker compose up
 
 # *** Build ***
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 # Version of LRS Admin UI to use
 
 LRS_ADMIN_UI_VERSION ?= v0.1.6
-
 LRS_ADMIN_UI_LOCATION ?= https://github.com/yetanalytics/lrs-admin-ui/releases/download/${LRS_ADMIN_UI_VERSION}/lrs-admin-ui.zip
 LRS_ADMIN_ZIPFILE ?= lrs-admin-ui-${LRS_ADMIN_UI_VERSION}.zip
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ resources/public/admin:
 # All other phony targets run lrsql instances that can be used and tested
 # during development. All start up with fixed DB properties and seed creds.
 
-.phony: clean-dev, ci, ephemeral, persistent, sqlite, postgres, bench, bench-async, check-vuln
+.phony: clean-dev, ci, ephemeral, ephemeral-prod, persistent, sqlite, postgres, bench, bench-async, check-vuln
 
 clean-dev:
 	rm -rf *.db *.log resources/public tmp target/nvd
@@ -46,6 +46,10 @@ ci: test-h2 test-sqlite test-postgres
 
 ephemeral: resources/public/admin
 	clojure -X:db-h2 lrsql.h2.main/run-test-h2 :persistent? false
+
+# like ephemeral, but takes env vars
+ephemeral-prod: resources/public/admin
+	clojure -M:db-h2 -m lrsql.h2.main --persistent false
 
 persistent: resources/public/admin
 	clojure -X:db-h2 lrsql.h2.main/run-test-h2 :persistent? true

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ For releases and release notes, see the [Releases](https://github.com/yetanalyti
 - [Setting up TLS/HTTPS](doc/https.md)
 - [Authority Configuration](doc/authority.md)
 - [Docker Image](doc/docker.md)
+- [OpenID Connect Support](doc/oidc.md)
 
 ### DBMS-specific Sections
 

--- a/deps.edn
+++ b/deps.edn
@@ -47,7 +47,10 @@
   com.yetanalytics/colossal-squuid
   {:mvn/version "0.1.4"
    :exclusions [org.clojure/clojure
-                org.clojure/clojurescript]}}
+                org.clojure/clojurescript]}
+  com.yetanalytics/pedestal-oidc
+  {:mvn/version "0.0.5"
+   :exclusions [org.clojure/clojure]}}
  :aliases
  {:db-h2
   {:extra-paths ["src/db/h2"]

--- a/deps.edn
+++ b/deps.edn
@@ -49,7 +49,7 @@
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript]}
   com.yetanalytics/pedestal-oidc
-  {:mvn/version "0.0.5"
+  {:mvn/version "0.0.6"
    :exclusions [org.clojure/clojure]}}
  :aliases
  {:db-h2

--- a/deps.edn
+++ b/deps.edn
@@ -49,7 +49,7 @@
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript]}
   com.yetanalytics/pedestal-oidc
-  {:mvn/version "0.0.6"
+  {:mvn/version "0.0.8"
    :exclusions [org.clojure/clojure]}}
  :aliases
  {:db-h2

--- a/deps.edn
+++ b/deps.edn
@@ -72,7 +72,7 @@
    :extra-deps  {org.xerial/sqlite-jdbc {:mvn/version "3.36.0"}}}
   :db-postgres
   {:extra-paths ["src/db/postgres"]
-   :extra-deps  {org.postgresql/postgresql {:mvn/version "42.2.23"}}}
+   :extra-deps  {org.postgresql/postgresql {:mvn/version "42.2.25"}}}
   :bench
   {:extra-paths ["src/bench" "dev-resources"]
    :extra-deps  {org.clojure/tools.cli          {:mvn/version "1.0.194"}

--- a/dev-resources/keycloak_demo/docker-compose.yml
+++ b/dev-resources/keycloak_demo/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+
+configs:
+  test_realm:
+    file: ./test-realm.json
+
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:16.1.0
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: changeme123
+      KEYCLOAK_IMPORT: /tmp/test-realm.json
+    configs:
+      - source: test_realm
+        target: /tmp/test-realm.json
+    ports:
+      - "8081:8080"

--- a/dev-resources/keycloak_demo/test-realm.json
+++ b/dev-resources/keycloak_demo/test-realm.json
@@ -1,1966 +1,2060 @@
 {
-    "id" : "test",
-    "realm" : "test",
-    "notBefore" : 1642523586,
-    "defaultSignatureAlgorithm" : "RS256",
-    "revokeRefreshToken" : false,
-    "refreshTokenMaxReuse" : 0,
-    "accessTokenLifespan" : 300,
-    "accessTokenLifespanForImplicitFlow" : 900,
-    "ssoSessionIdleTimeout" : 1800,
-    "ssoSessionMaxLifespan" : 36000,
-    "ssoSessionIdleTimeoutRememberMe" : 0,
-    "ssoSessionMaxLifespanRememberMe" : 0,
-    "offlineSessionIdleTimeout" : 2592000,
-    "offlineSessionMaxLifespanEnabled" : false,
-    "offlineSessionMaxLifespan" : 5184000,
-    "clientSessionIdleTimeout" : 0,
-    "clientSessionMaxLifespan" : 0,
-    "clientOfflineSessionIdleTimeout" : 0,
-    "clientOfflineSessionMaxLifespan" : 0,
-    "accessCodeLifespan" : 60,
-    "accessCodeLifespanUserAction" : 300,
-    "accessCodeLifespanLogin" : 1800,
-    "actionTokenGeneratedByAdminLifespan" : 43200,
-    "actionTokenGeneratedByUserLifespan" : 300,
-    "oauth2DeviceCodeLifespan" : 600,
-    "oauth2DevicePollingInterval" : 5,
-    "enabled" : true,
-    "sslRequired" : "external",
-    "registrationAllowed" : false,
-    "registrationEmailAsUsername" : false,
-    "rememberMe" : false,
-    "verifyEmail" : false,
-    "loginWithEmailAllowed" : true,
-    "duplicateEmailsAllowed" : false,
-    "resetPasswordAllowed" : false,
-    "editUsernameAllowed" : false,
-    "bruteForceProtected" : false,
-    "permanentLockout" : false,
-    "maxFailureWaitSeconds" : 900,
-    "minimumQuickLoginWaitSeconds" : 60,
-    "waitIncrementSeconds" : 60,
-    "quickLoginCheckMilliSeconds" : 1000,
-    "maxDeltaTimeSeconds" : 43200,
-    "failureFactor" : 30,
-    "roles" : {
-        "realm" : [ {
-            "id" : "c5f4c2f3-0d0a-41cd-be51-58eeb1b38514",
-            "name" : "uma_authorization",
-            "description" : "${role_uma_authorization}",
-            "composite" : false,
-            "clientRole" : false,
-            "containerId" : "test",
-            "attributes" : { }
-        }, {
-            "id" : "07cf52bc-5dce-4b29-8a6c-03d4f49d95b4",
-            "name" : "offline_access",
-            "description" : "${role_offline-access}",
-            "composite" : false,
-            "clientRole" : false,
-            "containerId" : "test",
-            "attributes" : { }
-        }, {
-            "id" : "d84a5ad7-ef32-4c7f-bfed-63256266c721",
-            "name" : "default-roles-test",
-            "description" : "${role_default-roles}",
-            "composite" : true,
-            "composites" : {
-                "realm" : [ "offline_access", "uma_authorization" ],
-                "client" : {
-                    "account" : [ "view-profile", "manage-account" ]
-                }
-            },
-            "clientRole" : false,
-            "containerId" : "test",
-            "attributes" : { }
-        } ],
+  "id" : "test",
+  "realm" : "test",
+  "notBefore" : 1642523586,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "c5f4c2f3-0d0a-41cd-be51-58eeb1b38514",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "test",
+      "attributes" : { }
+    }, {
+      "id" : "07cf52bc-5dce-4b29-8a6c-03d4f49d95b4",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "test",
+      "attributes" : { }
+    }, {
+      "id" : "d84a5ad7-ef32-4c7f-bfed-63256266c721",
+      "name" : "default-roles-test",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
         "client" : {
-            "realm-management" : [ {
-                "id" : "90f9feb7-3f87-4afe-ac9c-d68601f2735c",
-                "name" : "query-groups",
-                "description" : "${role_query-groups}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "803566ff-911d-4a3c-abd5-e492f11bf019",
-                "name" : "view-events",
-                "description" : "${role_view-events}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "81629562-dd95-4e74-8e2a-91e99afdd739",
-                "name" : "view-authorization",
-                "description" : "${role_view-authorization}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "f13b65bc-3591-434d-a74f-ddc5fee3b23b",
-                "name" : "query-realms",
-                "description" : "${role_query-realms}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "224b0eb1-81c2-42ff-bd70-74c4da9d3f02",
-                "name" : "create-client",
-                "description" : "${role_create-client}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "635e39b4-0c9c-4421-8767-240d0f11bb16",
-                "name" : "manage-users",
-                "description" : "${role_manage-users}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "aaa49cca-cce6-4ad4-8eda-c8239c773502",
-                "name" : "view-users",
-                "description" : "${role_view-users}",
-                "composite" : true,
-                "composites" : {
-                    "client" : {
-                        "realm-management" : [ "query-users", "query-groups" ]
-                    }
-                },
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "826a472d-6694-4778-b581-36f51e9dddc8",
-                "name" : "view-identity-providers",
-                "description" : "${role_view-identity-providers}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "7922f15b-8b87-4742-b764-39f4ed816a74",
-                "name" : "manage-authorization",
-                "description" : "${role_manage-authorization}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "86c58c5c-6b3f-4b63-bb6b-6baf6af177e1",
-                "name" : "manage-clients",
-                "description" : "${role_manage-clients}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "806ea0bf-d63c-4e21-a63d-735910488fa5",
-                "name" : "impersonation",
-                "description" : "${role_impersonation}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "b9c2dc0d-d35e-4a04-91f0-5170fbef7b87",
-                "name" : "view-realm",
-                "description" : "${role_view-realm}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "60a907de-14b4-4004-9a7e-4300a9afb2c0",
-                "name" : "query-users",
-                "description" : "${role_query-users}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "d23cdc0a-795e-42c6-b6a8-07a7dfa0f151",
-                "name" : "manage-events",
-                "description" : "${role_manage-events}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "6b6b4b28-b594-4379-b0dc-2cde8fddeca0",
-                "name" : "realm-admin",
-                "description" : "${role_realm-admin}",
-                "composite" : true,
-                "composites" : {
-                    "client" : {
-                        "realm-management" : [ "query-groups", "view-events", "view-authorization", "query-realms", "create-client", "manage-users", "view-users", "view-identity-providers", "manage-authorization", "manage-clients", "impersonation", "view-realm", "query-users", "manage-events", "manage-identity-providers", "query-clients", "manage-realm", "view-clients" ]
-                    }
-                },
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "a2220563-986a-4ef8-ae38-0546f11a1e9c",
-                "name" : "manage-identity-providers",
-                "description" : "${role_manage-identity-providers}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "8afdbb17-4b6e-4b2f-8609-77a3c5a0179c",
-                "name" : "query-clients",
-                "description" : "${role_query-clients}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "b184e0ae-a474-4651-97e8-d28435700a73",
-                "name" : "manage-realm",
-                "description" : "${role_manage-realm}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "9d6e1fc4-1949-4cf6-bb77-06633ad90077",
-                "name" : "view-clients",
-                "description" : "${role_view-clients}",
-                "composite" : true,
-                "composites" : {
-                    "client" : {
-                        "realm-management" : [ "query-clients" ]
-                    }
-                },
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            } ],
-            "security-admin-console" : [ ],
-            "admin-cli" : [ ],
-            "account-console" : [ ],
-            "broker" : [ {
-                "id" : "4ec62d80-1cd7-4502-8029-e93d920b69ae",
-                "name" : "read-token",
-                "description" : "${role_read-token}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "9cdbf3ec-85f6-4366-956b-d1556302eac1",
-                "attributes" : { }
-            } ],
-            "lrs" : [ ],
-            "account" : [ {
-                "id" : "e34fd9d6-b441-4415-a77d-857f456dd024",
-                "name" : "manage-consent",
-                "description" : "${role_manage-consent}",
-                "composite" : true,
-                "composites" : {
-                    "client" : {
-                        "account" : [ "view-consent" ]
-                    }
-                },
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            }, {
-                "id" : "8f99b9d9-abb3-42e3-828e-504068c5666c",
-                "name" : "manage-account-links",
-                "description" : "${role_manage-account-links}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            }, {
-                "id" : "e199034f-3da1-48d0-82ed-9cde5920528f",
-                "name" : "delete-account",
-                "description" : "${role_delete-account}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            }, {
-                "id" : "be80bb48-9ca7-4517-9f70-98acea96b8d6",
-                "name" : "view-consent",
-                "description" : "${role_view-consent}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            }, {
-                "id" : "5b050df5-1366-46fe-ab90-cd43a659724c",
-                "name" : "view-profile",
-                "description" : "${role_view-profile}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            }, {
-                "id" : "689b7ad1-019f-4449-b0f9-4caf6fac4ac8",
-                "name" : "manage-account",
-                "description" : "${role_manage-account}",
-                "composite" : true,
-                "composites" : {
-                    "client" : {
-                        "account" : [ "manage-account-links" ]
-                    }
-                },
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            }, {
-                "id" : "a1ab542d-c481-4dc2-9455-cbb78c8325e5",
-                "name" : "view-applications",
-                "description" : "${role_view-applications}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            } ],
-            "lrs_admin_ui" : [ ]
+          "account" : [ "view-profile", "manage-account" ]
         }
-    },
-    "groups" : [ {
-        "id" : "617dd33a-0ec4-4ad3-b496-d792020e839c",
-        "name" : "developers",
-        "path" : "/developers",
-        "attributes" : { },
-        "realmRoles" : [ ],
-        "clientRoles" : { },
-        "subGroups" : [ ]
+      },
+      "clientRole" : false,
+      "containerId" : "test",
+      "attributes" : { }
     } ],
-    "defaultRole" : {
-        "id" : "d84a5ad7-ef32-4c7f-bfed-63256266c721",
-        "name" : "default-roles-test",
-        "description" : "${role_default-roles}",
+    "client" : {
+      "lrs_client" : [ ],
+      "realm-management" : [ {
+        "id" : "90f9feb7-3f87-4afe-ac9c-d68601f2735c",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "803566ff-911d-4a3c-abd5-e492f11bf019",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "81629562-dd95-4e74-8e2a-91e99afdd739",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "f13b65bc-3591-434d-a74f-ddc5fee3b23b",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "224b0eb1-81c2-42ff-bd70-74c4da9d3f02",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "635e39b4-0c9c-4421-8767-240d0f11bb16",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "aaa49cca-cce6-4ad4-8eda-c8239c773502",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
         "composite" : true,
-        "clientRole" : false,
-        "containerId" : "test"
-    },
-    "requiredCredentials" : [ "password" ],
-    "otpPolicyType" : "totp",
-    "otpPolicyAlgorithm" : "HmacSHA1",
-    "otpPolicyInitialCounter" : 0,
-    "otpPolicyDigits" : 6,
-    "otpPolicyLookAheadWindow" : 1,
-    "otpPolicyPeriod" : 30,
-    "otpSupportedApplications" : [ "FreeOTP", "Google Authenticator" ],
-    "webAuthnPolicyRpEntityName" : "keycloak",
-    "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
-    "webAuthnPolicyRpId" : "",
-    "webAuthnPolicyAttestationConveyancePreference" : "not specified",
-    "webAuthnPolicyAuthenticatorAttachment" : "not specified",
-    "webAuthnPolicyRequireResidentKey" : "not specified",
-    "webAuthnPolicyUserVerificationRequirement" : "not specified",
-    "webAuthnPolicyCreateTimeout" : 0,
-    "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
-    "webAuthnPolicyAcceptableAaguids" : [ ],
-    "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
-    "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
-    "webAuthnPolicyPasswordlessRpId" : "",
-    "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
-    "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
-    "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
-    "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
-    "webAuthnPolicyPasswordlessCreateTimeout" : 0,
-    "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
-    "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
-    "users" : [ {
-        "id" : "9c9708f0-c84a-49db-805a-1231b007a306",
-        "createdTimestamp" : 1643146437013,
-        "username" : "dev_user",
-        "enabled" : true,
-        "totp" : false,
-        "emailVerified" : true,
-        "firstName" : "Development",
-        "lastName" : "User",
-        "email" : "dev_user@example.com",
-        "attributes" : {
-            "foo" : [ "bar" ]
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-users", "query-groups" ]
+          }
         },
-        "credentials" : [ {
-            "id" : "9477829d-6f0b-4a2d-b1bd-40769cd79121",
-            "type" : "password",
-            "createdDate" : 1643146523059,
-            "secretData" : "{\"value\":\"kiGu0mANJBvsuKpf9AJGPfXXN7JLuH/nXmK3+1fd7pXXTtRc8ZIaQKFXt09szSJAfosrMWbNDtMAc6Of/BeLqA==\",\"salt\":\"xRmuQt7YJKfeCxlAvf/v9A==\",\"additionalParameters\":{}}",
-            "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
-        } ],
-        "disableableCredentialTypes" : [ ],
-        "requiredActions" : [ ],
-        "realmRoles" : [ "default-roles-test" ],
-        "notBefore" : 0,
-        "groups" : [ "/developers" ]
-    } ],
-    "scopeMappings" : [ {
-        "clientScope" : "offline_access",
-        "roles" : [ "offline_access" ]
-    } ],
-    "clientScopeMappings" : {
-        "account" : [ {
-            "client" : "account-console",
-            "roles" : [ "manage-account" ]
-        } ]
-    },
-    "clients" : [ {
-        "id" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-        "clientId" : "account",
-        "name" : "${client_account}",
-        "rootUrl" : "${authBaseUrl}",
-        "baseUrl" : "/realms/test/account/",
-        "surrogateAuthRequired" : false,
-        "enabled" : true,
-        "alwaysDisplayInConsole" : false,
-        "clientAuthenticatorType" : "client-secret",
-        "redirectUris" : [ "/realms/test/account/*" ],
-        "webOrigins" : [ ],
-        "notBefore" : 0,
-        "bearerOnly" : false,
-        "consentRequired" : false,
-        "standardFlowEnabled" : true,
-        "implicitFlowEnabled" : false,
-        "directAccessGrantsEnabled" : false,
-        "serviceAccountsEnabled" : false,
-        "publicClient" : true,
-        "frontchannelLogout" : false,
-        "protocol" : "openid-connect",
-        "attributes" : { },
-        "authenticationFlowBindingOverrides" : { },
-        "fullScopeAllowed" : false,
-        "nodeReRegistrationTimeout" : 0,
-        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-    }, {
-        "id" : "c8f48dc1-c2fd-45d1-bcfb-1cc345cb269a",
-        "clientId" : "account-console",
-        "name" : "${client_account-console}",
-        "rootUrl" : "${authBaseUrl}",
-        "baseUrl" : "/realms/test/account/",
-        "surrogateAuthRequired" : false,
-        "enabled" : true,
-        "alwaysDisplayInConsole" : false,
-        "clientAuthenticatorType" : "client-secret",
-        "redirectUris" : [ "/realms/test/account/*" ],
-        "webOrigins" : [ ],
-        "notBefore" : 0,
-        "bearerOnly" : false,
-        "consentRequired" : false,
-        "standardFlowEnabled" : true,
-        "implicitFlowEnabled" : false,
-        "directAccessGrantsEnabled" : false,
-        "serviceAccountsEnabled" : false,
-        "publicClient" : true,
-        "frontchannelLogout" : false,
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "pkce.code.challenge.method" : "S256"
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "826a472d-6694-4778-b581-36f51e9dddc8",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "7922f15b-8b87-4742-b764-39f4ed816a74",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "86c58c5c-6b3f-4b63-bb6b-6baf6af177e1",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "806ea0bf-d63c-4e21-a63d-735910488fa5",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "b9c2dc0d-d35e-4a04-91f0-5170fbef7b87",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "60a907de-14b4-4004-9a7e-4300a9afb2c0",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "d23cdc0a-795e-42c6-b6a8-07a7dfa0f151",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "6b6b4b28-b594-4379-b0dc-2cde8fddeca0",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "view-events", "view-authorization", "query-realms", "create-client", "manage-users", "view-users", "view-identity-providers", "manage-authorization", "manage-clients", "impersonation", "view-realm", "query-users", "manage-events", "manage-identity-providers", "query-clients", "manage-realm", "view-clients" ]
+          }
         },
-        "authenticationFlowBindingOverrides" : { },
-        "fullScopeAllowed" : false,
-        "nodeReRegistrationTimeout" : 0,
-        "protocolMappers" : [ {
-            "id" : "8ad7c1f2-57d0-4989-bda9-8768dbc222b6",
-            "name" : "audience resolve",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-audience-resolve-mapper",
-            "consentRequired" : false,
-            "config" : { }
-        } ],
-        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-    }, {
-        "id" : "554b71bc-8f36-49f1-b39f-86fa65ebbe8f",
-        "clientId" : "admin-cli",
-        "name" : "${client_admin-cli}",
-        "surrogateAuthRequired" : false,
-        "enabled" : true,
-        "alwaysDisplayInConsole" : false,
-        "clientAuthenticatorType" : "client-secret",
-        "redirectUris" : [ ],
-        "webOrigins" : [ ],
-        "notBefore" : 0,
-        "bearerOnly" : false,
-        "consentRequired" : false,
-        "standardFlowEnabled" : false,
-        "implicitFlowEnabled" : false,
-        "directAccessGrantsEnabled" : true,
-        "serviceAccountsEnabled" : false,
-        "publicClient" : true,
-        "frontchannelLogout" : false,
-        "protocol" : "openid-connect",
-        "attributes" : { },
-        "authenticationFlowBindingOverrides" : { },
-        "fullScopeAllowed" : false,
-        "nodeReRegistrationTimeout" : 0,
-        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-    }, {
-        "id" : "9cdbf3ec-85f6-4366-956b-d1556302eac1",
-        "clientId" : "broker",
-        "name" : "${client_broker}",
-        "surrogateAuthRequired" : false,
-        "enabled" : true,
-        "alwaysDisplayInConsole" : false,
-        "clientAuthenticatorType" : "client-secret",
-        "redirectUris" : [ ],
-        "webOrigins" : [ ],
-        "notBefore" : 0,
-        "bearerOnly" : true,
-        "consentRequired" : false,
-        "standardFlowEnabled" : true,
-        "implicitFlowEnabled" : false,
-        "directAccessGrantsEnabled" : false,
-        "serviceAccountsEnabled" : false,
-        "publicClient" : false,
-        "frontchannelLogout" : false,
-        "protocol" : "openid-connect",
-        "attributes" : { },
-        "authenticationFlowBindingOverrides" : { },
-        "fullScopeAllowed" : false,
-        "nodeReRegistrationTimeout" : 0,
-        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-    }, {
-        "id" : "93f48f9d-bd78-44f2-97f7-7f3b65aaa8da",
-        "clientId" : "lrs",
-        "name" : "SQL LRS",
-        "rootUrl" : "http://0.0.0.0:8080/",
-        "adminUrl" : "http://0.0.0.0:8080/",
-        "surrogateAuthRequired" : false,
-        "enabled" : true,
-        "alwaysDisplayInConsole" : false,
-        "clientAuthenticatorType" : "client-secret",
-        "redirectUris" : [ "http://0.0.0.0:8080/*" ],
-        "webOrigins" : [ "http://0.0.0.0:8080" ],
-        "notBefore" : 0,
-        "bearerOnly" : true,
-        "consentRequired" : false,
-        "standardFlowEnabled" : true,
-        "implicitFlowEnabled" : false,
-        "directAccessGrantsEnabled" : true,
-        "serviceAccountsEnabled" : false,
-        "publicClient" : false,
-        "frontchannelLogout" : false,
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "id.token.as.detached.signature" : "false",
-            "saml.assertion.signature" : "false",
-            "saml.force.post.binding" : "false",
-            "saml.multivalued.roles" : "false",
-            "saml.encrypt" : "false",
-            "oauth2.device.authorization.grant.enabled" : "false",
-            "backchannel.logout.revoke.offline.tokens" : "false",
-            "saml.server.signature" : "false",
-            "saml.server.signature.keyinfo.ext" : "false",
-            "use.refresh.tokens" : "true",
-            "exclude.session.state.from.auth.response" : "false",
-            "oidc.ciba.grant.enabled" : "false",
-            "saml.artifact.binding" : "false",
-            "backchannel.logout.session.required" : "true",
-            "client_credentials.use_refresh_token" : "false",
-            "saml_force_name_id_format" : "false",
-            "require.pushed.authorization.requests" : "false",
-            "saml.client.signature" : "false",
-            "tls.client.certificate.bound.access.tokens" : "false",
-            "saml.authnstatement" : "false",
-            "display.on.consent.screen" : "false",
-            "saml.onetimeuse.condition" : "false"
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "a2220563-986a-4ef8-ae38-0546f11a1e9c",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "8afdbb17-4b6e-4b2f-8609-77a3c5a0179c",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "b184e0ae-a474-4651-97e8-d28435700a73",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "9d6e1fc4-1949-4cf6-bb77-06633ad90077",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
         },
-        "authenticationFlowBindingOverrides" : { },
-        "fullScopeAllowed" : true,
-        "nodeReRegistrationTimeout" : -1,
-        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-    }, {
-        "clientId": "lrs_admin_ui",
-        "name": "LRS Admin UI/Figwheel Server",
-        "rootUrl": "http://localhost:9500/",
-        "adminUrl": "http://localhost:9500/",
-        "surrogateAuthRequired": false,
-        "enabled": true,
-        "alwaysDisplayInConsole": false,
-        "clientAuthenticatorType": "client-secret",
-        "redirectUris": [
-            "http://localhost:9500/",
-            "http://0.0.0.0:8080/admin/index.html",
-            "http://localhost:9500/*"
-        ],
-        "webOrigins": [
-            "http://localhost:9500",
-            "http://0.0.0.0:8080"
-        ],
-        "notBefore": 0,
-        "bearerOnly": false,
-        "consentRequired": false,
-        "standardFlowEnabled": true,
-        "implicitFlowEnabled": false,
-        "directAccessGrantsEnabled": true,
-        "serviceAccountsEnabled": false,
-        "publicClient": true,
-        "frontchannelLogout": false,
-        "protocol": "openid-connect",
-        "attributes": {
-            "saml.force.post.binding": "false",
-            "saml.multivalued.roles": "false",
-            "oauth2.device.authorization.grant.enabled": "false",
-            "use.jwks.url": "false",
-            "backchannel.logout.revoke.offline.tokens": "false",
-            "saml.server.signature.keyinfo.ext": "false",
-            "use.refresh.tokens": "true",
-            "jwt.credential.certificate": "MIICqzCCAZMCBgF+VSRiwDANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDDA50ZXN0YXBwX3B1YmxpYzAeFw0yMjAxMTMyMDMwNTVaFw0zMjAxMTMyMDMyMzVaMBkxFzAVBgNVBAMMDnRlc3RhcHBfcHVibGljMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAl18eQYywttSxpioT0plMAj0BENJQhHu/7LmkF7a4GwG3OyZNpiky3V1W4oFgfmTcTisXYBB1eRIw+bC8Iy808DX7PbHr4N/qn1pjgkohl9pPo3UnKAa2hEUsKtQDfn5Oltx/qliSvT0zFzHmPXH2CHKCqyjy9NFFG+rPNXXrmY/xM8HToqjchwvA4DHOnbcUgRzGSQl2vmO0GJvRqcFQjoQXaPEvQck8geVB2bjx0Lkt6m5zWkMZsVH8aBeBTuuZqpCGO5LecyMOHz0iEx8T0lMJorE5uR6ul8jnZzFdv9blLEiroy8Btes8WCImopKO1MCqdIbrSB54v+lQ+Jg7HwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAy9xUwUDTQjRiiHCljmJpjQEqTuXHzFaBr9oj3pQ698eM0vjaoBh0DAqUfNiPHTwqvyuOOLYoO2HJzcjnGYn0hHgTWWUGAzj0id+Nq1+nfdq9yqW2PGsEza7/LZja80RclRs3E6ZjFxPBUndyTV2ppvtL5/KFN/OYC7iXvSJd++dOIPRtk4hyOtu08HvQ0uFwh+H3bcb0ZKnTqsVhkBs9AmHF61K4IKDPJc8FahVeSVQDH46uqLjhSBx4lmjGFF7hax3RxvLB4zO88YZECo8+ce4B9kMxsYqsVL2xuJFf8kucfJRwA6LIkARsICiDI9pIda9QbHibaxyFaARQ6kdIT",
-            "oidc.ciba.grant.enabled": "false",
-            "use.jwks.string": "false",
-            "backchannel.logout.session.required": "true",
-            "client_credentials.use_refresh_token": "false",
-            "require.pushed.authorization.requests": "false",
-            "saml.client.signature": "false",
-            "id.token.as.detached.signature": "false",
-            "saml.assertion.signature": "false",
-            "saml.encrypt": "false",
-            "saml.server.signature": "false",
-            "exclude.session.state.from.auth.response": "false",
-            "saml.artifact.binding": "false",
-            "saml_force_name_id_format": "false",
-            "tls.client.certificate.bound.access.tokens": "false",
-            "saml.authnstatement": "false",
-            "display.on.consent.screen": "false",
-            "saml.onetimeuse.condition": "false"
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "4ec62d80-1cd7-4502-8029-e93d920b69ae",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "9cdbf3ec-85f6-4366-956b-d1556302eac1",
+        "attributes" : { }
+      } ],
+      "lrs" : [ ],
+      "account" : [ {
+        "id" : "e34fd9d6-b441-4415-a77d-857f456dd024",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
         },
-        "authenticationFlowBindingOverrides": {},
-        "fullScopeAllowed": true,
-        "nodeReRegistrationTimeout": -1,
-        "protocolMappers": [
-            {
-                "name": "LRS Audience Mapper",
-                "protocol": "openid-connect",
-                "protocolMapper": "oidc-audience-mapper",
-                "consentRequired": false,
-                "config": {
-                    "id.token.claim": "false",
-                    "access.token.claim": "true",
-                    "included.custom.audience": "http://0.0.0.0:8080",
-                    "userinfo.token.claim": "false"
-                }
-            }
-        ],
-        "defaultClientScopes": [
-            "web-origins",
-            "profile",
-            "roles",
-            "email"
-        ],
-        "optionalClientScopes": [
-            "lrs:statements/read",
-            "lrs:admin",
-            "lrs:all/read",
-            "address",
-            "phone",
-            "offline_access",
-            "lrs:statements/write",
-            "microprofile-jwt",
-            "lrs:all"
-        ],
-        "access": {
-            "view": true,
-            "configure": true,
-            "manage": true
-        }
-    }, {
-        "id" : "07000d1e-39d0-4864-a39d-70566b870361",
-        "clientId" : "realm-management",
-        "name" : "${client_realm-management}",
-        "surrogateAuthRequired" : false,
-        "enabled" : true,
-        "alwaysDisplayInConsole" : false,
-        "clientAuthenticatorType" : "client-secret",
-        "redirectUris" : [ ],
-        "webOrigins" : [ ],
-        "notBefore" : 0,
-        "bearerOnly" : true,
-        "consentRequired" : false,
-        "standardFlowEnabled" : true,
-        "implicitFlowEnabled" : false,
-        "directAccessGrantsEnabled" : false,
-        "serviceAccountsEnabled" : false,
-        "publicClient" : false,
-        "frontchannelLogout" : false,
-        "protocol" : "openid-connect",
-        "attributes" : { },
-        "authenticationFlowBindingOverrides" : { },
-        "fullScopeAllowed" : false,
-        "nodeReRegistrationTimeout" : 0,
-        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-    }, {
-        "id" : "fe5daf9c-81b7-4aa8-9d89-557dac44e9cd",
-        "clientId" : "security-admin-console",
-        "name" : "${client_security-admin-console}",
-        "rootUrl" : "${authAdminUrl}",
-        "baseUrl" : "/admin/test/console/",
-        "surrogateAuthRequired" : false,
-        "enabled" : true,
-        "alwaysDisplayInConsole" : false,
-        "clientAuthenticatorType" : "client-secret",
-        "redirectUris" : [ "/admin/test/console/*" ],
-        "webOrigins" : [ "+" ],
-        "notBefore" : 0,
-        "bearerOnly" : false,
-        "consentRequired" : false,
-        "standardFlowEnabled" : true,
-        "implicitFlowEnabled" : false,
-        "directAccessGrantsEnabled" : false,
-        "serviceAccountsEnabled" : false,
-        "publicClient" : true,
-        "frontchannelLogout" : false,
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "pkce.code.challenge.method" : "S256"
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      }, {
+        "id" : "8f99b9d9-abb3-42e3-828e-504068c5666c",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      }, {
+        "id" : "e199034f-3da1-48d0-82ed-9cde5920528f",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      }, {
+        "id" : "be80bb48-9ca7-4517-9f70-98acea96b8d6",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      }, {
+        "id" : "5b050df5-1366-46fe-ab90-cd43a659724c",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      }, {
+        "id" : "689b7ad1-019f-4449-b0f9-4caf6fac4ac8",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
         },
-        "authenticationFlowBindingOverrides" : { },
-        "fullScopeAllowed" : false,
-        "nodeReRegistrationTimeout" : 0,
-        "protocolMappers" : [ {
-            "id" : "c368d119-cdfa-42d3-ac6f-25027c669774",
-            "name" : "locale",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "locale",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "locale",
-                "jsonType.label" : "String"
-            }
-        } ],
-        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-    } ],
-    "clientScopes" : [ {
-        "id" : "8b2321db-a3f5-4d8e-ae28-39f48125c07a",
-        "name" : "lrs:statements/read",
-        "description" : "xAPI Statements Read Only",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "xAPI Statements Read Only"
-        }
-    }, {
-        "id" : "6a4a4a4d-03aa-473f-aa0d-75b489977d5c",
-        "name" : "profile",
-        "description" : "OpenID Connect built-in scope: profile",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "${profileScopeConsentText}"
-        },
-        "protocolMappers" : [ {
-            "id" : "f8993932-62d2-48e0-a304-3f136ea8edfe",
-            "name" : "given name",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-property-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "firstName",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "given_name",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "523c9af4-4711-43d7-85af-f3ac04ace666",
-            "name" : "updated at",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "updatedAt",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "updated_at",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "1858bdad-5c52-4aa1-b0fc-5581af798a08",
-            "name" : "nickname",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "nickname",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "nickname",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "b3db4dc4-231d-4674-a5b6-ea6d5e9016dc",
-            "name" : "username",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-property-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "username",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "preferred_username",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "e0e5805c-c044-480f-a3a7-2981d794df86",
-            "name" : "birthdate",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "birthdate",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "birthdate",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "c5ced14b-2b38-419b-9896-85cf88a3711b",
-            "name" : "family name",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-property-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "lastName",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "family_name",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "75c08d02-0833-4aa2-a098-98e4b4963cd7",
-            "name" : "middle name",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "middleName",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "middle_name",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "1cdfb88e-1e04-4d78-a68a-3e289b089a33",
-            "name" : "locale",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "locale",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "locale",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "236affeb-fffc-4848-b717-7c8f190d06fb",
-            "name" : "full name",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-full-name-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "userinfo.token.claim" : "true"
-            }
-        }, {
-            "id" : "e59085e5-6bf4-4916-a8c9-44102337b968",
-            "name" : "profile",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "profile",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "profile",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "f3bbe050-5486-4e1c-8557-070e89096f7d",
-            "name" : "picture",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "picture",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "picture",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "c7181162-eabd-4e46-9c4b-c8c4ff14ce67",
-            "name" : "gender",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "gender",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "gender",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "c3dac1cf-d61a-4f3d-8bea-74f7eb65d565",
-            "name" : "website",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "website",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "website",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "bc51e879-fd49-4456-8dab-ad9495ce1da0",
-            "name" : "zoneinfo",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "zoneinfo",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "zoneinfo",
-                "jsonType.label" : "String"
-            }
-        } ]
-    }, {
-        "id" : "db720beb-9e39-4a19-9372-3fe356561c3b",
-        "name" : "lrs:admin",
-        "description" : "All admin permissions on LRS",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "Administer LRS"
-        }
-    }, {
-        "id" : "c6283805-484f-4d1c-9e85-1955c13c9c7f",
-        "name" : "roles",
-        "description" : "OpenID Connect scope for add user roles to the access token",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "false",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "${rolesScopeConsentText}"
-        },
-        "protocolMappers" : [ {
-            "id" : "71ef7385-cc4d-41a7-aa03-d67f0586f87e",
-            "name" : "audience resolve",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-audience-resolve-mapper",
-            "consentRequired" : false,
-            "config" : { }
-        }, {
-            "id" : "f4784c65-9cd1-4b38-be19-a8c36efa0c84",
-            "name" : "client roles",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-client-role-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "user.attribute" : "foo",
-                "access.token.claim" : "true",
-                "claim.name" : "resource_access.${client_id}.roles",
-                "jsonType.label" : "String",
-                "multivalued" : "true"
-            }
-        }, {
-            "id" : "8c57c0a4-f8b9-4358-962b-49b0f3013eac",
-            "name" : "realm roles",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-realm-role-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "user.attribute" : "foo",
-                "access.token.claim" : "true",
-                "claim.name" : "realm_access.roles",
-                "jsonType.label" : "String",
-                "multivalued" : "true"
-            }
-        } ]
-    }, {
-        "id" : "817b903a-cb78-4caf-a338-affb280d364f",
-        "name" : "email",
-        "description" : "OpenID Connect built-in scope: email",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "${emailScopeConsentText}"
-        },
-        "protocolMappers" : [ {
-            "id" : "fa86e7f0-866d-412c-8191-9cc86c5a7d8b",
-            "name" : "email verified",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-property-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "emailVerified",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "email_verified",
-                "jsonType.label" : "boolean"
-            }
-        }, {
-            "id" : "8833ffce-a1a0-4558-a65e-ed5d107f1022",
-            "name" : "email",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-property-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "email",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "email",
-                "jsonType.label" : "String"
-            }
-        } ]
-    }, {
-        "id" : "7141d9b9-5746-4559-9151-8411bdb3afb5",
-        "name" : "lrs:all",
-        "description" : "All xAPI Permissions",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "All xAPI"
-        }
-    }, {
-        "id" : "1066033a-7d3e-46ba-97a1-7fc2e84c65ab",
-        "name" : "lrs:statements/write",
-        "description" : "xAPI Statements Write Only",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "xAPI Statements Write Only"
-        }
-    }, {
-        "id" : "dca4ed1d-460c-4807-b0d9-568592e6d088",
-        "name" : "web-origins",
-        "description" : "OpenID Connect scope for add allowed web origins to the access token",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "false",
-            "display.on.consent.screen" : "false",
-            "consent.screen.text" : ""
-        },
-        "protocolMappers" : [ {
-            "id" : "6374f381-4889-489e-aead-5fa18ef1b822",
-            "name" : "allowed web origins",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-allowed-origins-mapper",
-            "consentRequired" : false,
-            "config" : { }
-        } ]
-    }, {
-        "id" : "be667ccc-ba78-4afa-970e-13da6bc07427",
-        "name" : "role_list",
-        "description" : "SAML role list",
-        "protocol" : "saml",
-        "attributes" : {
-            "consent.screen.text" : "${samlRoleListScopeConsentText}",
-            "display.on.consent.screen" : "true"
-        },
-        "protocolMappers" : [ {
-            "id" : "6a7b16b0-1e49-43b8-ae44-e4e6fdc2b3fc",
-            "name" : "role list",
-            "protocol" : "saml",
-            "protocolMapper" : "saml-role-list-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "single" : "false",
-                "attribute.nameformat" : "Basic",
-                "attribute.name" : "Role"
-            }
-        } ]
-    }, {
-        "id" : "52f9ee66-42fa-4bd0-a5b3-26aa8f42e25a",
-        "name" : "phone",
-        "description" : "OpenID Connect built-in scope: phone",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "${phoneScopeConsentText}"
-        },
-        "protocolMappers" : [ {
-            "id" : "1629c27c-75cc-4407-89e6-971c900bb127",
-            "name" : "phone number verified",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "phoneNumberVerified",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "phone_number_verified",
-                "jsonType.label" : "boolean"
-            }
-        }, {
-            "id" : "2da9c5aa-679c-433a-b4dc-8ab76917b1da",
-            "name" : "phone number",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "phoneNumber",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "phone_number",
-                "jsonType.label" : "String"
-            }
-        } ]
-    }, {
-        "id" : "6467a85b-e3a6-4181-ab4b-ca879ce2c123",
-        "name" : "lrs:all/read",
-        "description" : "Read-only xAPI Permissions",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "xAPI Read Only"
-        }
-    }, {
-        "id" : "84261ec9-96d3-4f8c-b343-619828a3ad4b",
-        "name" : "address",
-        "description" : "OpenID Connect built-in scope: address",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "${addressScopeConsentText}"
-        },
-        "protocolMappers" : [ {
-            "id" : "aceb7515-642e-4403-afab-3c93aebfb056",
-            "name" : "address",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-address-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "user.attribute.formatted" : "formatted",
-                "user.attribute.country" : "country",
-                "user.attribute.postal_code" : "postal_code",
-                "userinfo.token.claim" : "true",
-                "user.attribute.street" : "street",
-                "id.token.claim" : "true",
-                "user.attribute.region" : "region",
-                "access.token.claim" : "true",
-                "user.attribute.locality" : "locality"
-            }
-        } ]
-    }, {
-        "id" : "1e5dfa94-fed1-4fb4-a591-9951704e4a84",
-        "name" : "offline_access",
-        "description" : "OpenID Connect built-in scope: offline_access",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "consent.screen.text" : "${offlineAccessScopeConsentText}",
-            "display.on.consent.screen" : "true"
-        }
-    }, {
-        "id" : "7c2908d3-28c4-42e6-bd96-c9e57cef7cf0",
-        "name" : "microprofile-jwt",
-        "description" : "Microprofile - JWT built-in scope",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "false"
-        },
-        "protocolMappers" : [ {
-            "id" : "dc7578fc-d518-4312-99ea-bb4d93774562",
-            "name" : "upn",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-property-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "username",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "upn",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "f6241122-16ec-4f71-b9e8-efd173318dea",
-            "name" : "groups",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-realm-role-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "multivalued" : "true",
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "foo",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "groups",
-                "jsonType.label" : "String"
-            }
-        } ]
-    } ],
-    "defaultDefaultClientScopes" : [ "profile", "email", "role_list", "roles", "web-origins" ],
-    "defaultOptionalClientScopes" : [ "offline_access", "phone", "microprofile-jwt", "address" ],
-    "browserSecurityHeaders" : {
-        "contentSecurityPolicyReportOnly" : "",
-        "xContentTypeOptions" : "nosniff",
-        "xRobotsTag" : "none",
-        "xFrameOptions" : "SAMEORIGIN",
-        "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
-        "xXSSProtection" : "1; mode=block",
-        "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
-    },
-    "smtpServer" : { },
-    "eventsEnabled" : false,
-    "eventsListeners" : [ "jboss-logging" ],
-    "enabledEventTypes" : [ ],
-    "adminEventsEnabled" : false,
-    "adminEventsDetailsEnabled" : false,
-    "identityProviders" : [ ],
-    "identityProviderMappers" : [ ],
-    "components" : {
-        "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
-            "id" : "c0c16b10-415f-4d6e-88f6-c1050314e85d",
-            "name" : "Max Clients Limit",
-            "providerId" : "max-clients",
-            "subType" : "anonymous",
-            "subComponents" : { },
-            "config" : {
-                "max-clients" : [ "200" ]
-            }
-        }, {
-            "id" : "06bdbf20-05ff-4e6d-bbf0-3daa86fb0757",
-            "name" : "Consent Required",
-            "providerId" : "consent-required",
-            "subType" : "anonymous",
-            "subComponents" : { },
-            "config" : { }
-        }, {
-            "id" : "86f63e93-ef16-41ff-8a7b-9a0f99344497",
-            "name" : "Allowed Protocol Mapper Types",
-            "providerId" : "allowed-protocol-mappers",
-            "subType" : "anonymous",
-            "subComponents" : { },
-            "config" : {
-                "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "saml-user-property-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper" ]
-            }
-        }, {
-            "id" : "cb89ebbf-ff1c-432c-a43e-63df05848a62",
-            "name" : "Allowed Client Scopes",
-            "providerId" : "allowed-client-templates",
-            "subType" : "authenticated",
-            "subComponents" : { },
-            "config" : {
-                "allow-default-scopes" : [ "true" ]
-            }
-        }, {
-            "id" : "70c357f9-59c0-4758-b202-ba75ace53eda",
-            "name" : "Full Scope Disabled",
-            "providerId" : "scope",
-            "subType" : "anonymous",
-            "subComponents" : { },
-            "config" : { }
-        }, {
-            "id" : "9f3b5f54-efe8-4ebf-a6d7-1bcb3b3f192b",
-            "name" : "Allowed Client Scopes",
-            "providerId" : "allowed-client-templates",
-            "subType" : "anonymous",
-            "subComponents" : { },
-            "config" : {
-                "allow-default-scopes" : [ "true" ]
-            }
-        }, {
-            "id" : "e640c7f7-0c39-4b47-91c3-d1687c353769",
-            "name" : "Trusted Hosts",
-            "providerId" : "trusted-hosts",
-            "subType" : "anonymous",
-            "subComponents" : { },
-            "config" : {
-                "host-sending-registration-request-must-match" : [ "true" ],
-                "client-uris-must-match" : [ "true" ]
-            }
-        }, {
-            "id" : "ebc3625c-9fe2-4739-8d75-b07866794e28",
-            "name" : "Allowed Protocol Mapper Types",
-            "providerId" : "allowed-protocol-mappers",
-            "subType" : "authenticated",
-            "subComponents" : { },
-            "config" : {
-                "allowed-protocol-mapper-types" : [ "saml-user-attribute-mapper", "saml-role-list-mapper", "oidc-usermodel-property-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper" ]
-            }
-        } ],
-        "org.keycloak.keys.KeyProvider" : [ {
-            "id" : "2586006e-6e8e-479f-b6e3-dd2af4bd253d",
-            "name" : "rsa-generated",
-            "providerId" : "rsa-generated",
-            "subComponents" : { },
-            "config" : {
-                "privateKey" : [ "MIIEpAIBAAKCAQEAs49gQ2xcce8VslFoqBR3gj/oUmOc2g2J8SGlPaYAQ4pHWopfZqD6gBQ5hKmRKefuNBXn2bN2j2Zq7RMbPVYKH6F5U+RtJ1ja+tNOK8+uY5coqvwRrYR10BFtrYNq9MapWHXUFdzIJZ5IDT3/W/jS6qNPOL49Os/TO7tf8QpVV67d0zxblR8VSKagp1KmhjSvTx7lWJcRNYRIKFbIcZ0ZP4/2pzemTyDqJjkzgNrSW8K3cNLzohdjr1pR3UFVw+sGlG5NdDrVs0CporOJrArzqF8YkLMMpMCLpjYAiK7AEC7yN9cn7Og1NctqVN2lA+agqkcT+dpOE1wa2lr1oeTKAwIDAQABAoIBAGj34CaKKmDQi7Z6sNvRWyvhgEbpxMAUOheku5yWdoEFTUE4sxyj7s0BBb7wAdSlqTL5u1gg+aZLEScWjE4HBlQHaY4Jc2YVI66N6JzkA+Zkb3nFcfAmB1ljVuKgeN4vZMA54YoGT1rudOCI5cc2ZtaUMbPSQqkm5S1+FFAs4kcnD6t/m3dpHE0uG3cWutfzUHAkk0cZFtZFLlI+arB4Ml5fj/ZfDTC4cp8+LS4EeHK/+gmlBGOknEd8gtNLl4a9G2lOfvG8knjnWpIApkDhPpLqtn8x/KHYeu+dJ1u2V+Fn5ZNcILp66q3zbFevZVNNzsrQXx8f1huoO4dTnIytOIECgYEA4lh05yHfPohdoiW2DvowzV7Bg3V2e3Z5pXTB2kcfP65QITqYJpItmeLvfMUXbxbOUOP1ZaBJig7WbfngqFsOa9J77KBJw+c1N91FCtm7auovGsbo8sOAGRu7oQPS/DZO5aUBfGncfHAJpJ/yWWHlOk/S30fBU+QlVK168d1YK2sCgYEAyxXAnpR346U4ayW02Re1I7hPP0bYwQy9TseYlfimxzApIEa6vNbyHXtbl4ppl5uakBMZcDpM3JfZni7eLD6ndH5rWNyGSkNmPh+yb6E92Asnv+1VmGJd7FAM2VbLfY7ufS7qEBJWJrmwRuOB9DbpmRQqQ3PvdelOCGj3FOzX2ckCgYAh2Yq6GjWxu2ENY8hjWwU7YWVdTI7IjgJJPTnUc/h3ZJE1NvcUJZ5OOkMIjM0hXu7B6CWF6j+1NtzYm5r+coeollTUIXCGrKgnz56IreE6bwVWYtLpo1Uf7CbWQKUn9NM9wryDJ63Cqlq21PjAZ0SJwPBPVgLSkfcHP954F1sdOwKBgQCd9q18q78VMs5PiWTB987Nme8KKPEwN9iIDniBLoeLJ8rVcC6P9CEfDXSQyviXFFGE/1YqFS7z5qk+gPYPNCzMUAjvdZh+6y375GvGqISSJxskDlcl0F1+EkXsR7bAUwzuEi+9kIWyWXzjptLOQmgwyZ6WGPeJn48yu3J0tESxAQKBgQCHvUJOwdrXqN7mZzAWPUwbLr+evkJSQQyquR3HW/Yq8LYB1nFxzBVdNKvh5JMvpB1wOtjFdEQ0y6M+w+ZzMfsJEz0jap1z0m8R0DwrXCjtIT9YOtSkbp2cHxxMYodshqEKQErkFtNySit/BkYjpJrSNwk7AwfDNaCdcXcHmR962A==" ],
-                "keyUse" : [ "SIG" ],
-                "certificate" : [ "MIIClzCCAX8CBgF+ShW75DANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDAR0ZXN0MB4XDTIyMDExMTE2NTkwNVoXDTMyMDExMTE3MDA0NVowDzENMAsGA1UEAwwEdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALOPYENsXHHvFbJRaKgUd4I/6FJjnNoNifEhpT2mAEOKR1qKX2ag+oAUOYSpkSnn7jQV59mzdo9mau0TGz1WCh+heVPkbSdY2vrTTivPrmOXKKr8Ea2EddARba2DavTGqVh11BXcyCWeSA09/1v40uqjTzi+PTrP0zu7X/EKVVeu3dM8W5UfFUimoKdSpoY0r08e5ViXETWESChWyHGdGT+P9qc3pk8g6iY5M4Da0lvCt3DS86IXY69aUd1BVcPrBpRuTXQ61bNAqaKziawK86hfGJCzDKTAi6Y2AIiuwBAu8jfXJ+zoNTXLalTdpQPmoKpHE/naThNcGtpa9aHkygMCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAoj8kXR2fabdLtMGCj7BGy1xIJLUtNnmAIGnHaZ37cVadzHPxRXtOKJjBrAOrjQ7dvONelubZ3Uj9warCdsUV65t6NrG85KpJlW3qVtMuaIoY/sJ2bT9CYKemrOgTW3LgPmjO+YpZOR4uuo2LmVw0XL8KE6zlZwqRfwhjWy/QkRrgHsIXcbF4SnVDAQzpPlo3dTNS60pDtQtbYkIFI2ujdFpkA5u73DAPUCNakRvoutI8ZuHRqqPIIwKFzMXYZNG4GRfL51tRC14VSb+IIoknFwPpm2Y4ZCZkM7OfEDombHgU301NpMcc0ZZxw0zrI5ADEgLpxFitonbFf4MZyJXUbA==" ],
-                "priority" : [ "100" ]
-            }
-        }, {
-            "id" : "3c9c0ea4-c541-428d-ac49-44d955b4fbcc",
-            "name" : "rsa-enc-generated",
-            "providerId" : "rsa-enc-generated",
-            "subComponents" : { },
-            "config" : {
-                "privateKey" : [ "MIIEogIBAAKCAQEAh4/1V8qm/ZoenwUI15TispVHM24NvnhbPOlSg4Hj3FduSi9qJ/CbiOKaZ15cQ6n6J4Niiv5X6VgehrU00Ni/yzNfDVjiiz2esb4YEGHMoEzjtjh6B5sNaptYyYjOenHRdiEVsKX480DJDs81MrQS7dLaSkXP3nz8i1w6JK086vT6JLf5YX7w+aESFr4etzPluWokKtx9MvK36+oqoPqIzzzXOSDFQ1FaQmOMyYKxaVOL9TFJoCevR5BzDxz+p5OyjDvsDq6VhKavU5mggXgQNrpDuWvNJQ7aBnUY2iJ0+gOF4/KieHUWNgtDc5eyOuhWRqg6QsEM8jXiOa55tVm+7QIDAQABAoIBAEavLYJFTKVXQzgva9jc7QepBqMuc0QphYlRL5EanTE69WsBJh0FPFQ3s8LKVNmDO8h2nV9UF4q4Q9KBkbSEEB1n/9v5yMZJrwGG2Q1RsVy0Ote8wwRMOMapkbYj+2WlC07JGYIuSIyt7yglqttxQZ14IBIyLJ0aFqSjxj1xhx4LMlslOMzjgAqybqATj+3/dbhUxj82DoucVMkGvgJyax9VuJL7r0c7jvzn+/LRjP2oouECN9NjOusVM1CA4+l70IasR6dnuD93QMK/rBSTvls2knk9HPBX5bZZxa0cLK2en14Zv9T57zf7176Xuy7WC4eUSfVN7LiiO5RA5bK/QgECgYEA1pfZqp3ynhRp8VAO9qqSuOBdqxXYkKEnoQgNp9v/t8DM5DftOExyFPeAcFu1nSoKALM0J+MaV9ggsS8c1vVgc63jL96Yt9+/dhIXJuHFx0TlE/6TLYmrRgfOSvthiSsGxVutcGu0UfYcmhObNLike3Ulfb7Sww2z18Ic/NSEfs0CgYEAobhDLH8xfV7rPnvQB3bse2Pz4anqFIgfaTJYk9dYgjuHpy9v4qU5LqJ8UjJtVscceJObrQnkZADzaQNMkL1Ce7YBmzo/pB2M39J7cRyQ+H5d2VbSlX9dTL+jBzvIye73YXl9GQH7YPU0NwGY3qtmNUYUetFdLYaK0cCukfoeAKECgYBT/pPgSHqSjYL6RU/WFOXhH1EKij5+PdX5HeHadi4dioWoPovHoYR12HqZgAwSPEY2B+6+PhItmBcTw1ESgnECVmm6bvJv5lBWsrYFLhHv8XOI4/hPtrcnbh69ErAWtJSt4zh77GxkOGTxmgMCG9OlzzChi3OLjW17YiteewBxcQKBgFhO8Ud8ET8/tL/DBl79HrdmZkeE7FDX4Ccmmd3pSuiar0GpErS1ulrv2WldJf2r7q0dFXZRH4lIR6LBbW7gGkzJn2jvTs9EX6fdHREwIy2+e2ryET4XdZAyWUja6ZLzTdzJZXlhbq6MVz3uPlbhS4etxAMpDnOMs4NEb09BQF7hAoGAQ//vl9A328D5h5O5XyqylG1WPeXLcdwMQ3uP+erxS4kLrYlEv3Eo7BNpK6nRHQUndkrOGDMABc3TOOnYVE6486DWdrpy9MsQk3KoNM7KogswRQcDmXPLG3smOcfAtOraZGqlL8SX15N9CAedj0Nw4MeDI7biSZSt6jhaC5RlZlU=" ],
-                "keyUse" : [ "ENC" ],
-                "certificate" : [ "MIIClzCCAX8CBgF+ShW93DANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDAR0ZXN0MB4XDTIyMDExMTE2NTkwNVoXDTMyMDExMTE3MDA0NVowDzENMAsGA1UEAwwEdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIeP9VfKpv2aHp8FCNeU4rKVRzNuDb54WzzpUoOB49xXbkovaifwm4jimmdeXEOp+ieDYor+V+lYHoa1NNDYv8szXw1Y4os9nrG+GBBhzKBM47Y4egebDWqbWMmIznpx0XYhFbCl+PNAyQ7PNTK0Eu3S2kpFz958/ItcOiStPOr0+iS3+WF+8PmhEha+Hrcz5blqJCrcfTLyt+vqKqD6iM881zkgxUNRWkJjjMmCsWlTi/UxSaAnr0eQcw8c/qeTsow77A6ulYSmr1OZoIF4EDa6Q7lrzSUO2gZ1GNoidPoDhePyonh1FjYLQ3OXsjroVkaoOkLBDPI14jmuebVZvu0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEADSvRbqA28R+QU2ij01HcDNWmLvkxSMTFytHRs08n00Rd4ONYeXir1s2F4o0bSLCuYX1d7hOJiw2VVkQNqU2ZvfLZe9QBIetj+AaSsFEz3+3CqE22fHPrnM+1cI6SXpF/zK7Jx3sNdaKRuG3+WbTtjT1p45D/QwUd/YzjWf2YI824jAGamTupd1oyKX2klCnryS2sKrIqnH/1MDfgK93PLtSxNite/effRI2O6ySXX1wmila+nBo9hYcr5Y+yHCmPg+EtdVgGzvVDKrxFEQcLvbZD1HBDCymkWzix0hbsSKc4BDfBl8gOiAes4CATvhMyVJ4unsb/SMBkIDfclr/vdQ==" ],
-                "priority" : [ "100" ],
-                "algorithm" : [ "RSA-OAEP" ]
-            }
-        }, {
-            "id" : "ced222a6-758f-4bde-a993-c1f8882b99f3",
-            "name" : "hmac-generated",
-            "providerId" : "hmac-generated",
-            "subComponents" : { },
-            "config" : {
-                "kid" : [ "13938f82-4b06-4dfa-a9ae-9f113d84d602" ],
-                "secret" : [ "cROFgwh4hrwUtON8MHhFY2Izr-A70s5FbHetwhnr0HdWNqrCtiPznHbNcvCpC8RhA1Nlm5i_DuxfkNHxbmDyEQ" ],
-                "priority" : [ "100" ],
-                "algorithm" : [ "HS256" ]
-            }
-        }, {
-            "id" : "1346c112-4ab3-4609-8282-c13fdb429b51",
-            "name" : "aes-generated",
-            "providerId" : "aes-generated",
-            "subComponents" : { },
-            "config" : {
-                "kid" : [ "622051f7-e16a-45ea-ae3d-d0f3d7c6066f" ],
-                "secret" : [ "087wgqk1GaBeJqSwG0Va1A" ],
-                "priority" : [ "100" ]
-            }
-        } ]
-    },
-    "internationalizationEnabled" : false,
-    "supportedLocales" : [ ],
-    "authenticationFlows" : [ {
-        "id" : "42162a9e-46d8-4683-b4de-33f63f2acb3e",
-        "alias" : "Account verification options",
-        "description" : "Method with which to verity the existing account",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "idp-email-verification",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 20,
-            "flowAlias" : "Verify Existing Account by Re-authentication",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "377ebacb-348b-4a0c-89dc-8bc7c04f8ae9",
-        "alias" : "Authentication Options",
-        "description" : "Authentication options.",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "basic-auth",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "basic-auth-otp",
-            "authenticatorFlow" : false,
-            "requirement" : "DISABLED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "auth-spnego",
-            "authenticatorFlow" : false,
-            "requirement" : "DISABLED",
-            "priority" : 30,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "44561c83-653d-4e87-badf-0b60d90d1ac6",
-        "alias" : "Browser - Conditional OTP",
-        "description" : "Flow to determine if the OTP is required for the authentication",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "conditional-user-configured",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "auth-otp-form",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "224fa87f-aec9-479f-badc-a7de48a3b5e1",
-        "alias" : "Direct Grant - Conditional OTP",
-        "description" : "Flow to determine if the OTP is required for the authentication",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "conditional-user-configured",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "direct-grant-validate-otp",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "42e59c0b-41a7-458c-848b-3e28269151c6",
-        "alias" : "First broker login - Conditional OTP",
-        "description" : "Flow to determine if the OTP is required for the authentication",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "conditional-user-configured",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "auth-otp-form",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "b92df23b-0b5d-47ed-a0bb-1e7c59d3a7dd",
-        "alias" : "Handle Existing Account",
-        "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "idp-confirm-link",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "flowAlias" : "Account verification options",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "f124c209-55a1-494c-9b2f-5c940da6de4c",
-        "alias" : "Reset - Conditional OTP",
-        "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "conditional-user-configured",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "reset-otp",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "0e5718c0-8561-4da5-b466-223ab6668d07",
-        "alias" : "User creation or linking",
-        "description" : "Flow for the existing/non-existing user alternatives",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticatorConfig" : "create unique user config",
-            "authenticator" : "idp-create-user-if-unique",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 20,
-            "flowAlias" : "Handle Existing Account",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "e4dcb1d4-db3f-48af-991e-893364e81a18",
-        "alias" : "Verify Existing Account by Re-authentication",
-        "description" : "Reauthentication of existing account",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "idp-username-password-form",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "CONDITIONAL",
-            "priority" : 20,
-            "flowAlias" : "First broker login - Conditional OTP",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "9516356e-7d84-4bb8-916e-ac9b8ecc7762",
-        "alias" : "browser",
-        "description" : "browser based authentication",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "auth-cookie",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "auth-spnego",
-            "authenticatorFlow" : false,
-            "requirement" : "DISABLED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "identity-provider-redirector",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 25,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 30,
-            "flowAlias" : "forms",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "fd8729f9-54e0-4668-981d-ba07816bedc6",
-        "alias" : "clients",
-        "description" : "Base authentication for clients",
-        "providerId" : "client-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "client-secret",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "client-jwt",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "client-secret-jwt",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 30,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "client-x509",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 40,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "1ee381cc-3d6e-4997-8e55-337a39d5c72d",
-        "alias" : "direct grant",
-        "description" : "OpenID Connect Resource Owner Grant",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "direct-grant-validate-username",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "direct-grant-validate-password",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "CONDITIONAL",
-            "priority" : 30,
-            "flowAlias" : "Direct Grant - Conditional OTP",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "238e5013-5aa6-4199-8364-272ecbddb6d9",
-        "alias" : "docker auth",
-        "description" : "Used by Docker clients to authenticate against the IDP",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "docker-http-basic-authenticator",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "ba482013-fbc2-42a1-bbfa-3166f9eb7506",
-        "alias" : "first broker login",
-        "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticatorConfig" : "review profile config",
-            "authenticator" : "idp-review-profile",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "flowAlias" : "User creation or linking",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "f1366e50-9bf5-4b76-a10b-cbc78dfbc513",
-        "alias" : "forms",
-        "description" : "Username, password, otp and other auth forms.",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "auth-username-password-form",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "CONDITIONAL",
-            "priority" : 20,
-            "flowAlias" : "Browser - Conditional OTP",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "45807ee7-a310-4fb0-91c4-4510de12643a",
-        "alias" : "http challenge",
-        "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "no-cookie-redirect",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "flowAlias" : "Authentication Options",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "c7fd3e3c-5eeb-4b78-9651-313f60ec97ae",
-        "alias" : "registration",
-        "description" : "registration flow",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "registration-page-form",
-            "authenticatorFlow" : true,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "flowAlias" : "registration form",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "9e7b6c5e-0124-4e82-9266-ee24cd489b79",
-        "alias" : "registration form",
-        "description" : "registration form",
-        "providerId" : "form-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "registration-user-creation",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "registration-profile-action",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 40,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "registration-password-action",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 50,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "registration-recaptcha-action",
-            "authenticatorFlow" : false,
-            "requirement" : "DISABLED",
-            "priority" : 60,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "28c7878b-49cd-4ae3-895d-fe470601813d",
-        "alias" : "reset credentials",
-        "description" : "Reset credentials for a user if they forgot their password or something",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "reset-credentials-choose-user",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "reset-credential-email",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "reset-password",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 30,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "CONDITIONAL",
-            "priority" : 40,
-            "flowAlias" : "Reset - Conditional OTP",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "1490e50b-c26d-423e-91c7-62801ddb1e19",
-        "alias" : "saml ecp",
-        "description" : "SAML ECP Profile Authentication Flow",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "http-basic-authenticator",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    } ],
-    "authenticatorConfig" : [ {
-        "id" : "8f937846-ec80-4e17-a50c-f7fdfd900d5d",
-        "alias" : "create unique user config",
-        "config" : {
-            "require.password.update.after.registration" : "false"
-        }
-    }, {
-        "id" : "3a8384cd-4ef4-4f0f-9c52-2f7ebe234bc0",
-        "alias" : "review profile config",
-        "config" : {
-            "update.profile.on.first.login" : "missing"
-        }
-    } ],
-    "requiredActions" : [ {
-        "alias" : "CONFIGURE_TOTP",
-        "name" : "Configure OTP",
-        "providerId" : "CONFIGURE_TOTP",
-        "enabled" : true,
-        "defaultAction" : false,
-        "priority" : 10,
-        "config" : { }
-    }, {
-        "alias" : "terms_and_conditions",
-        "name" : "Terms and Conditions",
-        "providerId" : "terms_and_conditions",
-        "enabled" : false,
-        "defaultAction" : false,
-        "priority" : 20,
-        "config" : { }
-    }, {
-        "alias" : "UPDATE_PASSWORD",
-        "name" : "Update Password",
-        "providerId" : "UPDATE_PASSWORD",
-        "enabled" : true,
-        "defaultAction" : false,
-        "priority" : 30,
-        "config" : { }
-    }, {
-        "alias" : "UPDATE_PROFILE",
-        "name" : "Update Profile",
-        "providerId" : "UPDATE_PROFILE",
-        "enabled" : true,
-        "defaultAction" : false,
-        "priority" : 40,
-        "config" : { }
-    }, {
-        "alias" : "VERIFY_EMAIL",
-        "name" : "Verify Email",
-        "providerId" : "VERIFY_EMAIL",
-        "enabled" : true,
-        "defaultAction" : false,
-        "priority" : 50,
-        "config" : { }
-    }, {
-        "alias" : "delete_account",
-        "name" : "Delete Account",
-        "providerId" : "delete_account",
-        "enabled" : false,
-        "defaultAction" : false,
-        "priority" : 60,
-        "config" : { }
-    }, {
-        "alias" : "update_user_locale",
-        "name" : "Update User Locale",
-        "providerId" : "update_user_locale",
-        "enabled" : true,
-        "defaultAction" : false,
-        "priority" : 1000,
-        "config" : { }
-    } ],
-    "browserFlow" : "browser",
-    "registrationFlow" : "registration",
-    "directGrantFlow" : "direct grant",
-    "resetCredentialsFlow" : "reset credentials",
-    "clientAuthenticationFlow" : "clients",
-    "dockerAuthenticationFlow" : "docker auth",
-    "attributes" : {
-        "cibaBackchannelTokenDeliveryMode" : "poll",
-        "cibaExpiresIn" : "120",
-        "cibaAuthRequestedUserHint" : "login_hint",
-        "oauth2DeviceCodeLifespan" : "600",
-        "clientOfflineSessionMaxLifespan" : "0",
-        "oauth2DevicePollingInterval" : "5",
-        "clientSessionIdleTimeout" : "0",
-        "parRequestUriLifespan" : "60",
-        "clientSessionMaxLifespan" : "0",
-        "clientOfflineSessionIdleTimeout" : "0",
-        "cibaInterval" : "5"
-    },
-    "keycloakVersion" : "16.1.0",
-    "userManagedAccessAllowed" : false,
-    "clientProfiles" : {
-        "profiles" : [ ]
-    },
-    "clientPolicies" : {
-        "policies" : [ ]
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      }, {
+        "id" : "a1ab542d-c481-4dc2-9455-cbb78c8325e5",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      } ],
+      "lrs_admin_ui" : [ ]
     }
+  },
+  "groups" : [ {
+    "id" : "617dd33a-0ec4-4ad3-b496-d792020e839c",
+    "name" : "developers",
+    "path" : "/developers",
+    "attributes" : { },
+    "realmRoles" : [ ],
+    "clientRoles" : { },
+    "subGroups" : [ ]
+  } ],
+  "defaultRole" : {
+    "id" : "d84a5ad7-ef32-4c7f-bfed-63256266c721",
+    "name" : "default-roles-test",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "test"
+  },
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpSupportedApplications" : [ "FreeOTP", "Google Authenticator" ],
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "users" : [ {
+    "id" : "9c9708f0-c84a-49db-805a-1231b007a306",
+    "createdTimestamp" : 1643146437013,
+    "username" : "dev_user",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : true,
+    "firstName" : "Development",
+    "lastName" : "User",
+    "email" : "dev_user@example.com",
+    "attributes" : {
+      "foo" : [ "bar" ]
+    },
+    "credentials" : [ {
+      "id" : "9477829d-6f0b-4a2d-b1bd-40769cd79121",
+      "type" : "password",
+      "createdDate" : 1643146523059,
+      "secretData" : "{\"value\":\"kiGu0mANJBvsuKpf9AJGPfXXN7JLuH/nXmK3+1fd7pXXTtRc8ZIaQKFXt09szSJAfosrMWbNDtMAc6Of/BeLqA==\",\"salt\":\"xRmuQt7YJKfeCxlAvf/v9A==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-test" ],
+    "notBefore" : 0,
+    "groups" : [ "/developers" ]
+  }, {
+    "id" : "992c8e02-6407-4f52-9c67-13821d62ac4e",
+    "createdTimestamp" : 1648052715358,
+    "username" : "service-account-lrs_client",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "serviceAccountClientId" : "lrs_client",
+    "credentials" : [ ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-test" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  } ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/test/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/test/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "c8f48dc1-c2fd-45d1-bcfb-1cc345cb269a",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/test/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/test/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "8ad7c1f2-57d0-4989-bda9-8768dbc222b6",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "554b71bc-8f36-49f1-b39f-86fa65ebbe8f",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "9cdbf3ec-85f6-4366-956b-d1556302eac1",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "93f48f9d-bd78-44f2-97f7-7f3b65aaa8da",
+    "clientId" : "lrs",
+    "name" : "SQL LRS",
+    "rootUrl" : "http://0.0.0.0:8080/",
+    "adminUrl" : "http://0.0.0.0:8080/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "http://0.0.0.0:8080/*" ],
+    "webOrigins" : [ "http://0.0.0.0:8080" ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "id.token.as.detached.signature" : "false",
+      "saml.assertion.signature" : "false",
+      "saml.force.post.binding" : "false",
+      "saml.multivalued.roles" : "false",
+      "saml.encrypt" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false",
+      "saml.server.signature" : "false",
+      "saml.server.signature.keyinfo.ext" : "false",
+      "use.refresh.tokens" : "true",
+      "exclude.session.state.from.auth.response" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "saml.artifact.binding" : "false",
+      "backchannel.logout.session.required" : "true",
+      "client_credentials.use_refresh_token" : "false",
+      "saml_force_name_id_format" : "false",
+      "require.pushed.authorization.requests" : "false",
+      "saml.client.signature" : "false",
+      "tls.client.certificate.bound.access.tokens" : "false",
+      "saml.authnstatement" : "false",
+      "display.on.consent.screen" : "false",
+      "saml.onetimeuse.condition" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "5815065b-8104-4051-b4a8-59a97c2af242",
+    "clientId" : "lrs_admin_ui",
+    "name" : "LRS Admin UI/Figwheel Server",
+    "rootUrl" : "http://localhost:9500/",
+    "adminUrl" : "http://localhost:9500/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "http://localhost:9500/", "http://0.0.0.0:8080/admin/index.html", "http://localhost:9500/*" ],
+    "webOrigins" : [ "http://localhost:9500", "http://0.0.0.0:8080" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "saml.force.post.binding" : "false",
+      "saml.multivalued.roles" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "use.jwks.url" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false",
+      "saml.server.signature.keyinfo.ext" : "false",
+      "use.refresh.tokens" : "true",
+      "jwt.credential.certificate" : "MIICqzCCAZMCBgF+VSRiwDANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDDA50ZXN0YXBwX3B1YmxpYzAeFw0yMjAxMTMyMDMwNTVaFw0zMjAxMTMyMDMyMzVaMBkxFzAVBgNVBAMMDnRlc3RhcHBfcHVibGljMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAl18eQYywttSxpioT0plMAj0BENJQhHu/7LmkF7a4GwG3OyZNpiky3V1W4oFgfmTcTisXYBB1eRIw+bC8Iy808DX7PbHr4N/qn1pjgkohl9pPo3UnKAa2hEUsKtQDfn5Oltx/qliSvT0zFzHmPXH2CHKCqyjy9NFFG+rPNXXrmY/xM8HToqjchwvA4DHOnbcUgRzGSQl2vmO0GJvRqcFQjoQXaPEvQck8geVB2bjx0Lkt6m5zWkMZsVH8aBeBTuuZqpCGO5LecyMOHz0iEx8T0lMJorE5uR6ul8jnZzFdv9blLEiroy8Btes8WCImopKO1MCqdIbrSB54v+lQ+Jg7HwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAy9xUwUDTQjRiiHCljmJpjQEqTuXHzFaBr9oj3pQ698eM0vjaoBh0DAqUfNiPHTwqvyuOOLYoO2HJzcjnGYn0hHgTWWUGAzj0id+Nq1+nfdq9yqW2PGsEza7/LZja80RclRs3E6ZjFxPBUndyTV2ppvtL5/KFN/OYC7iXvSJd++dOIPRtk4hyOtu08HvQ0uFwh+H3bcb0ZKnTqsVhkBs9AmHF61K4IKDPJc8FahVeSVQDH46uqLjhSBx4lmjGFF7hax3RxvLB4zO88YZECo8+ce4B9kMxsYqsVL2xuJFf8kucfJRwA6LIkARsICiDI9pIda9QbHibaxyFaARQ6kdIT",
+      "oidc.ciba.grant.enabled" : "false",
+      "use.jwks.string" : "false",
+      "backchannel.logout.session.required" : "true",
+      "client_credentials.use_refresh_token" : "false",
+      "require.pushed.authorization.requests" : "false",
+      "saml.client.signature" : "false",
+      "id.token.as.detached.signature" : "false",
+      "saml.assertion.signature" : "false",
+      "saml.encrypt" : "false",
+      "saml.server.signature" : "false",
+      "exclude.session.state.from.auth.response" : "false",
+      "saml.artifact.binding" : "false",
+      "saml_force_name_id_format" : "false",
+      "tls.client.certificate.bound.access.tokens" : "false",
+      "saml.authnstatement" : "false",
+      "display.on.consent.screen" : "false",
+      "saml.onetimeuse.condition" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "07ca9c45-03b8-4744-bedd-6dcd3cbfc6b1",
+      "name" : "LRS Audience Mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "false",
+        "access.token.claim" : "true",
+        "included.custom.audience" : "http://0.0.0.0:8080",
+        "userinfo.token.claim" : "false"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "lrs:statements/read", "lrs:admin", "lrs:all/read", "address", "phone", "offline_access", "lrs:statements/write", "microprofile-jwt", "lrs:all" ]
+  }, {
+    "id" : "c71245dc-e3ed-43b3-bfd9-49955d7d793a",
+    "clientId" : "lrs_client",
+    "name" : "LRS Client",
+    "description" : "An example LRS client suitable for the OAuth Client Credentials Grant",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "vGxvFpk9CLtfQwGCSJlb9SvUoDByuZjN",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : true,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "id.token.as.detached.signature" : "false",
+      "saml.assertion.signature" : "false",
+      "saml.force.post.binding" : "false",
+      "saml.multivalued.roles" : "false",
+      "saml.encrypt" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false",
+      "saml.server.signature" : "false",
+      "saml.server.signature.keyinfo.ext" : "false",
+      "use.refresh.tokens" : "true",
+      "exclude.session.state.from.auth.response" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "saml.artifact.binding" : "false",
+      "backchannel.logout.session.required" : "true",
+      "client_credentials.use_refresh_token" : "false",
+      "saml_force_name_id_format" : "false",
+      "require.pushed.authorization.requests" : "false",
+      "saml.client.signature" : "false",
+      "tls.client.certificate.bound.access.tokens" : "false",
+      "saml.authnstatement" : "false",
+      "display.on.consent.screen" : "false",
+      "saml.onetimeuse.condition" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "d2df95b0-4f7e-48ba-82a6-ebacb2b9dbc3",
+      "name" : "Client IP Address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientAddress",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientAddress",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c175448a-9739-45a1-b2d0-1c0f830ba903",
+      "name" : "Client Host",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientHost",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientHost",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "6b8382a5-6372-4863-9012-05ebbd8c3239",
+      "name" : "lrs_client_audience_mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "false",
+        "access.token.claim" : "true",
+        "included.custom.audience" : "http://0.0.0.0:8080",
+        "userinfo.token.claim" : "false"
+      }
+    }, {
+      "id" : "4a076dfe-db68-4792-b3bf-cc46e92605fb",
+      "name" : "Client ID",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientId",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientId",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "lrs:all", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "07000d1e-39d0-4864-a39d-70566b870361",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "fe5daf9c-81b7-4aa8-9d89-557dac44e9cd",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/test/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/test/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "c368d119-cdfa-42d3-ac6f-25027c669774",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "8b2321db-a3f5-4d8e-ae28-39f48125c07a",
+    "name" : "lrs:statements/read",
+    "description" : "xAPI Statements Read Only",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "xAPI Statements Read Only"
+    }
+  }, {
+    "id" : "6a4a4a4d-03aa-473f-aa0d-75b489977d5c",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "f8993932-62d2-48e0-a304-3f136ea8edfe",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "523c9af4-4711-43d7-85af-f3ac04ace666",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "1858bdad-5c52-4aa1-b0fc-5581af798a08",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b3db4dc4-231d-4674-a5b6-ea6d5e9016dc",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e0e5805c-c044-480f-a3a7-2981d794df86",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c5ced14b-2b38-419b-9896-85cf88a3711b",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "75c08d02-0833-4aa2-a098-98e4b4963cd7",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "1cdfb88e-1e04-4d78-a68a-3e289b089a33",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "236affeb-fffc-4848-b717-7c8f190d06fb",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "e59085e5-6bf4-4916-a8c9-44102337b968",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f3bbe050-5486-4e1c-8557-070e89096f7d",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c7181162-eabd-4e46-9c4b-c8c4ff14ce67",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c3dac1cf-d61a-4f3d-8bea-74f7eb65d565",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "bc51e879-fd49-4456-8dab-ad9495ce1da0",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "db720beb-9e39-4a19-9372-3fe356561c3b",
+    "name" : "lrs:admin",
+    "description" : "All admin permissions on LRS",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "Administer LRS"
+    }
+  }, {
+    "id" : "c6283805-484f-4d1c-9e85-1955c13c9c7f",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "71ef7385-cc4d-41a7-aa03-d67f0586f87e",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    }, {
+      "id" : "f4784c65-9cd1-4b38-be19-a8c36efa0c84",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "8c57c0a4-f8b9-4358-962b-49b0f3013eac",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    } ]
+  }, {
+    "id" : "817b903a-cb78-4caf-a338-affb280d364f",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "fa86e7f0-866d-412c-8191-9cc86c5a7d8b",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "8833ffce-a1a0-4558-a65e-ed5d107f1022",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "7141d9b9-5746-4559-9151-8411bdb3afb5",
+    "name" : "lrs:all",
+    "description" : "All xAPI Permissions",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "All xAPI"
+    }
+  }, {
+    "id" : "1066033a-7d3e-46ba-97a1-7fc2e84c65ab",
+    "name" : "lrs:statements/write",
+    "description" : "xAPI Statements Write Only",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "xAPI Statements Write Only"
+    }
+  }, {
+    "id" : "dca4ed1d-460c-4807-b0d9-568592e6d088",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "6374f381-4889-489e-aead-5fa18ef1b822",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "be667ccc-ba78-4afa-970e-13da6bc07427",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "6a7b16b0-1e49-43b8-ae44-e4e6fdc2b3fc",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "52f9ee66-42fa-4bd0-a5b3-26aa8f42e25a",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "1629c27c-75cc-4407-89e6-971c900bb127",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "2da9c5aa-679c-433a-b4dc-8ab76917b1da",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "6467a85b-e3a6-4181-ab4b-ca879ce2c123",
+    "name" : "lrs:all/read",
+    "description" : "Read-only xAPI Permissions",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "xAPI Read Only"
+    }
+  }, {
+    "id" : "84261ec9-96d3-4f8c-b343-619828a3ad4b",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "aceb7515-642e-4403-afab-3c93aebfb056",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "1e5dfa94-fed1-4fb4-a591-9951704e4a84",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "7c2908d3-28c4-42e6-bd96-c9e57cef7cf0",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "dc7578fc-d518-4312-99ea-bb4d93774562",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f6241122-16ec-4f71-b9e8-efd173318dea",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "profile", "email", "role_list", "roles", "web-origins" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "phone", "microprofile-jwt", "address" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "c0c16b10-415f-4d6e-88f6-c1050314e85d",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "06bdbf20-05ff-4e6d-bbf0-3daa86fb0757",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "86f63e93-ef16-41ff-8a7b-9a0f99344497",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "oidc-address-mapper", "saml-role-list-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper" ]
+      }
+    }, {
+      "id" : "cb89ebbf-ff1c-432c-a43e-63df05848a62",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "70c357f9-59c0-4758-b202-ba75ace53eda",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "9f3b5f54-efe8-4ebf-a6d7-1bcb3b3f192b",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "e640c7f7-0c39-4b47-91c3-d1687c353769",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "ebc3625c-9fe2-4739-8d75-b07866794e28",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "saml-user-property-mapper", "oidc-address-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "2586006e-6e8e-479f-b6e3-dd2af4bd253d",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEpAIBAAKCAQEAs49gQ2xcce8VslFoqBR3gj/oUmOc2g2J8SGlPaYAQ4pHWopfZqD6gBQ5hKmRKefuNBXn2bN2j2Zq7RMbPVYKH6F5U+RtJ1ja+tNOK8+uY5coqvwRrYR10BFtrYNq9MapWHXUFdzIJZ5IDT3/W/jS6qNPOL49Os/TO7tf8QpVV67d0zxblR8VSKagp1KmhjSvTx7lWJcRNYRIKFbIcZ0ZP4/2pzemTyDqJjkzgNrSW8K3cNLzohdjr1pR3UFVw+sGlG5NdDrVs0CporOJrArzqF8YkLMMpMCLpjYAiK7AEC7yN9cn7Og1NctqVN2lA+agqkcT+dpOE1wa2lr1oeTKAwIDAQABAoIBAGj34CaKKmDQi7Z6sNvRWyvhgEbpxMAUOheku5yWdoEFTUE4sxyj7s0BBb7wAdSlqTL5u1gg+aZLEScWjE4HBlQHaY4Jc2YVI66N6JzkA+Zkb3nFcfAmB1ljVuKgeN4vZMA54YoGT1rudOCI5cc2ZtaUMbPSQqkm5S1+FFAs4kcnD6t/m3dpHE0uG3cWutfzUHAkk0cZFtZFLlI+arB4Ml5fj/ZfDTC4cp8+LS4EeHK/+gmlBGOknEd8gtNLl4a9G2lOfvG8knjnWpIApkDhPpLqtn8x/KHYeu+dJ1u2V+Fn5ZNcILp66q3zbFevZVNNzsrQXx8f1huoO4dTnIytOIECgYEA4lh05yHfPohdoiW2DvowzV7Bg3V2e3Z5pXTB2kcfP65QITqYJpItmeLvfMUXbxbOUOP1ZaBJig7WbfngqFsOa9J77KBJw+c1N91FCtm7auovGsbo8sOAGRu7oQPS/DZO5aUBfGncfHAJpJ/yWWHlOk/S30fBU+QlVK168d1YK2sCgYEAyxXAnpR346U4ayW02Re1I7hPP0bYwQy9TseYlfimxzApIEa6vNbyHXtbl4ppl5uakBMZcDpM3JfZni7eLD6ndH5rWNyGSkNmPh+yb6E92Asnv+1VmGJd7FAM2VbLfY7ufS7qEBJWJrmwRuOB9DbpmRQqQ3PvdelOCGj3FOzX2ckCgYAh2Yq6GjWxu2ENY8hjWwU7YWVdTI7IjgJJPTnUc/h3ZJE1NvcUJZ5OOkMIjM0hXu7B6CWF6j+1NtzYm5r+coeollTUIXCGrKgnz56IreE6bwVWYtLpo1Uf7CbWQKUn9NM9wryDJ63Cqlq21PjAZ0SJwPBPVgLSkfcHP954F1sdOwKBgQCd9q18q78VMs5PiWTB987Nme8KKPEwN9iIDniBLoeLJ8rVcC6P9CEfDXSQyviXFFGE/1YqFS7z5qk+gPYPNCzMUAjvdZh+6y375GvGqISSJxskDlcl0F1+EkXsR7bAUwzuEi+9kIWyWXzjptLOQmgwyZ6WGPeJn48yu3J0tESxAQKBgQCHvUJOwdrXqN7mZzAWPUwbLr+evkJSQQyquR3HW/Yq8LYB1nFxzBVdNKvh5JMvpB1wOtjFdEQ0y6M+w+ZzMfsJEz0jap1z0m8R0DwrXCjtIT9YOtSkbp2cHxxMYodshqEKQErkFtNySit/BkYjpJrSNwk7AwfDNaCdcXcHmR962A==" ],
+        "keyUse" : [ "SIG" ],
+        "certificate" : [ "MIIClzCCAX8CBgF+ShW75DANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDAR0ZXN0MB4XDTIyMDExMTE2NTkwNVoXDTMyMDExMTE3MDA0NVowDzENMAsGA1UEAwwEdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALOPYENsXHHvFbJRaKgUd4I/6FJjnNoNifEhpT2mAEOKR1qKX2ag+oAUOYSpkSnn7jQV59mzdo9mau0TGz1WCh+heVPkbSdY2vrTTivPrmOXKKr8Ea2EddARba2DavTGqVh11BXcyCWeSA09/1v40uqjTzi+PTrP0zu7X/EKVVeu3dM8W5UfFUimoKdSpoY0r08e5ViXETWESChWyHGdGT+P9qc3pk8g6iY5M4Da0lvCt3DS86IXY69aUd1BVcPrBpRuTXQ61bNAqaKziawK86hfGJCzDKTAi6Y2AIiuwBAu8jfXJ+zoNTXLalTdpQPmoKpHE/naThNcGtpa9aHkygMCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAoj8kXR2fabdLtMGCj7BGy1xIJLUtNnmAIGnHaZ37cVadzHPxRXtOKJjBrAOrjQ7dvONelubZ3Uj9warCdsUV65t6NrG85KpJlW3qVtMuaIoY/sJ2bT9CYKemrOgTW3LgPmjO+YpZOR4uuo2LmVw0XL8KE6zlZwqRfwhjWy/QkRrgHsIXcbF4SnVDAQzpPlo3dTNS60pDtQtbYkIFI2ujdFpkA5u73DAPUCNakRvoutI8ZuHRqqPIIwKFzMXYZNG4GRfL51tRC14VSb+IIoknFwPpm2Y4ZCZkM7OfEDombHgU301NpMcc0ZZxw0zrI5ADEgLpxFitonbFf4MZyJXUbA==" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "3c9c0ea4-c541-428d-ac49-44d955b4fbcc",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEogIBAAKCAQEAh4/1V8qm/ZoenwUI15TispVHM24NvnhbPOlSg4Hj3FduSi9qJ/CbiOKaZ15cQ6n6J4Niiv5X6VgehrU00Ni/yzNfDVjiiz2esb4YEGHMoEzjtjh6B5sNaptYyYjOenHRdiEVsKX480DJDs81MrQS7dLaSkXP3nz8i1w6JK086vT6JLf5YX7w+aESFr4etzPluWokKtx9MvK36+oqoPqIzzzXOSDFQ1FaQmOMyYKxaVOL9TFJoCevR5BzDxz+p5OyjDvsDq6VhKavU5mggXgQNrpDuWvNJQ7aBnUY2iJ0+gOF4/KieHUWNgtDc5eyOuhWRqg6QsEM8jXiOa55tVm+7QIDAQABAoIBAEavLYJFTKVXQzgva9jc7QepBqMuc0QphYlRL5EanTE69WsBJh0FPFQ3s8LKVNmDO8h2nV9UF4q4Q9KBkbSEEB1n/9v5yMZJrwGG2Q1RsVy0Ote8wwRMOMapkbYj+2WlC07JGYIuSIyt7yglqttxQZ14IBIyLJ0aFqSjxj1xhx4LMlslOMzjgAqybqATj+3/dbhUxj82DoucVMkGvgJyax9VuJL7r0c7jvzn+/LRjP2oouECN9NjOusVM1CA4+l70IasR6dnuD93QMK/rBSTvls2knk9HPBX5bZZxa0cLK2en14Zv9T57zf7176Xuy7WC4eUSfVN7LiiO5RA5bK/QgECgYEA1pfZqp3ynhRp8VAO9qqSuOBdqxXYkKEnoQgNp9v/t8DM5DftOExyFPeAcFu1nSoKALM0J+MaV9ggsS8c1vVgc63jL96Yt9+/dhIXJuHFx0TlE/6TLYmrRgfOSvthiSsGxVutcGu0UfYcmhObNLike3Ulfb7Sww2z18Ic/NSEfs0CgYEAobhDLH8xfV7rPnvQB3bse2Pz4anqFIgfaTJYk9dYgjuHpy9v4qU5LqJ8UjJtVscceJObrQnkZADzaQNMkL1Ce7YBmzo/pB2M39J7cRyQ+H5d2VbSlX9dTL+jBzvIye73YXl9GQH7YPU0NwGY3qtmNUYUetFdLYaK0cCukfoeAKECgYBT/pPgSHqSjYL6RU/WFOXhH1EKij5+PdX5HeHadi4dioWoPovHoYR12HqZgAwSPEY2B+6+PhItmBcTw1ESgnECVmm6bvJv5lBWsrYFLhHv8XOI4/hPtrcnbh69ErAWtJSt4zh77GxkOGTxmgMCG9OlzzChi3OLjW17YiteewBxcQKBgFhO8Ud8ET8/tL/DBl79HrdmZkeE7FDX4Ccmmd3pSuiar0GpErS1ulrv2WldJf2r7q0dFXZRH4lIR6LBbW7gGkzJn2jvTs9EX6fdHREwIy2+e2ryET4XdZAyWUja6ZLzTdzJZXlhbq6MVz3uPlbhS4etxAMpDnOMs4NEb09BQF7hAoGAQ//vl9A328D5h5O5XyqylG1WPeXLcdwMQ3uP+erxS4kLrYlEv3Eo7BNpK6nRHQUndkrOGDMABc3TOOnYVE6486DWdrpy9MsQk3KoNM7KogswRQcDmXPLG3smOcfAtOraZGqlL8SX15N9CAedj0Nw4MeDI7biSZSt6jhaC5RlZlU=" ],
+        "keyUse" : [ "ENC" ],
+        "certificate" : [ "MIIClzCCAX8CBgF+ShW93DANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDAR0ZXN0MB4XDTIyMDExMTE2NTkwNVoXDTMyMDExMTE3MDA0NVowDzENMAsGA1UEAwwEdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIeP9VfKpv2aHp8FCNeU4rKVRzNuDb54WzzpUoOB49xXbkovaifwm4jimmdeXEOp+ieDYor+V+lYHoa1NNDYv8szXw1Y4os9nrG+GBBhzKBM47Y4egebDWqbWMmIznpx0XYhFbCl+PNAyQ7PNTK0Eu3S2kpFz958/ItcOiStPOr0+iS3+WF+8PmhEha+Hrcz5blqJCrcfTLyt+vqKqD6iM881zkgxUNRWkJjjMmCsWlTi/UxSaAnr0eQcw8c/qeTsow77A6ulYSmr1OZoIF4EDa6Q7lrzSUO2gZ1GNoidPoDhePyonh1FjYLQ3OXsjroVkaoOkLBDPI14jmuebVZvu0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEADSvRbqA28R+QU2ij01HcDNWmLvkxSMTFytHRs08n00Rd4ONYeXir1s2F4o0bSLCuYX1d7hOJiw2VVkQNqU2ZvfLZe9QBIetj+AaSsFEz3+3CqE22fHPrnM+1cI6SXpF/zK7Jx3sNdaKRuG3+WbTtjT1p45D/QwUd/YzjWf2YI824jAGamTupd1oyKX2klCnryS2sKrIqnH/1MDfgK93PLtSxNite/effRI2O6ySXX1wmila+nBo9hYcr5Y+yHCmPg+EtdVgGzvVDKrxFEQcLvbZD1HBDCymkWzix0hbsSKc4BDfBl8gOiAes4CATvhMyVJ4unsb/SMBkIDfclr/vdQ==" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    }, {
+      "id" : "ced222a6-758f-4bde-a993-c1f8882b99f3",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "13938f82-4b06-4dfa-a9ae-9f113d84d602" ],
+        "secret" : [ "cROFgwh4hrwUtON8MHhFY2Izr-A70s5FbHetwhnr0HdWNqrCtiPznHbNcvCpC8RhA1Nlm5i_DuxfkNHxbmDyEQ" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS256" ]
+      }
+    }, {
+      "id" : "1346c112-4ab3-4609-8282-c13fdb429b51",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "622051f7-e16a-45ea-ae3d-d0f3d7c6066f" ],
+        "secret" : [ "087wgqk1GaBeJqSwG0Va1A" ],
+        "priority" : [ "100" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "c629abb1-27aa-4069-9eff-88696a6bf2dd",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "fb210296-cf90-40b3-a634-4ebf59015309",
+    "alias" : "Authentication Options",
+    "description" : "Authentication options.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "basic-auth",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "basic-auth-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "880de9f9-56c8-42cf-ae24-6d742117965c",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "7a7cf4ce-3efe-4532-a83c-68cf048d06ab",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "4e0b1784-7ec6-45c0-b31a-e67b37eb2ed3",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "93a17980-f94c-4ab1-ba70-9748be1efc5a",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "f57018a5-7750-4e48-8ad4-0f56bf6e9556",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "fdfd97d7-21e1-477a-a62c-1c13eb1981e1",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "e8dd210d-45cb-4184-9190-b0670fd194c1",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "2b7d37a1-e858-4b0a-b472-0e117e9dd867",
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "c48f10da-e463-401c-918b-23e8b0e50d38",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "3d911f1c-3035-4b93-b956-202c219f5b9e",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "7158f40c-97cd-4652-b36a-399db39eb4fc",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "2a2d8fa1-6591-4b6d-9bec-1e2c57b5ebc2",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "2a294bda-bb2a-46ab-8534-0f1f28e67b97",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "ea82fdd2-d742-4eb3-94b3-b871b8d70476",
+    "alias" : "http challenge",
+    "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "no-cookie-redirect",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "flowAlias" : "Authentication Options",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "de10e1c0-bca0-432e-ad60-87d9e6192dc2",
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "f84ec39b-22d5-40d9-94c7-7e98bff41fdd",
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-profile-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 40,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "c1226766-e5a4-4b0d-bb9d-6182bb7b6826",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "4bab12b2-3513-4e4d-a22e-b9dc12ff428b",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "7c882b45-0091-46de-89f9-2f1f8b5375eb",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "43cf4a3b-64a4-48a0-92ad-96b45c78f24c",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "terms_and_conditions",
+    "name" : "Terms and Conditions",
+    "providerId" : "terms_and_conditions",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaExpiresIn" : "120",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "oauth2DeviceCodeLifespan" : "600",
+    "clientOfflineSessionMaxLifespan" : "0",
+    "oauth2DevicePollingInterval" : "5",
+    "clientSessionIdleTimeout" : "0",
+    "parRequestUriLifespan" : "60",
+    "clientSessionMaxLifespan" : "0",
+    "clientOfflineSessionIdleTimeout" : "0",
+    "cibaInterval" : "5"
+  },
+  "keycloakVersion" : "16.1.0",
+  "userManagedAccessAllowed" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
 }

--- a/dev-resources/keycloak_demo/test-realm.json
+++ b/dev-resources/keycloak_demo/test-realm.json
@@ -1,0 +1,1966 @@
+{
+    "id" : "test",
+    "realm" : "test",
+    "notBefore" : 1642523586,
+    "defaultSignatureAlgorithm" : "RS256",
+    "revokeRefreshToken" : false,
+    "refreshTokenMaxReuse" : 0,
+    "accessTokenLifespan" : 300,
+    "accessTokenLifespanForImplicitFlow" : 900,
+    "ssoSessionIdleTimeout" : 1800,
+    "ssoSessionMaxLifespan" : 36000,
+    "ssoSessionIdleTimeoutRememberMe" : 0,
+    "ssoSessionMaxLifespanRememberMe" : 0,
+    "offlineSessionIdleTimeout" : 2592000,
+    "offlineSessionMaxLifespanEnabled" : false,
+    "offlineSessionMaxLifespan" : 5184000,
+    "clientSessionIdleTimeout" : 0,
+    "clientSessionMaxLifespan" : 0,
+    "clientOfflineSessionIdleTimeout" : 0,
+    "clientOfflineSessionMaxLifespan" : 0,
+    "accessCodeLifespan" : 60,
+    "accessCodeLifespanUserAction" : 300,
+    "accessCodeLifespanLogin" : 1800,
+    "actionTokenGeneratedByAdminLifespan" : 43200,
+    "actionTokenGeneratedByUserLifespan" : 300,
+    "oauth2DeviceCodeLifespan" : 600,
+    "oauth2DevicePollingInterval" : 5,
+    "enabled" : true,
+    "sslRequired" : "external",
+    "registrationAllowed" : false,
+    "registrationEmailAsUsername" : false,
+    "rememberMe" : false,
+    "verifyEmail" : false,
+    "loginWithEmailAllowed" : true,
+    "duplicateEmailsAllowed" : false,
+    "resetPasswordAllowed" : false,
+    "editUsernameAllowed" : false,
+    "bruteForceProtected" : false,
+    "permanentLockout" : false,
+    "maxFailureWaitSeconds" : 900,
+    "minimumQuickLoginWaitSeconds" : 60,
+    "waitIncrementSeconds" : 60,
+    "quickLoginCheckMilliSeconds" : 1000,
+    "maxDeltaTimeSeconds" : 43200,
+    "failureFactor" : 30,
+    "roles" : {
+        "realm" : [ {
+            "id" : "c5f4c2f3-0d0a-41cd-be51-58eeb1b38514",
+            "name" : "uma_authorization",
+            "description" : "${role_uma_authorization}",
+            "composite" : false,
+            "clientRole" : false,
+            "containerId" : "test",
+            "attributes" : { }
+        }, {
+            "id" : "07cf52bc-5dce-4b29-8a6c-03d4f49d95b4",
+            "name" : "offline_access",
+            "description" : "${role_offline-access}",
+            "composite" : false,
+            "clientRole" : false,
+            "containerId" : "test",
+            "attributes" : { }
+        }, {
+            "id" : "d84a5ad7-ef32-4c7f-bfed-63256266c721",
+            "name" : "default-roles-test",
+            "description" : "${role_default-roles}",
+            "composite" : true,
+            "composites" : {
+                "realm" : [ "offline_access", "uma_authorization" ],
+                "client" : {
+                    "account" : [ "view-profile", "manage-account" ]
+                }
+            },
+            "clientRole" : false,
+            "containerId" : "test",
+            "attributes" : { }
+        } ],
+        "client" : {
+            "realm-management" : [ {
+                "id" : "90f9feb7-3f87-4afe-ac9c-d68601f2735c",
+                "name" : "query-groups",
+                "description" : "${role_query-groups}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "803566ff-911d-4a3c-abd5-e492f11bf019",
+                "name" : "view-events",
+                "description" : "${role_view-events}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "81629562-dd95-4e74-8e2a-91e99afdd739",
+                "name" : "view-authorization",
+                "description" : "${role_view-authorization}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "f13b65bc-3591-434d-a74f-ddc5fee3b23b",
+                "name" : "query-realms",
+                "description" : "${role_query-realms}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "224b0eb1-81c2-42ff-bd70-74c4da9d3f02",
+                "name" : "create-client",
+                "description" : "${role_create-client}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "635e39b4-0c9c-4421-8767-240d0f11bb16",
+                "name" : "manage-users",
+                "description" : "${role_manage-users}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "aaa49cca-cce6-4ad4-8eda-c8239c773502",
+                "name" : "view-users",
+                "description" : "${role_view-users}",
+                "composite" : true,
+                "composites" : {
+                    "client" : {
+                        "realm-management" : [ "query-users", "query-groups" ]
+                    }
+                },
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "826a472d-6694-4778-b581-36f51e9dddc8",
+                "name" : "view-identity-providers",
+                "description" : "${role_view-identity-providers}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "7922f15b-8b87-4742-b764-39f4ed816a74",
+                "name" : "manage-authorization",
+                "description" : "${role_manage-authorization}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "86c58c5c-6b3f-4b63-bb6b-6baf6af177e1",
+                "name" : "manage-clients",
+                "description" : "${role_manage-clients}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "806ea0bf-d63c-4e21-a63d-735910488fa5",
+                "name" : "impersonation",
+                "description" : "${role_impersonation}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "b9c2dc0d-d35e-4a04-91f0-5170fbef7b87",
+                "name" : "view-realm",
+                "description" : "${role_view-realm}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "60a907de-14b4-4004-9a7e-4300a9afb2c0",
+                "name" : "query-users",
+                "description" : "${role_query-users}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "d23cdc0a-795e-42c6-b6a8-07a7dfa0f151",
+                "name" : "manage-events",
+                "description" : "${role_manage-events}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "6b6b4b28-b594-4379-b0dc-2cde8fddeca0",
+                "name" : "realm-admin",
+                "description" : "${role_realm-admin}",
+                "composite" : true,
+                "composites" : {
+                    "client" : {
+                        "realm-management" : [ "query-groups", "view-events", "view-authorization", "query-realms", "create-client", "manage-users", "view-users", "view-identity-providers", "manage-authorization", "manage-clients", "impersonation", "view-realm", "query-users", "manage-events", "manage-identity-providers", "query-clients", "manage-realm", "view-clients" ]
+                    }
+                },
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "a2220563-986a-4ef8-ae38-0546f11a1e9c",
+                "name" : "manage-identity-providers",
+                "description" : "${role_manage-identity-providers}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "8afdbb17-4b6e-4b2f-8609-77a3c5a0179c",
+                "name" : "query-clients",
+                "description" : "${role_query-clients}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "b184e0ae-a474-4651-97e8-d28435700a73",
+                "name" : "manage-realm",
+                "description" : "${role_manage-realm}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            }, {
+                "id" : "9d6e1fc4-1949-4cf6-bb77-06633ad90077",
+                "name" : "view-clients",
+                "description" : "${role_view-clients}",
+                "composite" : true,
+                "composites" : {
+                    "client" : {
+                        "realm-management" : [ "query-clients" ]
+                    }
+                },
+                "clientRole" : true,
+                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+                "attributes" : { }
+            } ],
+            "security-admin-console" : [ ],
+            "admin-cli" : [ ],
+            "account-console" : [ ],
+            "broker" : [ {
+                "id" : "4ec62d80-1cd7-4502-8029-e93d920b69ae",
+                "name" : "read-token",
+                "description" : "${role_read-token}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "9cdbf3ec-85f6-4366-956b-d1556302eac1",
+                "attributes" : { }
+            } ],
+            "lrs" : [ ],
+            "account" : [ {
+                "id" : "e34fd9d6-b441-4415-a77d-857f456dd024",
+                "name" : "manage-consent",
+                "description" : "${role_manage-consent}",
+                "composite" : true,
+                "composites" : {
+                    "client" : {
+                        "account" : [ "view-consent" ]
+                    }
+                },
+                "clientRole" : true,
+                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+                "attributes" : { }
+            }, {
+                "id" : "8f99b9d9-abb3-42e3-828e-504068c5666c",
+                "name" : "manage-account-links",
+                "description" : "${role_manage-account-links}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+                "attributes" : { }
+            }, {
+                "id" : "e199034f-3da1-48d0-82ed-9cde5920528f",
+                "name" : "delete-account",
+                "description" : "${role_delete-account}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+                "attributes" : { }
+            }, {
+                "id" : "be80bb48-9ca7-4517-9f70-98acea96b8d6",
+                "name" : "view-consent",
+                "description" : "${role_view-consent}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+                "attributes" : { }
+            }, {
+                "id" : "5b050df5-1366-46fe-ab90-cd43a659724c",
+                "name" : "view-profile",
+                "description" : "${role_view-profile}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+                "attributes" : { }
+            }, {
+                "id" : "689b7ad1-019f-4449-b0f9-4caf6fac4ac8",
+                "name" : "manage-account",
+                "description" : "${role_manage-account}",
+                "composite" : true,
+                "composites" : {
+                    "client" : {
+                        "account" : [ "manage-account-links" ]
+                    }
+                },
+                "clientRole" : true,
+                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+                "attributes" : { }
+            }, {
+                "id" : "a1ab542d-c481-4dc2-9455-cbb78c8325e5",
+                "name" : "view-applications",
+                "description" : "${role_view-applications}",
+                "composite" : false,
+                "clientRole" : true,
+                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+                "attributes" : { }
+            } ],
+            "lrs_admin_ui" : [ ]
+        }
+    },
+    "groups" : [ {
+        "id" : "617dd33a-0ec4-4ad3-b496-d792020e839c",
+        "name" : "developers",
+        "path" : "/developers",
+        "attributes" : { },
+        "realmRoles" : [ ],
+        "clientRoles" : { },
+        "subGroups" : [ ]
+    } ],
+    "defaultRole" : {
+        "id" : "d84a5ad7-ef32-4c7f-bfed-63256266c721",
+        "name" : "default-roles-test",
+        "description" : "${role_default-roles}",
+        "composite" : true,
+        "clientRole" : false,
+        "containerId" : "test"
+    },
+    "requiredCredentials" : [ "password" ],
+    "otpPolicyType" : "totp",
+    "otpPolicyAlgorithm" : "HmacSHA1",
+    "otpPolicyInitialCounter" : 0,
+    "otpPolicyDigits" : 6,
+    "otpPolicyLookAheadWindow" : 1,
+    "otpPolicyPeriod" : 30,
+    "otpSupportedApplications" : [ "FreeOTP", "Google Authenticator" ],
+    "webAuthnPolicyRpEntityName" : "keycloak",
+    "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
+    "webAuthnPolicyRpId" : "",
+    "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+    "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+    "webAuthnPolicyRequireResidentKey" : "not specified",
+    "webAuthnPolicyUserVerificationRequirement" : "not specified",
+    "webAuthnPolicyCreateTimeout" : 0,
+    "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+    "webAuthnPolicyAcceptableAaguids" : [ ],
+    "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+    "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
+    "webAuthnPolicyPasswordlessRpId" : "",
+    "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+    "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+    "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+    "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+    "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+    "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+    "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+    "users" : [ {
+        "id" : "9c9708f0-c84a-49db-805a-1231b007a306",
+        "createdTimestamp" : 1643146437013,
+        "username" : "dev_user",
+        "enabled" : true,
+        "totp" : false,
+        "emailVerified" : true,
+        "firstName" : "Development",
+        "lastName" : "User",
+        "email" : "dev_user@example.com",
+        "attributes" : {
+            "foo" : [ "bar" ]
+        },
+        "credentials" : [ {
+            "id" : "9477829d-6f0b-4a2d-b1bd-40769cd79121",
+            "type" : "password",
+            "createdDate" : 1643146523059,
+            "secretData" : "{\"value\":\"kiGu0mANJBvsuKpf9AJGPfXXN7JLuH/nXmK3+1fd7pXXTtRc8ZIaQKFXt09szSJAfosrMWbNDtMAc6Of/BeLqA==\",\"salt\":\"xRmuQt7YJKfeCxlAvf/v9A==\",\"additionalParameters\":{}}",
+            "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+        } ],
+        "disableableCredentialTypes" : [ ],
+        "requiredActions" : [ ],
+        "realmRoles" : [ "default-roles-test" ],
+        "notBefore" : 0,
+        "groups" : [ "/developers" ]
+    } ],
+    "scopeMappings" : [ {
+        "clientScope" : "offline_access",
+        "roles" : [ "offline_access" ]
+    } ],
+    "clientScopeMappings" : {
+        "account" : [ {
+            "client" : "account-console",
+            "roles" : [ "manage-account" ]
+        } ]
+    },
+    "clients" : [ {
+        "id" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "clientId" : "account",
+        "name" : "${client_account}",
+        "rootUrl" : "${authBaseUrl}",
+        "baseUrl" : "/realms/test/account/",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ "/realms/test/account/*" ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : true,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : { },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+    }, {
+        "id" : "c8f48dc1-c2fd-45d1-bcfb-1cc345cb269a",
+        "clientId" : "account-console",
+        "name" : "${client_account-console}",
+        "rootUrl" : "${authBaseUrl}",
+        "baseUrl" : "/realms/test/account/",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ "/realms/test/account/*" ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : true,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "pkce.code.challenge.method" : "S256"
+        },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "protocolMappers" : [ {
+            "id" : "8ad7c1f2-57d0-4989-bda9-8768dbc222b6",
+            "name" : "audience resolve",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-audience-resolve-mapper",
+            "consentRequired" : false,
+            "config" : { }
+        } ],
+        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+    }, {
+        "id" : "554b71bc-8f36-49f1-b39f-86fa65ebbe8f",
+        "clientId" : "admin-cli",
+        "name" : "${client_admin-cli}",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : false,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : true,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : true,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : { },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+    }, {
+        "id" : "9cdbf3ec-85f6-4366-956b-d1556302eac1",
+        "clientId" : "broker",
+        "name" : "${client_broker}",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : true,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : false,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : { },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+    }, {
+        "id" : "93f48f9d-bd78-44f2-97f7-7f3b65aaa8da",
+        "clientId" : "lrs",
+        "name" : "SQL LRS",
+        "rootUrl" : "http://0.0.0.0:8080/",
+        "adminUrl" : "http://0.0.0.0:8080/",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ "http://0.0.0.0:8080/*" ],
+        "webOrigins" : [ "http://0.0.0.0:8080" ],
+        "notBefore" : 0,
+        "bearerOnly" : true,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : true,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : false,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "id.token.as.detached.signature" : "false",
+            "saml.assertion.signature" : "false",
+            "saml.force.post.binding" : "false",
+            "saml.multivalued.roles" : "false",
+            "saml.encrypt" : "false",
+            "oauth2.device.authorization.grant.enabled" : "false",
+            "backchannel.logout.revoke.offline.tokens" : "false",
+            "saml.server.signature" : "false",
+            "saml.server.signature.keyinfo.ext" : "false",
+            "use.refresh.tokens" : "true",
+            "exclude.session.state.from.auth.response" : "false",
+            "oidc.ciba.grant.enabled" : "false",
+            "saml.artifact.binding" : "false",
+            "backchannel.logout.session.required" : "true",
+            "client_credentials.use_refresh_token" : "false",
+            "saml_force_name_id_format" : "false",
+            "require.pushed.authorization.requests" : "false",
+            "saml.client.signature" : "false",
+            "tls.client.certificate.bound.access.tokens" : "false",
+            "saml.authnstatement" : "false",
+            "display.on.consent.screen" : "false",
+            "saml.onetimeuse.condition" : "false"
+        },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : true,
+        "nodeReRegistrationTimeout" : -1,
+        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+    }, {
+        "clientId": "lrs_admin_ui",
+        "name": "LRS Admin UI/Figwheel Server",
+        "rootUrl": "http://localhost:9500/",
+        "adminUrl": "http://localhost:9500/",
+        "surrogateAuthRequired": false,
+        "enabled": true,
+        "alwaysDisplayInConsole": false,
+        "clientAuthenticatorType": "client-secret",
+        "redirectUris": [
+            "http://localhost:9500/",
+            "http://0.0.0.0:8080/admin/index.html",
+            "http://localhost:9500/*"
+        ],
+        "webOrigins": [
+            "http://localhost:9500",
+            "http://0.0.0.0:8080"
+        ],
+        "notBefore": 0,
+        "bearerOnly": false,
+        "consentRequired": false,
+        "standardFlowEnabled": true,
+        "implicitFlowEnabled": false,
+        "directAccessGrantsEnabled": true,
+        "serviceAccountsEnabled": false,
+        "publicClient": true,
+        "frontchannelLogout": false,
+        "protocol": "openid-connect",
+        "attributes": {
+            "saml.force.post.binding": "false",
+            "saml.multivalued.roles": "false",
+            "oauth2.device.authorization.grant.enabled": "false",
+            "use.jwks.url": "false",
+            "backchannel.logout.revoke.offline.tokens": "false",
+            "saml.server.signature.keyinfo.ext": "false",
+            "use.refresh.tokens": "true",
+            "jwt.credential.certificate": "MIICqzCCAZMCBgF+VSRiwDANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDDA50ZXN0YXBwX3B1YmxpYzAeFw0yMjAxMTMyMDMwNTVaFw0zMjAxMTMyMDMyMzVaMBkxFzAVBgNVBAMMDnRlc3RhcHBfcHVibGljMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAl18eQYywttSxpioT0plMAj0BENJQhHu/7LmkF7a4GwG3OyZNpiky3V1W4oFgfmTcTisXYBB1eRIw+bC8Iy808DX7PbHr4N/qn1pjgkohl9pPo3UnKAa2hEUsKtQDfn5Oltx/qliSvT0zFzHmPXH2CHKCqyjy9NFFG+rPNXXrmY/xM8HToqjchwvA4DHOnbcUgRzGSQl2vmO0GJvRqcFQjoQXaPEvQck8geVB2bjx0Lkt6m5zWkMZsVH8aBeBTuuZqpCGO5LecyMOHz0iEx8T0lMJorE5uR6ul8jnZzFdv9blLEiroy8Btes8WCImopKO1MCqdIbrSB54v+lQ+Jg7HwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAy9xUwUDTQjRiiHCljmJpjQEqTuXHzFaBr9oj3pQ698eM0vjaoBh0DAqUfNiPHTwqvyuOOLYoO2HJzcjnGYn0hHgTWWUGAzj0id+Nq1+nfdq9yqW2PGsEza7/LZja80RclRs3E6ZjFxPBUndyTV2ppvtL5/KFN/OYC7iXvSJd++dOIPRtk4hyOtu08HvQ0uFwh+H3bcb0ZKnTqsVhkBs9AmHF61K4IKDPJc8FahVeSVQDH46uqLjhSBx4lmjGFF7hax3RxvLB4zO88YZECo8+ce4B9kMxsYqsVL2xuJFf8kucfJRwA6LIkARsICiDI9pIda9QbHibaxyFaARQ6kdIT",
+            "oidc.ciba.grant.enabled": "false",
+            "use.jwks.string": "false",
+            "backchannel.logout.session.required": "true",
+            "client_credentials.use_refresh_token": "false",
+            "require.pushed.authorization.requests": "false",
+            "saml.client.signature": "false",
+            "id.token.as.detached.signature": "false",
+            "saml.assertion.signature": "false",
+            "saml.encrypt": "false",
+            "saml.server.signature": "false",
+            "exclude.session.state.from.auth.response": "false",
+            "saml.artifact.binding": "false",
+            "saml_force_name_id_format": "false",
+            "tls.client.certificate.bound.access.tokens": "false",
+            "saml.authnstatement": "false",
+            "display.on.consent.screen": "false",
+            "saml.onetimeuse.condition": "false"
+        },
+        "authenticationFlowBindingOverrides": {},
+        "fullScopeAllowed": true,
+        "nodeReRegistrationTimeout": -1,
+        "protocolMappers": [
+            {
+                "name": "LRS Audience Mapper",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-audience-mapper",
+                "consentRequired": false,
+                "config": {
+                    "id.token.claim": "false",
+                    "access.token.claim": "true",
+                    "included.custom.audience": "http://0.0.0.0:8080",
+                    "userinfo.token.claim": "false"
+                }
+            }
+        ],
+        "defaultClientScopes": [
+            "web-origins",
+            "profile",
+            "roles",
+            "email"
+        ],
+        "optionalClientScopes": [
+            "lrs:statements/read",
+            "lrs:admin",
+            "lrs:all/read",
+            "address",
+            "phone",
+            "offline_access",
+            "lrs:statements/write",
+            "microprofile-jwt",
+            "lrs:all"
+        ],
+        "access": {
+            "view": true,
+            "configure": true,
+            "manage": true
+        }
+    }, {
+        "id" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "clientId" : "realm-management",
+        "name" : "${client_realm-management}",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : true,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : false,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : { },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+    }, {
+        "id" : "fe5daf9c-81b7-4aa8-9d89-557dac44e9cd",
+        "clientId" : "security-admin-console",
+        "name" : "${client_security-admin-console}",
+        "rootUrl" : "${authAdminUrl}",
+        "baseUrl" : "/admin/test/console/",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ "/admin/test/console/*" ],
+        "webOrigins" : [ "+" ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : true,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "pkce.code.challenge.method" : "S256"
+        },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "protocolMappers" : [ {
+            "id" : "c368d119-cdfa-42d3-ac6f-25027c669774",
+            "name" : "locale",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-attribute-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "locale",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "locale",
+                "jsonType.label" : "String"
+            }
+        } ],
+        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+    } ],
+    "clientScopes" : [ {
+        "id" : "8b2321db-a3f5-4d8e-ae28-39f48125c07a",
+        "name" : "lrs:statements/read",
+        "description" : "xAPI Statements Read Only",
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "include.in.token.scope" : "true",
+            "display.on.consent.screen" : "true",
+            "consent.screen.text" : "xAPI Statements Read Only"
+        }
+    }, {
+        "id" : "6a4a4a4d-03aa-473f-aa0d-75b489977d5c",
+        "name" : "profile",
+        "description" : "OpenID Connect built-in scope: profile",
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "include.in.token.scope" : "true",
+            "display.on.consent.screen" : "true",
+            "consent.screen.text" : "${profileScopeConsentText}"
+        },
+        "protocolMappers" : [ {
+            "id" : "f8993932-62d2-48e0-a304-3f136ea8edfe",
+            "name" : "given name",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-property-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "firstName",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "given_name",
+                "jsonType.label" : "String"
+            }
+        }, {
+            "id" : "523c9af4-4711-43d7-85af-f3ac04ace666",
+            "name" : "updated at",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-attribute-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "updatedAt",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "updated_at",
+                "jsonType.label" : "String"
+            }
+        }, {
+            "id" : "1858bdad-5c52-4aa1-b0fc-5581af798a08",
+            "name" : "nickname",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-attribute-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "nickname",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "nickname",
+                "jsonType.label" : "String"
+            }
+        }, {
+            "id" : "b3db4dc4-231d-4674-a5b6-ea6d5e9016dc",
+            "name" : "username",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-property-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "username",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "preferred_username",
+                "jsonType.label" : "String"
+            }
+        }, {
+            "id" : "e0e5805c-c044-480f-a3a7-2981d794df86",
+            "name" : "birthdate",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-attribute-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "birthdate",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "birthdate",
+                "jsonType.label" : "String"
+            }
+        }, {
+            "id" : "c5ced14b-2b38-419b-9896-85cf88a3711b",
+            "name" : "family name",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-property-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "lastName",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "family_name",
+                "jsonType.label" : "String"
+            }
+        }, {
+            "id" : "75c08d02-0833-4aa2-a098-98e4b4963cd7",
+            "name" : "middle name",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-attribute-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "middleName",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "middle_name",
+                "jsonType.label" : "String"
+            }
+        }, {
+            "id" : "1cdfb88e-1e04-4d78-a68a-3e289b089a33",
+            "name" : "locale",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-attribute-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "locale",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "locale",
+                "jsonType.label" : "String"
+            }
+        }, {
+            "id" : "236affeb-fffc-4848-b717-7c8f190d06fb",
+            "name" : "full name",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-full-name-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "userinfo.token.claim" : "true"
+            }
+        }, {
+            "id" : "e59085e5-6bf4-4916-a8c9-44102337b968",
+            "name" : "profile",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-attribute-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "profile",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "profile",
+                "jsonType.label" : "String"
+            }
+        }, {
+            "id" : "f3bbe050-5486-4e1c-8557-070e89096f7d",
+            "name" : "picture",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-attribute-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "picture",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "picture",
+                "jsonType.label" : "String"
+            }
+        }, {
+            "id" : "c7181162-eabd-4e46-9c4b-c8c4ff14ce67",
+            "name" : "gender",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-attribute-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "gender",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "gender",
+                "jsonType.label" : "String"
+            }
+        }, {
+            "id" : "c3dac1cf-d61a-4f3d-8bea-74f7eb65d565",
+            "name" : "website",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-attribute-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "website",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "website",
+                "jsonType.label" : "String"
+            }
+        }, {
+            "id" : "bc51e879-fd49-4456-8dab-ad9495ce1da0",
+            "name" : "zoneinfo",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-attribute-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "zoneinfo",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "zoneinfo",
+                "jsonType.label" : "String"
+            }
+        } ]
+    }, {
+        "id" : "db720beb-9e39-4a19-9372-3fe356561c3b",
+        "name" : "lrs:admin",
+        "description" : "All admin permissions on LRS",
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "include.in.token.scope" : "true",
+            "display.on.consent.screen" : "true",
+            "consent.screen.text" : "Administer LRS"
+        }
+    }, {
+        "id" : "c6283805-484f-4d1c-9e85-1955c13c9c7f",
+        "name" : "roles",
+        "description" : "OpenID Connect scope for add user roles to the access token",
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "include.in.token.scope" : "false",
+            "display.on.consent.screen" : "true",
+            "consent.screen.text" : "${rolesScopeConsentText}"
+        },
+        "protocolMappers" : [ {
+            "id" : "71ef7385-cc4d-41a7-aa03-d67f0586f87e",
+            "name" : "audience resolve",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-audience-resolve-mapper",
+            "consentRequired" : false,
+            "config" : { }
+        }, {
+            "id" : "f4784c65-9cd1-4b38-be19-a8c36efa0c84",
+            "name" : "client roles",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-client-role-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "user.attribute" : "foo",
+                "access.token.claim" : "true",
+                "claim.name" : "resource_access.${client_id}.roles",
+                "jsonType.label" : "String",
+                "multivalued" : "true"
+            }
+        }, {
+            "id" : "8c57c0a4-f8b9-4358-962b-49b0f3013eac",
+            "name" : "realm roles",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "user.attribute" : "foo",
+                "access.token.claim" : "true",
+                "claim.name" : "realm_access.roles",
+                "jsonType.label" : "String",
+                "multivalued" : "true"
+            }
+        } ]
+    }, {
+        "id" : "817b903a-cb78-4caf-a338-affb280d364f",
+        "name" : "email",
+        "description" : "OpenID Connect built-in scope: email",
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "include.in.token.scope" : "true",
+            "display.on.consent.screen" : "true",
+            "consent.screen.text" : "${emailScopeConsentText}"
+        },
+        "protocolMappers" : [ {
+            "id" : "fa86e7f0-866d-412c-8191-9cc86c5a7d8b",
+            "name" : "email verified",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-property-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "emailVerified",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "email_verified",
+                "jsonType.label" : "boolean"
+            }
+        }, {
+            "id" : "8833ffce-a1a0-4558-a65e-ed5d107f1022",
+            "name" : "email",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-property-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "email",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "email",
+                "jsonType.label" : "String"
+            }
+        } ]
+    }, {
+        "id" : "7141d9b9-5746-4559-9151-8411bdb3afb5",
+        "name" : "lrs:all",
+        "description" : "All xAPI Permissions",
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "include.in.token.scope" : "true",
+            "display.on.consent.screen" : "true",
+            "consent.screen.text" : "All xAPI"
+        }
+    }, {
+        "id" : "1066033a-7d3e-46ba-97a1-7fc2e84c65ab",
+        "name" : "lrs:statements/write",
+        "description" : "xAPI Statements Write Only",
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "include.in.token.scope" : "true",
+            "display.on.consent.screen" : "true",
+            "consent.screen.text" : "xAPI Statements Write Only"
+        }
+    }, {
+        "id" : "dca4ed1d-460c-4807-b0d9-568592e6d088",
+        "name" : "web-origins",
+        "description" : "OpenID Connect scope for add allowed web origins to the access token",
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "include.in.token.scope" : "false",
+            "display.on.consent.screen" : "false",
+            "consent.screen.text" : ""
+        },
+        "protocolMappers" : [ {
+            "id" : "6374f381-4889-489e-aead-5fa18ef1b822",
+            "name" : "allowed web origins",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-allowed-origins-mapper",
+            "consentRequired" : false,
+            "config" : { }
+        } ]
+    }, {
+        "id" : "be667ccc-ba78-4afa-970e-13da6bc07427",
+        "name" : "role_list",
+        "description" : "SAML role list",
+        "protocol" : "saml",
+        "attributes" : {
+            "consent.screen.text" : "${samlRoleListScopeConsentText}",
+            "display.on.consent.screen" : "true"
+        },
+        "protocolMappers" : [ {
+            "id" : "6a7b16b0-1e49-43b8-ae44-e4e6fdc2b3fc",
+            "name" : "role list",
+            "protocol" : "saml",
+            "protocolMapper" : "saml-role-list-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "single" : "false",
+                "attribute.nameformat" : "Basic",
+                "attribute.name" : "Role"
+            }
+        } ]
+    }, {
+        "id" : "52f9ee66-42fa-4bd0-a5b3-26aa8f42e25a",
+        "name" : "phone",
+        "description" : "OpenID Connect built-in scope: phone",
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "include.in.token.scope" : "true",
+            "display.on.consent.screen" : "true",
+            "consent.screen.text" : "${phoneScopeConsentText}"
+        },
+        "protocolMappers" : [ {
+            "id" : "1629c27c-75cc-4407-89e6-971c900bb127",
+            "name" : "phone number verified",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-attribute-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "phoneNumberVerified",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "phone_number_verified",
+                "jsonType.label" : "boolean"
+            }
+        }, {
+            "id" : "2da9c5aa-679c-433a-b4dc-8ab76917b1da",
+            "name" : "phone number",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-attribute-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "phoneNumber",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "phone_number",
+                "jsonType.label" : "String"
+            }
+        } ]
+    }, {
+        "id" : "6467a85b-e3a6-4181-ab4b-ca879ce2c123",
+        "name" : "lrs:all/read",
+        "description" : "Read-only xAPI Permissions",
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "include.in.token.scope" : "true",
+            "display.on.consent.screen" : "true",
+            "consent.screen.text" : "xAPI Read Only"
+        }
+    }, {
+        "id" : "84261ec9-96d3-4f8c-b343-619828a3ad4b",
+        "name" : "address",
+        "description" : "OpenID Connect built-in scope: address",
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "include.in.token.scope" : "true",
+            "display.on.consent.screen" : "true",
+            "consent.screen.text" : "${addressScopeConsentText}"
+        },
+        "protocolMappers" : [ {
+            "id" : "aceb7515-642e-4403-afab-3c93aebfb056",
+            "name" : "address",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-address-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "user.attribute.formatted" : "formatted",
+                "user.attribute.country" : "country",
+                "user.attribute.postal_code" : "postal_code",
+                "userinfo.token.claim" : "true",
+                "user.attribute.street" : "street",
+                "id.token.claim" : "true",
+                "user.attribute.region" : "region",
+                "access.token.claim" : "true",
+                "user.attribute.locality" : "locality"
+            }
+        } ]
+    }, {
+        "id" : "1e5dfa94-fed1-4fb4-a591-9951704e4a84",
+        "name" : "offline_access",
+        "description" : "OpenID Connect built-in scope: offline_access",
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "consent.screen.text" : "${offlineAccessScopeConsentText}",
+            "display.on.consent.screen" : "true"
+        }
+    }, {
+        "id" : "7c2908d3-28c4-42e6-bd96-c9e57cef7cf0",
+        "name" : "microprofile-jwt",
+        "description" : "Microprofile - JWT built-in scope",
+        "protocol" : "openid-connect",
+        "attributes" : {
+            "include.in.token.scope" : "true",
+            "display.on.consent.screen" : "false"
+        },
+        "protocolMappers" : [ {
+            "id" : "dc7578fc-d518-4312-99ea-bb4d93774562",
+            "name" : "upn",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-property-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "username",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "upn",
+                "jsonType.label" : "String"
+            }
+        }, {
+            "id" : "f6241122-16ec-4f71-b9e8-efd173318dea",
+            "name" : "groups",
+            "protocol" : "openid-connect",
+            "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+            "consentRequired" : false,
+            "config" : {
+                "multivalued" : "true",
+                "userinfo.token.claim" : "true",
+                "user.attribute" : "foo",
+                "id.token.claim" : "true",
+                "access.token.claim" : "true",
+                "claim.name" : "groups",
+                "jsonType.label" : "String"
+            }
+        } ]
+    } ],
+    "defaultDefaultClientScopes" : [ "profile", "email", "role_list", "roles", "web-origins" ],
+    "defaultOptionalClientScopes" : [ "offline_access", "phone", "microprofile-jwt", "address" ],
+    "browserSecurityHeaders" : {
+        "contentSecurityPolicyReportOnly" : "",
+        "xContentTypeOptions" : "nosniff",
+        "xRobotsTag" : "none",
+        "xFrameOptions" : "SAMEORIGIN",
+        "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+        "xXSSProtection" : "1; mode=block",
+        "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+    },
+    "smtpServer" : { },
+    "eventsEnabled" : false,
+    "eventsListeners" : [ "jboss-logging" ],
+    "enabledEventTypes" : [ ],
+    "adminEventsEnabled" : false,
+    "adminEventsDetailsEnabled" : false,
+    "identityProviders" : [ ],
+    "identityProviderMappers" : [ ],
+    "components" : {
+        "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+            "id" : "c0c16b10-415f-4d6e-88f6-c1050314e85d",
+            "name" : "Max Clients Limit",
+            "providerId" : "max-clients",
+            "subType" : "anonymous",
+            "subComponents" : { },
+            "config" : {
+                "max-clients" : [ "200" ]
+            }
+        }, {
+            "id" : "06bdbf20-05ff-4e6d-bbf0-3daa86fb0757",
+            "name" : "Consent Required",
+            "providerId" : "consent-required",
+            "subType" : "anonymous",
+            "subComponents" : { },
+            "config" : { }
+        }, {
+            "id" : "86f63e93-ef16-41ff-8a7b-9a0f99344497",
+            "name" : "Allowed Protocol Mapper Types",
+            "providerId" : "allowed-protocol-mappers",
+            "subType" : "anonymous",
+            "subComponents" : { },
+            "config" : {
+                "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "saml-user-property-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper" ]
+            }
+        }, {
+            "id" : "cb89ebbf-ff1c-432c-a43e-63df05848a62",
+            "name" : "Allowed Client Scopes",
+            "providerId" : "allowed-client-templates",
+            "subType" : "authenticated",
+            "subComponents" : { },
+            "config" : {
+                "allow-default-scopes" : [ "true" ]
+            }
+        }, {
+            "id" : "70c357f9-59c0-4758-b202-ba75ace53eda",
+            "name" : "Full Scope Disabled",
+            "providerId" : "scope",
+            "subType" : "anonymous",
+            "subComponents" : { },
+            "config" : { }
+        }, {
+            "id" : "9f3b5f54-efe8-4ebf-a6d7-1bcb3b3f192b",
+            "name" : "Allowed Client Scopes",
+            "providerId" : "allowed-client-templates",
+            "subType" : "anonymous",
+            "subComponents" : { },
+            "config" : {
+                "allow-default-scopes" : [ "true" ]
+            }
+        }, {
+            "id" : "e640c7f7-0c39-4b47-91c3-d1687c353769",
+            "name" : "Trusted Hosts",
+            "providerId" : "trusted-hosts",
+            "subType" : "anonymous",
+            "subComponents" : { },
+            "config" : {
+                "host-sending-registration-request-must-match" : [ "true" ],
+                "client-uris-must-match" : [ "true" ]
+            }
+        }, {
+            "id" : "ebc3625c-9fe2-4739-8d75-b07866794e28",
+            "name" : "Allowed Protocol Mapper Types",
+            "providerId" : "allowed-protocol-mappers",
+            "subType" : "authenticated",
+            "subComponents" : { },
+            "config" : {
+                "allowed-protocol-mapper-types" : [ "saml-user-attribute-mapper", "saml-role-list-mapper", "oidc-usermodel-property-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper" ]
+            }
+        } ],
+        "org.keycloak.keys.KeyProvider" : [ {
+            "id" : "2586006e-6e8e-479f-b6e3-dd2af4bd253d",
+            "name" : "rsa-generated",
+            "providerId" : "rsa-generated",
+            "subComponents" : { },
+            "config" : {
+                "privateKey" : [ "MIIEpAIBAAKCAQEAs49gQ2xcce8VslFoqBR3gj/oUmOc2g2J8SGlPaYAQ4pHWopfZqD6gBQ5hKmRKefuNBXn2bN2j2Zq7RMbPVYKH6F5U+RtJ1ja+tNOK8+uY5coqvwRrYR10BFtrYNq9MapWHXUFdzIJZ5IDT3/W/jS6qNPOL49Os/TO7tf8QpVV67d0zxblR8VSKagp1KmhjSvTx7lWJcRNYRIKFbIcZ0ZP4/2pzemTyDqJjkzgNrSW8K3cNLzohdjr1pR3UFVw+sGlG5NdDrVs0CporOJrArzqF8YkLMMpMCLpjYAiK7AEC7yN9cn7Og1NctqVN2lA+agqkcT+dpOE1wa2lr1oeTKAwIDAQABAoIBAGj34CaKKmDQi7Z6sNvRWyvhgEbpxMAUOheku5yWdoEFTUE4sxyj7s0BBb7wAdSlqTL5u1gg+aZLEScWjE4HBlQHaY4Jc2YVI66N6JzkA+Zkb3nFcfAmB1ljVuKgeN4vZMA54YoGT1rudOCI5cc2ZtaUMbPSQqkm5S1+FFAs4kcnD6t/m3dpHE0uG3cWutfzUHAkk0cZFtZFLlI+arB4Ml5fj/ZfDTC4cp8+LS4EeHK/+gmlBGOknEd8gtNLl4a9G2lOfvG8knjnWpIApkDhPpLqtn8x/KHYeu+dJ1u2V+Fn5ZNcILp66q3zbFevZVNNzsrQXx8f1huoO4dTnIytOIECgYEA4lh05yHfPohdoiW2DvowzV7Bg3V2e3Z5pXTB2kcfP65QITqYJpItmeLvfMUXbxbOUOP1ZaBJig7WbfngqFsOa9J77KBJw+c1N91FCtm7auovGsbo8sOAGRu7oQPS/DZO5aUBfGncfHAJpJ/yWWHlOk/S30fBU+QlVK168d1YK2sCgYEAyxXAnpR346U4ayW02Re1I7hPP0bYwQy9TseYlfimxzApIEa6vNbyHXtbl4ppl5uakBMZcDpM3JfZni7eLD6ndH5rWNyGSkNmPh+yb6E92Asnv+1VmGJd7FAM2VbLfY7ufS7qEBJWJrmwRuOB9DbpmRQqQ3PvdelOCGj3FOzX2ckCgYAh2Yq6GjWxu2ENY8hjWwU7YWVdTI7IjgJJPTnUc/h3ZJE1NvcUJZ5OOkMIjM0hXu7B6CWF6j+1NtzYm5r+coeollTUIXCGrKgnz56IreE6bwVWYtLpo1Uf7CbWQKUn9NM9wryDJ63Cqlq21PjAZ0SJwPBPVgLSkfcHP954F1sdOwKBgQCd9q18q78VMs5PiWTB987Nme8KKPEwN9iIDniBLoeLJ8rVcC6P9CEfDXSQyviXFFGE/1YqFS7z5qk+gPYPNCzMUAjvdZh+6y375GvGqISSJxskDlcl0F1+EkXsR7bAUwzuEi+9kIWyWXzjptLOQmgwyZ6WGPeJn48yu3J0tESxAQKBgQCHvUJOwdrXqN7mZzAWPUwbLr+evkJSQQyquR3HW/Yq8LYB1nFxzBVdNKvh5JMvpB1wOtjFdEQ0y6M+w+ZzMfsJEz0jap1z0m8R0DwrXCjtIT9YOtSkbp2cHxxMYodshqEKQErkFtNySit/BkYjpJrSNwk7AwfDNaCdcXcHmR962A==" ],
+                "keyUse" : [ "SIG" ],
+                "certificate" : [ "MIIClzCCAX8CBgF+ShW75DANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDAR0ZXN0MB4XDTIyMDExMTE2NTkwNVoXDTMyMDExMTE3MDA0NVowDzENMAsGA1UEAwwEdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALOPYENsXHHvFbJRaKgUd4I/6FJjnNoNifEhpT2mAEOKR1qKX2ag+oAUOYSpkSnn7jQV59mzdo9mau0TGz1WCh+heVPkbSdY2vrTTivPrmOXKKr8Ea2EddARba2DavTGqVh11BXcyCWeSA09/1v40uqjTzi+PTrP0zu7X/EKVVeu3dM8W5UfFUimoKdSpoY0r08e5ViXETWESChWyHGdGT+P9qc3pk8g6iY5M4Da0lvCt3DS86IXY69aUd1BVcPrBpRuTXQ61bNAqaKziawK86hfGJCzDKTAi6Y2AIiuwBAu8jfXJ+zoNTXLalTdpQPmoKpHE/naThNcGtpa9aHkygMCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAoj8kXR2fabdLtMGCj7BGy1xIJLUtNnmAIGnHaZ37cVadzHPxRXtOKJjBrAOrjQ7dvONelubZ3Uj9warCdsUV65t6NrG85KpJlW3qVtMuaIoY/sJ2bT9CYKemrOgTW3LgPmjO+YpZOR4uuo2LmVw0XL8KE6zlZwqRfwhjWy/QkRrgHsIXcbF4SnVDAQzpPlo3dTNS60pDtQtbYkIFI2ujdFpkA5u73DAPUCNakRvoutI8ZuHRqqPIIwKFzMXYZNG4GRfL51tRC14VSb+IIoknFwPpm2Y4ZCZkM7OfEDombHgU301NpMcc0ZZxw0zrI5ADEgLpxFitonbFf4MZyJXUbA==" ],
+                "priority" : [ "100" ]
+            }
+        }, {
+            "id" : "3c9c0ea4-c541-428d-ac49-44d955b4fbcc",
+            "name" : "rsa-enc-generated",
+            "providerId" : "rsa-enc-generated",
+            "subComponents" : { },
+            "config" : {
+                "privateKey" : [ "MIIEogIBAAKCAQEAh4/1V8qm/ZoenwUI15TispVHM24NvnhbPOlSg4Hj3FduSi9qJ/CbiOKaZ15cQ6n6J4Niiv5X6VgehrU00Ni/yzNfDVjiiz2esb4YEGHMoEzjtjh6B5sNaptYyYjOenHRdiEVsKX480DJDs81MrQS7dLaSkXP3nz8i1w6JK086vT6JLf5YX7w+aESFr4etzPluWokKtx9MvK36+oqoPqIzzzXOSDFQ1FaQmOMyYKxaVOL9TFJoCevR5BzDxz+p5OyjDvsDq6VhKavU5mggXgQNrpDuWvNJQ7aBnUY2iJ0+gOF4/KieHUWNgtDc5eyOuhWRqg6QsEM8jXiOa55tVm+7QIDAQABAoIBAEavLYJFTKVXQzgva9jc7QepBqMuc0QphYlRL5EanTE69WsBJh0FPFQ3s8LKVNmDO8h2nV9UF4q4Q9KBkbSEEB1n/9v5yMZJrwGG2Q1RsVy0Ote8wwRMOMapkbYj+2WlC07JGYIuSIyt7yglqttxQZ14IBIyLJ0aFqSjxj1xhx4LMlslOMzjgAqybqATj+3/dbhUxj82DoucVMkGvgJyax9VuJL7r0c7jvzn+/LRjP2oouECN9NjOusVM1CA4+l70IasR6dnuD93QMK/rBSTvls2knk9HPBX5bZZxa0cLK2en14Zv9T57zf7176Xuy7WC4eUSfVN7LiiO5RA5bK/QgECgYEA1pfZqp3ynhRp8VAO9qqSuOBdqxXYkKEnoQgNp9v/t8DM5DftOExyFPeAcFu1nSoKALM0J+MaV9ggsS8c1vVgc63jL96Yt9+/dhIXJuHFx0TlE/6TLYmrRgfOSvthiSsGxVutcGu0UfYcmhObNLike3Ulfb7Sww2z18Ic/NSEfs0CgYEAobhDLH8xfV7rPnvQB3bse2Pz4anqFIgfaTJYk9dYgjuHpy9v4qU5LqJ8UjJtVscceJObrQnkZADzaQNMkL1Ce7YBmzo/pB2M39J7cRyQ+H5d2VbSlX9dTL+jBzvIye73YXl9GQH7YPU0NwGY3qtmNUYUetFdLYaK0cCukfoeAKECgYBT/pPgSHqSjYL6RU/WFOXhH1EKij5+PdX5HeHadi4dioWoPovHoYR12HqZgAwSPEY2B+6+PhItmBcTw1ESgnECVmm6bvJv5lBWsrYFLhHv8XOI4/hPtrcnbh69ErAWtJSt4zh77GxkOGTxmgMCG9OlzzChi3OLjW17YiteewBxcQKBgFhO8Ud8ET8/tL/DBl79HrdmZkeE7FDX4Ccmmd3pSuiar0GpErS1ulrv2WldJf2r7q0dFXZRH4lIR6LBbW7gGkzJn2jvTs9EX6fdHREwIy2+e2ryET4XdZAyWUja6ZLzTdzJZXlhbq6MVz3uPlbhS4etxAMpDnOMs4NEb09BQF7hAoGAQ//vl9A328D5h5O5XyqylG1WPeXLcdwMQ3uP+erxS4kLrYlEv3Eo7BNpK6nRHQUndkrOGDMABc3TOOnYVE6486DWdrpy9MsQk3KoNM7KogswRQcDmXPLG3smOcfAtOraZGqlL8SX15N9CAedj0Nw4MeDI7biSZSt6jhaC5RlZlU=" ],
+                "keyUse" : [ "ENC" ],
+                "certificate" : [ "MIIClzCCAX8CBgF+ShW93DANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDAR0ZXN0MB4XDTIyMDExMTE2NTkwNVoXDTMyMDExMTE3MDA0NVowDzENMAsGA1UEAwwEdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIeP9VfKpv2aHp8FCNeU4rKVRzNuDb54WzzpUoOB49xXbkovaifwm4jimmdeXEOp+ieDYor+V+lYHoa1NNDYv8szXw1Y4os9nrG+GBBhzKBM47Y4egebDWqbWMmIznpx0XYhFbCl+PNAyQ7PNTK0Eu3S2kpFz958/ItcOiStPOr0+iS3+WF+8PmhEha+Hrcz5blqJCrcfTLyt+vqKqD6iM881zkgxUNRWkJjjMmCsWlTi/UxSaAnr0eQcw8c/qeTsow77A6ulYSmr1OZoIF4EDa6Q7lrzSUO2gZ1GNoidPoDhePyonh1FjYLQ3OXsjroVkaoOkLBDPI14jmuebVZvu0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEADSvRbqA28R+QU2ij01HcDNWmLvkxSMTFytHRs08n00Rd4ONYeXir1s2F4o0bSLCuYX1d7hOJiw2VVkQNqU2ZvfLZe9QBIetj+AaSsFEz3+3CqE22fHPrnM+1cI6SXpF/zK7Jx3sNdaKRuG3+WbTtjT1p45D/QwUd/YzjWf2YI824jAGamTupd1oyKX2klCnryS2sKrIqnH/1MDfgK93PLtSxNite/effRI2O6ySXX1wmila+nBo9hYcr5Y+yHCmPg+EtdVgGzvVDKrxFEQcLvbZD1HBDCymkWzix0hbsSKc4BDfBl8gOiAes4CATvhMyVJ4unsb/SMBkIDfclr/vdQ==" ],
+                "priority" : [ "100" ],
+                "algorithm" : [ "RSA-OAEP" ]
+            }
+        }, {
+            "id" : "ced222a6-758f-4bde-a993-c1f8882b99f3",
+            "name" : "hmac-generated",
+            "providerId" : "hmac-generated",
+            "subComponents" : { },
+            "config" : {
+                "kid" : [ "13938f82-4b06-4dfa-a9ae-9f113d84d602" ],
+                "secret" : [ "cROFgwh4hrwUtON8MHhFY2Izr-A70s5FbHetwhnr0HdWNqrCtiPznHbNcvCpC8RhA1Nlm5i_DuxfkNHxbmDyEQ" ],
+                "priority" : [ "100" ],
+                "algorithm" : [ "HS256" ]
+            }
+        }, {
+            "id" : "1346c112-4ab3-4609-8282-c13fdb429b51",
+            "name" : "aes-generated",
+            "providerId" : "aes-generated",
+            "subComponents" : { },
+            "config" : {
+                "kid" : [ "622051f7-e16a-45ea-ae3d-d0f3d7c6066f" ],
+                "secret" : [ "087wgqk1GaBeJqSwG0Va1A" ],
+                "priority" : [ "100" ]
+            }
+        } ]
+    },
+    "internationalizationEnabled" : false,
+    "supportedLocales" : [ ],
+    "authenticationFlows" : [ {
+        "id" : "42162a9e-46d8-4683-b4de-33f63f2acb3e",
+        "alias" : "Account verification options",
+        "description" : "Method with which to verity the existing account",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "idp-email-verification",
+            "authenticatorFlow" : false,
+            "requirement" : "ALTERNATIVE",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticatorFlow" : true,
+            "requirement" : "ALTERNATIVE",
+            "priority" : 20,
+            "flowAlias" : "Verify Existing Account by Re-authentication",
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : true
+        } ]
+    }, {
+        "id" : "377ebacb-348b-4a0c-89dc-8bc7c04f8ae9",
+        "alias" : "Authentication Options",
+        "description" : "Authentication options.",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "basic-auth",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "basic-auth-otp",
+            "authenticatorFlow" : false,
+            "requirement" : "DISABLED",
+            "priority" : 20,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "auth-spnego",
+            "authenticatorFlow" : false,
+            "requirement" : "DISABLED",
+            "priority" : 30,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        } ]
+    }, {
+        "id" : "44561c83-653d-4e87-badf-0b60d90d1ac6",
+        "alias" : "Browser - Conditional OTP",
+        "description" : "Flow to determine if the OTP is required for the authentication",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "conditional-user-configured",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "auth-otp-form",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 20,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        } ]
+    }, {
+        "id" : "224fa87f-aec9-479f-badc-a7de48a3b5e1",
+        "alias" : "Direct Grant - Conditional OTP",
+        "description" : "Flow to determine if the OTP is required for the authentication",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "conditional-user-configured",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "direct-grant-validate-otp",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 20,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        } ]
+    }, {
+        "id" : "42e59c0b-41a7-458c-848b-3e28269151c6",
+        "alias" : "First broker login - Conditional OTP",
+        "description" : "Flow to determine if the OTP is required for the authentication",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "conditional-user-configured",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "auth-otp-form",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 20,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        } ]
+    }, {
+        "id" : "b92df23b-0b5d-47ed-a0bb-1e7c59d3a7dd",
+        "alias" : "Handle Existing Account",
+        "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "idp-confirm-link",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticatorFlow" : true,
+            "requirement" : "REQUIRED",
+            "priority" : 20,
+            "flowAlias" : "Account verification options",
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : true
+        } ]
+    }, {
+        "id" : "f124c209-55a1-494c-9b2f-5c940da6de4c",
+        "alias" : "Reset - Conditional OTP",
+        "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "conditional-user-configured",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "reset-otp",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 20,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        } ]
+    }, {
+        "id" : "0e5718c0-8561-4da5-b466-223ab6668d07",
+        "alias" : "User creation or linking",
+        "description" : "Flow for the existing/non-existing user alternatives",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticatorConfig" : "create unique user config",
+            "authenticator" : "idp-create-user-if-unique",
+            "authenticatorFlow" : false,
+            "requirement" : "ALTERNATIVE",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticatorFlow" : true,
+            "requirement" : "ALTERNATIVE",
+            "priority" : 20,
+            "flowAlias" : "Handle Existing Account",
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : true
+        } ]
+    }, {
+        "id" : "e4dcb1d4-db3f-48af-991e-893364e81a18",
+        "alias" : "Verify Existing Account by Re-authentication",
+        "description" : "Reauthentication of existing account",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "idp-username-password-form",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticatorFlow" : true,
+            "requirement" : "CONDITIONAL",
+            "priority" : 20,
+            "flowAlias" : "First broker login - Conditional OTP",
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : true
+        } ]
+    }, {
+        "id" : "9516356e-7d84-4bb8-916e-ac9b8ecc7762",
+        "alias" : "browser",
+        "description" : "browser based authentication",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "auth-cookie",
+            "authenticatorFlow" : false,
+            "requirement" : "ALTERNATIVE",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "auth-spnego",
+            "authenticatorFlow" : false,
+            "requirement" : "DISABLED",
+            "priority" : 20,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "identity-provider-redirector",
+            "authenticatorFlow" : false,
+            "requirement" : "ALTERNATIVE",
+            "priority" : 25,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticatorFlow" : true,
+            "requirement" : "ALTERNATIVE",
+            "priority" : 30,
+            "flowAlias" : "forms",
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : true
+        } ]
+    }, {
+        "id" : "fd8729f9-54e0-4668-981d-ba07816bedc6",
+        "alias" : "clients",
+        "description" : "Base authentication for clients",
+        "providerId" : "client-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "client-secret",
+            "authenticatorFlow" : false,
+            "requirement" : "ALTERNATIVE",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "client-jwt",
+            "authenticatorFlow" : false,
+            "requirement" : "ALTERNATIVE",
+            "priority" : 20,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "client-secret-jwt",
+            "authenticatorFlow" : false,
+            "requirement" : "ALTERNATIVE",
+            "priority" : 30,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "client-x509",
+            "authenticatorFlow" : false,
+            "requirement" : "ALTERNATIVE",
+            "priority" : 40,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        } ]
+    }, {
+        "id" : "1ee381cc-3d6e-4997-8e55-337a39d5c72d",
+        "alias" : "direct grant",
+        "description" : "OpenID Connect Resource Owner Grant",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "direct-grant-validate-username",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "direct-grant-validate-password",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 20,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticatorFlow" : true,
+            "requirement" : "CONDITIONAL",
+            "priority" : 30,
+            "flowAlias" : "Direct Grant - Conditional OTP",
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : true
+        } ]
+    }, {
+        "id" : "238e5013-5aa6-4199-8364-272ecbddb6d9",
+        "alias" : "docker auth",
+        "description" : "Used by Docker clients to authenticate against the IDP",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "docker-http-basic-authenticator",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        } ]
+    }, {
+        "id" : "ba482013-fbc2-42a1-bbfa-3166f9eb7506",
+        "alias" : "first broker login",
+        "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticatorConfig" : "review profile config",
+            "authenticator" : "idp-review-profile",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticatorFlow" : true,
+            "requirement" : "REQUIRED",
+            "priority" : 20,
+            "flowAlias" : "User creation or linking",
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : true
+        } ]
+    }, {
+        "id" : "f1366e50-9bf5-4b76-a10b-cbc78dfbc513",
+        "alias" : "forms",
+        "description" : "Username, password, otp and other auth forms.",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "auth-username-password-form",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticatorFlow" : true,
+            "requirement" : "CONDITIONAL",
+            "priority" : 20,
+            "flowAlias" : "Browser - Conditional OTP",
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : true
+        } ]
+    }, {
+        "id" : "45807ee7-a310-4fb0-91c4-4510de12643a",
+        "alias" : "http challenge",
+        "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "no-cookie-redirect",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticatorFlow" : true,
+            "requirement" : "REQUIRED",
+            "priority" : 20,
+            "flowAlias" : "Authentication Options",
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : true
+        } ]
+    }, {
+        "id" : "c7fd3e3c-5eeb-4b78-9651-313f60ec97ae",
+        "alias" : "registration",
+        "description" : "registration flow",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "registration-page-form",
+            "authenticatorFlow" : true,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "flowAlias" : "registration form",
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : true
+        } ]
+    }, {
+        "id" : "9e7b6c5e-0124-4e82-9266-ee24cd489b79",
+        "alias" : "registration form",
+        "description" : "registration form",
+        "providerId" : "form-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "registration-user-creation",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 20,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "registration-profile-action",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 40,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "registration-password-action",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 50,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "registration-recaptcha-action",
+            "authenticatorFlow" : false,
+            "requirement" : "DISABLED",
+            "priority" : 60,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        } ]
+    }, {
+        "id" : "28c7878b-49cd-4ae3-895d-fe470601813d",
+        "alias" : "reset credentials",
+        "description" : "Reset credentials for a user if they forgot their password or something",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "reset-credentials-choose-user",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "reset-credential-email",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 20,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticator" : "reset-password",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 30,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        }, {
+            "authenticatorFlow" : true,
+            "requirement" : "CONDITIONAL",
+            "priority" : 40,
+            "flowAlias" : "Reset - Conditional OTP",
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : true
+        } ]
+    }, {
+        "id" : "1490e50b-c26d-423e-91c7-62801ddb1e19",
+        "alias" : "saml ecp",
+        "description" : "SAML ECP Profile Authentication Flow",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+            "authenticator" : "http-basic-authenticator",
+            "authenticatorFlow" : false,
+            "requirement" : "REQUIRED",
+            "priority" : 10,
+            "userSetupAllowed" : false,
+            "autheticatorFlow" : false
+        } ]
+    } ],
+    "authenticatorConfig" : [ {
+        "id" : "8f937846-ec80-4e17-a50c-f7fdfd900d5d",
+        "alias" : "create unique user config",
+        "config" : {
+            "require.password.update.after.registration" : "false"
+        }
+    }, {
+        "id" : "3a8384cd-4ef4-4f0f-9c52-2f7ebe234bc0",
+        "alias" : "review profile config",
+        "config" : {
+            "update.profile.on.first.login" : "missing"
+        }
+    } ],
+    "requiredActions" : [ {
+        "alias" : "CONFIGURE_TOTP",
+        "name" : "Configure OTP",
+        "providerId" : "CONFIGURE_TOTP",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 10,
+        "config" : { }
+    }, {
+        "alias" : "terms_and_conditions",
+        "name" : "Terms and Conditions",
+        "providerId" : "terms_and_conditions",
+        "enabled" : false,
+        "defaultAction" : false,
+        "priority" : 20,
+        "config" : { }
+    }, {
+        "alias" : "UPDATE_PASSWORD",
+        "name" : "Update Password",
+        "providerId" : "UPDATE_PASSWORD",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 30,
+        "config" : { }
+    }, {
+        "alias" : "UPDATE_PROFILE",
+        "name" : "Update Profile",
+        "providerId" : "UPDATE_PROFILE",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 40,
+        "config" : { }
+    }, {
+        "alias" : "VERIFY_EMAIL",
+        "name" : "Verify Email",
+        "providerId" : "VERIFY_EMAIL",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 50,
+        "config" : { }
+    }, {
+        "alias" : "delete_account",
+        "name" : "Delete Account",
+        "providerId" : "delete_account",
+        "enabled" : false,
+        "defaultAction" : false,
+        "priority" : 60,
+        "config" : { }
+    }, {
+        "alias" : "update_user_locale",
+        "name" : "Update User Locale",
+        "providerId" : "update_user_locale",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 1000,
+        "config" : { }
+    } ],
+    "browserFlow" : "browser",
+    "registrationFlow" : "registration",
+    "directGrantFlow" : "direct grant",
+    "resetCredentialsFlow" : "reset credentials",
+    "clientAuthenticationFlow" : "clients",
+    "dockerAuthenticationFlow" : "docker auth",
+    "attributes" : {
+        "cibaBackchannelTokenDeliveryMode" : "poll",
+        "cibaExpiresIn" : "120",
+        "cibaAuthRequestedUserHint" : "login_hint",
+        "oauth2DeviceCodeLifespan" : "600",
+        "clientOfflineSessionMaxLifespan" : "0",
+        "oauth2DevicePollingInterval" : "5",
+        "clientSessionIdleTimeout" : "0",
+        "parRequestUriLifespan" : "60",
+        "clientSessionMaxLifespan" : "0",
+        "clientOfflineSessionIdleTimeout" : "0",
+        "cibaInterval" : "5"
+    },
+    "keycloakVersion" : "16.1.0",
+    "userManagedAccessAllowed" : false,
+    "clientProfiles" : {
+        "profiles" : [ ]
+    },
+    "clientPolicies" : {
+        "policies" : [ ]
+    }
+}

--- a/dev-resources/oidc/.well-known/openid-configuration
+++ b/dev-resources/oidc/.well-known/openid-configuration
@@ -1,0 +1,106 @@
+{
+  "issuer": "https://server.example.com",
+  "authorization_endpoint": "https://server.example.com/connect/authorize",
+  "token_endpoint": "https://server.example.com/connect/token",
+  "token_endpoint_auth_methods_supported": [
+    "client_secret_basic",
+    "private_key_jwt"
+  ],
+  "token_endpoint_auth_signing_alg_values_supported": [
+    "RS256",
+    "ES256"
+  ],
+  "userinfo_endpoint": "https://server.example.com/connect/userinfo",
+  "check_session_iframe": "https://server.example.com/connect/check_session",
+  "end_session_endpoint": "https://server.example.com/connect/end_session",
+  "jwks_uri": "https://server.example.com/jwks.json",
+  "registration_endpoint": "https://server.example.com/connect/register",
+  "scopes_supported": [
+    "openid",
+    "profile",
+    "email",
+    "address",
+    "phone",
+    "offline_access"
+  ],
+  "response_types_supported": [
+    "code",
+    "code id_token",
+    "id_token",
+    "token id_token"
+  ],
+  "acr_values_supported": [
+    "urn:mace:incommon:iap:silver",
+    "urn:mace:incommon:iap:bronze"
+  ],
+  "subject_types_supported": [
+    "public",
+    "pairwise"
+  ],
+  "userinfo_signing_alg_values_supported": [
+    "RS256",
+    "ES256",
+    "HS256"
+  ],
+  "userinfo_encryption_alg_values_supported": [
+    "RSA1_5",
+    "A128KW"
+  ],
+  "userinfo_encryption_enc_values_supported": [
+    "A128CBC-HS256",
+    "A128GCM"
+  ],
+  "id_token_signing_alg_values_supported": [
+    "RS256",
+    "ES256",
+    "HS256"
+  ],
+  "id_token_encryption_alg_values_supported": [
+    "RSA1_5",
+    "A128KW"
+  ],
+  "id_token_encryption_enc_values_supported": [
+    "A128CBC-HS256",
+    "A128GCM"
+  ],
+  "request_object_signing_alg_values_supported": [
+    "none",
+    "RS256",
+    "ES256"
+  ],
+  "display_values_supported": [
+    "page",
+    "popup"
+  ],
+  "claim_types_supported": [
+    "normal",
+    "distributed"
+  ],
+  "claims_supported": [
+    "sub",
+    "iss",
+    "auth_time",
+    "acr",
+    "name",
+    "given_name",
+    "family_name",
+    "nickname",
+    "profile",
+    "picture",
+    "website",
+    "email",
+    "email_verified",
+    "locale",
+    "zoneinfo",
+    "http://example.info/claims/groups"
+  ],
+  "claims_parameter_supported": true,
+  "service_documentation": "http://server.example.com/connect/service_documentation.html",
+  "ui_locales_supported": [
+    "en-US",
+    "en-GB",
+    "en-CA",
+    "fr-FR",
+    "fr-CA"
+  ]
+}

--- a/doc/authority.md
+++ b/doc/authority.md
@@ -59,4 +59,40 @@ If you do not configure a template, the default is to use the `cred-id` and `aut
     "objectType":"Agent"
 }
 ```
+
+### OIDC Authority
+
+When SQL LRS is [configured for OIDC](oidc.md) an alternative template is used that forms the authority from token claims:
+
+``` json
+{
+  "objectType": "Group",
+  "member": [
+    {
+      "account": {
+        "homePage": "{{iss}}",
+        "name": "{{lrsql/resolved-client-id}}"
+      }
+    },
+    {
+      "account": {
+        "homePage": "{{iss}}",
+        "name": "{{sub}}"
+      }
+    }
+  ]
+}
+```
+
+Possible claims vary by identity provider, see the [comprehensive list here](https://www.iana.org/assignments/jwt/jwt.xhtml). SQL LRS provides one additional value, `lrsql/resolved-client-id` that resolves to the following claims in order of precedence:
+
+1. `client_id`
+2. `azp`
+3. `aud` (if `aud` is a string)
+4. `aud[0]` (if `aud` is an array)
+
+Note that the request will fail if expected claims are not present on the token.
+
+As with the normal authority template, you can provide a custom version by setting the `LRSQL_OIDC_AUTHORITY_TEMPLATE` (`lrs.oidcAuthorityTemplate`) config variable.
+
 [<- Back to Index](index.md)

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -26,6 +26,7 @@ The SQL LRS can be built or run with the following Makefile targets. They can be
 | Target | Description |
 | --- | --- |
 | `ephemeral` | Start an in-memory SQL LRS based on H2 DB. |
+| `ephemeral-prod` | Similar to `ephemeral`, except that the `:prod` profile is used, enabling the use of environment variables without full compilation. |
 | `persistent` | Similar to `ephemeral`, except that the H2 DB is stored on-disk, not in-memory. |
 | `sqlite` | Start a SQLite-based SQL LRS. |
 | `postgres` | Start a Postgres SQL LRS. Requires a running Postgres instance. |

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -85,6 +85,8 @@ You may have noted that some options are not available:
 | `LRSQL_STMT_GET_MAX` | `stmtGetMax` | The maximum allowed `limit` value for a statement query. If an explicit `limit` value exceeds this value, it will be overridden. | `50` |
 | `LRSQL_AUTHORITY_TEMPLATE` | `authorityTemplate` | The filepath to the Statement authority template file, which describes how authorities are constructed during statement insertion. If the file is not found, the system defaults to a default authority function. | <details>`config/authority.json.template`<summary>(Filepath)</summary></details> |
 | `LRSQL_AUTHORITY_URL` | `authorityUrl` | The URL that is set as the `authority-url` value when constructing an authority from a template. | `http://example.org` |
+| `LRSQL_OIDC_AUTHORITY_TEMPLATE` | `oidcAuthorityTemplate` | Like `LRSQL_AUTHORITY_TEMPLATE`, but only used when forming an authority from an OIDC access token. | <details>`config/oidc_authority.json.template`<summary>(Filepath)</summary></details> |
+| `LRSQL_OIDC_SCOPE_PREFIX` | `oidcScopePrefix` | An optional prefix prepended to OIDC scope. For example, setting this to `lrs:` would change the expected `all` scope to `lrs:all` | `""` |
 | `LRSQL_STMT_RETRY_LIMIT` | `stmtRetryLimit` | The number of times to retry a statement post transaction before failing. | `10` |
 | `LRSQL_STMT_RETRY_BUDGET` | `stmtRetryBudget` | The max amount of time allowed for statement POST transaction retries before failing (ms). | `1000` |
 
@@ -110,8 +112,8 @@ You may have noted that some options are not available:
 | `LRSQL_URL_PREFIX` | `urlPrefix` | The prefix of the webserver URL path, e.g. the prefix in `http://0.0.0.0:8080/xapi` is `/xapi`. Used when constructing the `more` value for multi-statement queries. | `/xapi` |
 | `LRSQL_ENABLE_ADMIN_UI` | `enableAdminUi` | Whether or not to serve the administrative UI at `/admin` | `true` |
 | `LRSQL_ENABLE_STMT_HTML` | `enableStmtHtml` | Whether or not HTML data is returned in the LRS HTTP response. If `false` disables HTML rendering even if `LRSQL_ENABLE_ADMIN_UI` is `true`. In that case the UI will not display the Statement Browser feature. | `true` |
-| `LRSQL_OPENID_ISSUER` | `openidIssuer` | OIDC Issuer address used for [discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig) | Not set |
-| `LRSQL_OPENID_CONFIG` | `openidConfig` | Custom OIDC configuration location | Not set |
+| `LRSQL_OIDC_ISSUER` | `oidcIssuer` | OIDC Issuer address used for [discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig) | Not set |
+| `LRSQL_OIDC_CONFIG` | `oidcConfig` | Custom OIDC configuration location | Not set |
 | `LRSQL_JWKS_URI` | `jwksUri` | Custom JWKS [keyset](https://datatracker.ietf.org/doc/html/rfc7517#section-5) location | Not set |
 
 [<- Back to Index](index.md)

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -114,9 +114,9 @@ You may have noted that some options are not available:
 | `LRSQL_ENABLE_STMT_HTML` | `enableStmtHtml` | Whether or not HTML data is returned in the LRS HTTP response. If `false` disables HTML rendering even if `LRSQL_ENABLE_ADMIN_UI` is `true`. In that case the UI will not display the Statement Browser feature. | `true` |
 | `LRSQL_OIDC_ISSUER` | `oidcIssuer` | OIDC Issuer address used for [discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). Will enable OIDC if present. | Not set |
 | `LRSQL_OIDC_AUDIENCE` | `oidcAudience` | Optional OIDC audience for token claim verification. No effect if `LRSQL_OIDC_ISSUER` is not set. | Not set |
-| `LRSQL_OIDC_CLIENT_ID` | `oidcClientId` | An optional OIDC client ID for the SQL LRS Admin SPA. If provided, along with the `LRSQL_OIDC_ISSUER` and `LRSQL_OIDC_AUDIENCE` variables, will enable OIDC access to the Admin UI. | Not Set |
-| `LRSQL_OIDC_CLIENT_TEMPLATE` | `oidcClientTemplate` | An optional template to modify LRS Admin UI client OIDC configuration. | Not Set |
+| `LRSQL_OIDC_CLIENT_ID` | `oidcClientId` | An optional OIDC client ID for the SQL LRS Admin SPA. If provided, along with the `LRSQL_OIDC_ISSUER` and `LRSQL_OIDC_AUDIENCE` variables, will enable OIDC access to the Admin UI. No effect if `LRSQL_OIDC_ISSUER` is not set. | Not Set |
+| `LRSQL_OIDC_CLIENT_TEMPLATE` | `oidcClientTemplate` | An optional template to modify LRS Admin UI client OIDC configuration. No effect if `LRSQL_OIDC_ISSUER` is not set. | Not Set |
 | `LRSQL_OIDC_VERIFY_REMOTE_ISSUER` | `oidcVerifyRemoteIssuer` | Verify on startup that the issuer in remote configuration matches `LRSQL_OIDC_ISSUER`. No effect if `LRSQL_OIDC_ISSUER` is not set. | `true` |
-| `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` | `oidcEnableLocalAdmin` | Whether or not to enable local administrative account authentication, login and management when `LRSQL_OIDC_ISSUER` is set. | `false` |
+| `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` | `oidcEnableLocalAdmin` | Whether or not to enable local administrative account authentication, login and management when `LRSQL_OIDC_ISSUER` is set. No effect if `LRSQL_OIDC_ISSUER` is not set. | `false` |
 
 [<- Back to Index](index.md)

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -112,8 +112,8 @@ You may have noted that some options are not available:
 | `LRSQL_URL_PREFIX` | `urlPrefix` | The prefix of the webserver URL path, e.g. the prefix in `http://0.0.0.0:8080/xapi` is `/xapi`. Used when constructing the `more` value for multi-statement queries. | `/xapi` |
 | `LRSQL_ENABLE_ADMIN_UI` | `enableAdminUi` | Whether or not to serve the administrative UI at `/admin` | `true` |
 | `LRSQL_ENABLE_STMT_HTML` | `enableStmtHtml` | Whether or not HTML data is returned in the LRS HTTP response. If `false` disables HTML rendering even if `LRSQL_ENABLE_ADMIN_UI` is `true`. In that case the UI will not display the Statement Browser feature. | `true` |
-| `LRSQL_OIDC_ISSUER` | `oidcIssuer` | OIDC Issuer address used for [discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig) | Not set |
-| `LRSQL_OIDC_CONFIG` | `oidcConfig` | Custom OIDC configuration location | Not set |
-| `LRSQL_JWKS_URI` | `jwksUri` | Custom JWKS [keyset](https://datatracker.ietf.org/doc/html/rfc7517#section-5) location | Not set |
+| `LRSQL_OIDC_ISSUER` | `oidcIssuer` | OIDC Issuer address used for [discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). Will enable OIDC if present. | Not set |
+| `LRSQL_OIDC_AUDIENCE` | `oidcAudience` | Optional OIDC audience for token claim verification. No effect if `LRSQL_OIDC_ISSUER` is not set. | Not set |
+| `LRSQL_OIDC_VERIFY_REMOTE_ISSUER` | `oidcVerifyRemoteIssuer` | Verify on startup that the issuer in remote configuration matches `LRSQL_OIDC_ISSUER`. No effect if `LRSQL_OIDC_ISSUER` is not set. | `true` |
 
 [<- Back to Index](index.md)

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -103,7 +103,7 @@ You may have noted that some options are not available:
 | `LRSQL_KEY_CERT_CHAIN` | `keyCertChain` | Comma separated PEM files for cert. See the TLS/HTTPS section below. | <details>`config/server.crt.pem,config/cacert.pem`<summary>(Filepaths)</summary></details> |
 | `LRSQL_KEY_ENABLE_SELFIE` | `keyEnableSelfie` | Boolean, whether or not to enable self-signed cert generation. | `true` |
 | `LRSQL_JWT_EXP_TIME` | `jwtExpTime` | The amount of time, in seconds, after a JWT is created when it expires. Since JWTs are not revocable, **this this time should be short** (i.e. one hour or less). | `3600` (one hour) |
-| `LRSQL_JWT_EXP_LEEWAY` | `jwtExpLeeway` | The amount of time, in seconds, before or after the expiration instant when a JWT should still count as un-expired. Used to compensate for clock desync. | `1` (one second) |
+| `LRSQL_JWT_EXP_LEEWAY` | `jwtExpLeeway` | The amount of time, in seconds, before or after the expiration instant when a JWT should still count as un-expired. Used to compensate for clock desync. Applied to both LRS and OIDC tokens. | `1` (one second) |
 | `LRSQL_ENABLE_HTTP` | `enableHttp` | Whether HTTP is enabled or not (as opposed to HTTPS, which is always enabled). | `true` |
 | `LRSQL_ENABLE_HTTP2` | `enableHttp2` | Whether HTTP/2 is supported or not. | `true` |
 | `LRSQL_HTTP_HOST` | `httpHost` | The host that the webserver will run on. | `0.0.0.0` |
@@ -114,6 +114,8 @@ You may have noted that some options are not available:
 | `LRSQL_ENABLE_STMT_HTML` | `enableStmtHtml` | Whether or not HTML data is returned in the LRS HTTP response. If `false` disables HTML rendering even if `LRSQL_ENABLE_ADMIN_UI` is `true`. In that case the UI will not display the Statement Browser feature. | `true` |
 | `LRSQL_OIDC_ISSUER` | `oidcIssuer` | OIDC Issuer address used for [discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). Will enable OIDC if present. | Not set |
 | `LRSQL_OIDC_AUDIENCE` | `oidcAudience` | Optional OIDC audience for token claim verification. No effect if `LRSQL_OIDC_ISSUER` is not set. | Not set |
+| `LRSQL_OIDC_CLIENT_ID` | `oidcClientId` | An optional OIDC client ID for the SQL LRS Admin SPA. If provided, along with the `LRSQL_OIDC_ISSUER` and `LRSQL_OIDC_AUDIENCE` variables, will enable OIDC access to the Admin UI. | Not Set |
+| `LRSQL_OIDC_CLIENT_TEMPLATE` | `oidcClientTemplate` | An optional template to modify LRS Admin UI client OIDC configuration. | Not Set |
 | `LRSQL_OIDC_VERIFY_REMOTE_ISSUER` | `oidcVerifyRemoteIssuer` | Verify on startup that the issuer in remote configuration matches `LRSQL_OIDC_ISSUER`. No effect if `LRSQL_OIDC_ISSUER` is not set. | `true` |
 
 [<- Back to Index](index.md)

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -110,5 +110,8 @@ You may have noted that some options are not available:
 | `LRSQL_URL_PREFIX` | `urlPrefix` | The prefix of the webserver URL path, e.g. the prefix in `http://0.0.0.0:8080/xapi` is `/xapi`. Used when constructing the `more` value for multi-statement queries. | `/xapi` |
 | `LRSQL_ENABLE_ADMIN_UI` | `enableAdminUi` | Whether or not to serve the administrative UI at `/admin` | `true` |
 | `LRSQL_ENABLE_STMT_HTML` | `enableStmtHtml` | Whether or not HTML data is returned in the LRS HTTP response. If `false` disables HTML rendering even if `LRSQL_ENABLE_ADMIN_UI` is `true`. In that case the UI will not display the Statement Browser feature. | `true` |
+| `LRSQL_OPENID_ISSUER` | `openidIssuer` | OIDC Issuer address used for [discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig) | Not set |
+| `LRSQL_OPENID_CONFIG` | `openidConfig` | Custom OIDC configuration location | Not set |
+| `LRSQL_JWKS_URI` | `jwksUri` | Custom JWKS [keyset](https://datatracker.ietf.org/doc/html/rfc7517#section-5) location | Not set |
 
 [<- Back to Index](index.md)

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -117,5 +117,6 @@ You may have noted that some options are not available:
 | `LRSQL_OIDC_CLIENT_ID` | `oidcClientId` | An optional OIDC client ID for the SQL LRS Admin SPA. If provided, along with the `LRSQL_OIDC_ISSUER` and `LRSQL_OIDC_AUDIENCE` variables, will enable OIDC access to the Admin UI. | Not Set |
 | `LRSQL_OIDC_CLIENT_TEMPLATE` | `oidcClientTemplate` | An optional template to modify LRS Admin UI client OIDC configuration. | Not Set |
 | `LRSQL_OIDC_VERIFY_REMOTE_ISSUER` | `oidcVerifyRemoteIssuer` | Verify on startup that the issuer in remote configuration matches `LRSQL_OIDC_ISSUER`. No effect if `LRSQL_OIDC_ISSUER` is not set. | `true` |
+| `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` | `oidcEnableLocalAdmin` | Whether or not to enable local administrative account authentication, login and management when `LRSQL_OIDC_ISSUER` is set. | `false` |
 
 [<- Back to Index](index.md)

--- a/doc/oidc.md
+++ b/doc/oidc.md
@@ -1,0 +1,88 @@
+[<- Back to Index](index.md)
+
+# OpenID Connect Support
+
+SQL LRS supports [OpenID Connect (OIDC)](https://openid.net/connect/) on top of [OAuth 2.0](https://oauth.net/2/) for authentication and authorization to access xAPI resources and administrative functions. OIDC support enables several integration use cases:
+
+* Send xAPI statements to the LRS from OIDC-authenticated client applications
+* Provision LRS credentials programatically via the API
+* Log in to the LRS Admin UI with a foreign identity (SSO)
+
+### Resource Server
+
+SQL LRS supports OIDC token authentication to all [endpoints](endpoints.md), allowing the use of an OIDC access token to make requests. In this context SQL LRS acts as an OAuth 2.0 "resource server".
+
+To enable OIDC auth, set the `LRSQL_OIDC_ISSUER` (`webserver.oidcIssuer` in JSON) configuration variable to your identity provider's [Issuer Identifier](https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier) URI. This address must be accessible to the LRS on startup as it will perform [OIDC Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html) to retrieve public keys and other information about the OIDC environment. It is also *strongly* recommended that you set the optional `LRSQL_OIDC_AUDIENCE` (`webserver.oidcAudience`) variable to the origin address of the LRS itself (ex. "http://0.0.0.0:8080") to enable verification that a given token was issued specifically for the LRS.
+
+#### Scope
+
+Resource authorization is determined by the scopes present in the token's `scope` claim. Note that the resource scopes discussed below can be prefixed with an arbitrary string by setting the `LRSQL_OIDC_SCOPE_PREFIX` (`lrs.oidcScopePrefix`). This is useful if the scopes used by SQL LRS might conflict with others used by your identity provider. For example, setting the variable to `lrs:` will change the `all` scope to `lrs:all`.
+
+OIDC Clients making requests to SQL LRS will need to request the desired scopes, and it is responsibility of the identity provider to grant them (or not). Configuration of scopes and associated behavior varies by identity provider.
+
+#### xAPI Resources
+
+xAPI resources accept tokens with the following scopes:
+
+| Scope              | Capability                                    |
+| ---                | ---                                           |
+| `all`              | Full read/write access to all xAPI resources. |
+| `all/read`         | Read-only access to all xAPI resources.       |
+| `statements/read`  | Read-only access to xAPI Statements           |
+| `statements/write` | Write-only access to xAPI Statements          |
+
+When SQL LRS accepts xAPI statements via OIDC auth it uses token claims to form the xAPI Authority. See [Authority Configuration](authority.md#oidc-authority) for more information.
+
+#### Admin API Resources
+
+Admin API resources share a single scope `admin` that represents full administrative control over SQL LRS.
+
+Administrative functions like credential provisioning require a local admin account. After decoding the token SQL LRS will ensure that an account exists (or is created) with a `username` matching the token's `sub` claim and an `oidc_issuer` matching the `iss` claim. If the user exists but the issuer does not match the request will fail with a 401 status.
+
+##### Local Admins
+
+By default SQL LRS will disable local administrator account usage and management when `LRSQL_OIDC_ISSUER` is provided. To enable local admin accounts when using OIDC, set the `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` (`lrs.oidcEnableLocalAdmin`) variable to `true`.
+
+### Admin UI Authentication
+
+The LRS Admin UI supports interactive login via an OIDC identity provider. To enable this functionality you must provide the OIDC issuer and audience (not optional in this case) as above and additionally set the `LRSQL_OIDC_CLIENT_ID` (`webserver.oidcClientId`) to the Client ID representing your Admin UI.
+
+When enabled the LRS will send configuration to the Admin UI directing it to offer OIDC login. Click the OIDC login link to be redirected to your identity provider for login. Upon a successful login you will be redirected to the Admin UI.
+
+#### Client Template
+
+The LRS Admin UI uses [oidc-client-js](https://github.com/IdentityModel/oidc-client-js) to manage communication with the OIDC identity provider. For some providers it may be necessary to customize client configuration in which case the `LRSQL_OIDC_CLIENT_TEMPLATE` (`webserver.oidcClientTemplate`) variable can be set. Note that the `redirect_uri` and `post_logout_redirect_uri` will be set by the Admin UI client and should not be provided.
+
+### Identity Providers
+
+OIDC support is currently developed and tested against [Keycloak](https://www.keycloak.org/) but may work with other identity providers that implement the specification.
+
+#### Keycloak Demo
+
+This repository contains a Docker Compose file and configuration for a demo instance of keycloak that you can run locally to try out OIDC support. To run keycloak:
+
+    cd dev-resources/keycloak_demo
+    docker compose up
+
+This will start a Keycloak server available at port 8081. You can adminster Keycloak via the [admin console](http://0.0.0.0:8081/auth/admin/master/console/) with the username `admin` and the password `changeme123`.
+
+When Keycloak is up, start SQL LRS with the following config variables:
+
+| Environment Variable      | JSON                     | Value                                  | Notes                                                             |
+| ---                       | ---                      | ---                                    | ---                                                               |
+| `LRSQL_OIDC_ISSUER`       | `webserver.oidcIssuer`   | `http://0.0.0.0:8081/auth/realms/test` | Keycloak realm uri.                                               |
+| `LRSQL_OIDC_AUDIENCE`     | `webserver.oidcAudience` | `http://0.0.0.0:8080`                  | The origin address of the LRS.                                    |
+| `LRSQL_OIDC_CLIENT_ID`    | `webserver.oidcClientId` | `lrs_admin_ui`                         | This is the ID of the preconfigured client in Keycloak.           |
+| `LRSQL_OIDC_SCOPE_PREFIX` | `lrs.oidcScopePrefix`    | `lrs:`                                 | Prefix scopes so general names like `all` do not cause collision. |
+
+Like so:
+
+    LRSQL_OIDC_ISSUER=http://0.0.0.0:8081/auth/realms/test \
+    LRSQL_OIDC_AUDIENCE=http://0.0.0.0:8080 \
+    LRSQL_OIDC_CLIENT_ID=lrs_admin_ui \
+    LRSQL_OIDC_SCOPE_PREFIX=lrs: \
+    ./bin/run_h2.sh
+
+When SQL LRS has started navigate to the [Admin UI](http://0.0.0.0:8080/admin/index.html) and log in with the username `dev_user` and password `changeme123`.
+
+[<- Back to Index](index.md)

--- a/resources/lrsql/config/config.edn
+++ b/resources/lrsql/config/config.edn
@@ -23,6 +23,9 @@
 
                    ;; Testing Only! Specify the version used with testcontainers
                    :test-db-version "11.9"}
+   :test-oidc     {:db-type "h2:mem"
+                   :db-name "ephemeral"}
+
    ;; Production
    :prod-h2-mem   #include "prod/h2_mem/database.edn"
    :prod-h2       #include "prod/h2/database.edn"
@@ -35,6 +38,7 @@
    :test-h2       #include "test/default/connection.edn"
    :test-sqlite   #include "test/default/connection.edn"
    :test-postgres #include "test/postgres/connection.edn"
+   :test-oidc     #include "test/default/connection.edn"
    ;; Production
    :prod-h2-mem   #include "prod/default/connection.edn"
    :prod-h2       #include "prod/default/connection.edn"
@@ -47,6 +51,7 @@
    :test-h2       #include "test/default/lrs.edn"
    :test-sqlite   #include "test/default/lrs.edn"
    :test-postgres #include "test/default/lrs.edn"
+   :test-oidc     #include "test/oidc/lrs.edn"
    ;; Production
    :prod-h2-mem   #include "prod/default/lrs.edn"
    :prod-h2       #include "prod/default/lrs.edn"
@@ -59,6 +64,7 @@
   :test-h2       #include "test/default/webserver.edn"
   :test-sqlite   #include "test/default/webserver.edn"
   :test-postgres #include "test/default/webserver.edn"
+  :test-oidc     #include "test/oidc/webserver.edn"
   ;; Production
   :prod-h2-mem   #include "prod/default/webserver.edn"
   :prod-h2       #include "prod/default/webserver.edn"

--- a/resources/lrsql/config/oidc_authority.json.template
+++ b/resources/lrsql/config/oidc_authority.json.template
@@ -1,0 +1,30 @@
+{# for template syntax see: https://github.com/yogthos/Selmer#templates
+
+   Use any variable present in token claims
+   https://www.iana.org/assignments/jwt/jwt.xhtml
+
+   This default template uses the "iss" claim to represent the IDP and the "sub"
+   claim to represent the user.
+
+   Special Variables:
+
+   * lrsql/resolved-client-id - Replacement for aud that is always a string.
+
+#}
+{
+  "objectType": "Group",
+  "member": [
+    {
+      "account": {
+        "homePage": "{{iss}}",
+        "name": "{{lrsql/resolved-client-id}}"
+      }
+    },
+    {
+      "account": {
+        "homePage": "{{iss}}",
+        "name": "{{sub}}"
+      }
+    }
+  ]
+}

--- a/resources/lrsql/config/oidc_client.json.template
+++ b/resources/lrsql/config/oidc_client.json.template
@@ -1,0 +1,21 @@
+{# for template syntax see: https://github.com/yogthos/Selmer#templates
+
+   This template maps config to oidc-client-js configuration.
+
+   Variables:
+   * lrs - The LRS configuration.
+   * webserver - The webserver configuration.
+
+#}
+{
+    "authority": "{{webserver.oidc-issuer}}",
+    "client_id": "{{webserver.oidc-client-id}}",
+    "response_type": "code",
+    "scope": "openid profile {{lrs.oidc-scope-prefix}}admin",
+    "automaticSilentRenew": true,
+    "monitorSession": false,
+    "filterProtocolClaims": false,
+    "extraQueryParams": {
+        "audience": "{{webserver.oidc-audience}}"
+    }
+}

--- a/resources/lrsql/config/prod/default/lrs.edn
+++ b/resources/lrsql/config/prod/default/lrs.edn
@@ -1,11 +1,13 @@
-{:admin-user-default #or [#env LRSQL_ADMIN_USER_DEFAULT nil]
- :admin-pass-default #or [#env LRSQL_ADMIN_PASS_DEFAULT nil]
- :api-key-default    #or [#env LRSQL_API_KEY_DEFAULT nil]
- :api-secret-default #or [#env LRSQL_API_SECRET_DEFAULT nil]
- :stmt-get-default   #long #or [#env LRSQL_STMT_GET_DEFAULT 50]
- :stmt-get-max       #long #or [#env LRSQL_STMT_GET_MAX 50]
- :stmt-url-prefix    "/xapi" ; overriden by ::webserver/url-prefix
- :authority-template #or [#env LRSQL_AUTHORITY_TEMPLATE "config/authority.json.template"]
- :authority-url      #or [#env LRSQL_AUTHORITY_URL "http://example.org"]
- :stmt-retry-limit   #or [#env LRSQL_STMT_RETRY_LIMIT 10]
- :stmt-retry-budget  #or [#env LRSQL_STMT_RETRY_BUDGET 1000]}
+{:admin-user-default      #or [#env LRSQL_ADMIN_USER_DEFAULT nil]
+ :admin-pass-default      #or [#env LRSQL_ADMIN_PASS_DEFAULT nil]
+ :api-key-default         #or [#env LRSQL_API_KEY_DEFAULT nil]
+ :api-secret-default      #or [#env LRSQL_API_SECRET_DEFAULT nil]
+ :stmt-get-default        #long #or [#env LRSQL_STMT_GET_DEFAULT 50]
+ :stmt-get-max            #long #or [#env LRSQL_STMT_GET_MAX 50]
+ :stmt-url-prefix         "/xapi" ; overriden by ::webserver/url-prefix
+ :authority-template      #or [#env LRSQL_AUTHORITY_TEMPLATE "config/authority.json.template"]
+ :authority-url           #or [#env LRSQL_AUTHORITY_URL "http://example.org"]
+ :oidc-authority-template #or [#env LRSQL_OIDC_AUTHORITY_TEMPLATE "config/oidc_authority.json.template"]
+ :oidc-scope-prefix       #or [#env LRSQL_OIDC_SCOPE_PREFIX ""]
+ :stmt-retry-limit        #or [#env LRSQL_STMT_RETRY_LIMIT 10]
+ :stmt-retry-budget       #or [#env LRSQL_STMT_RETRY_BUDGET 1000]}

--- a/resources/lrsql/config/prod/default/webserver.edn
+++ b/resources/lrsql/config/prod/default/webserver.edn
@@ -13,4 +13,7 @@
  :ssl-port          #long #or [#env LRSQL_SSL_PORT 8443]
  :url-prefix        #or [#env LRSQL_URL_PREFIX "/xapi"]
  :enable-admin-ui   #boolean #or [#env LRSQL_ENABLE_ADMIN_UI true]
- :enable-stmt-html  #boolean #or [#env LRSQL_ENABLE_STMT_HTML true]}
+ :enable-stmt-html  #boolean #or [#env LRSQL_ENABLE_STMT_HTML true]
+ :openid-issuer     #env LRSQL_OPENID_ISSUER
+ :openid-config     #env LRSQL_OPENID_CONFIG
+ :jwks-uri          #env LRSQL_JWKS_URI}

--- a/resources/lrsql/config/prod/default/webserver.edn
+++ b/resources/lrsql/config/prod/default/webserver.edn
@@ -18,4 +18,5 @@
  :oidc-audience             #env LRSQL_OIDC_AUDIENCE
  :oidc-client-id            #env LRSQL_OIDC_CLIENT_ID
  :oidc-client-template      #or [#env LRSQL_OIDC_CLIENT_TEMPLATE "config/oidc_client.json.template"]
- :oidc-verify-remote-issuer #or [#env LRSQL_OIDC_VERIFY_REMOTE_ISSUER true]}
+ :oidc-verify-remote-issuer #boolean #or [#env LRSQL_OIDC_VERIFY_REMOTE_ISSUER true]
+ :oidc-enable-local-admin   #boolean #or [#env LRSQL_OIDC_ENABLE_LOCAL_ADMIN false]}

--- a/resources/lrsql/config/prod/default/webserver.edn
+++ b/resources/lrsql/config/prod/default/webserver.edn
@@ -16,4 +16,6 @@
  :enable-stmt-html          #boolean #or [#env LRSQL_ENABLE_STMT_HTML true]
  :oidc-issuer               #env LRSQL_OIDC_ISSUER
  :oidc-audience             #env LRSQL_OIDC_AUDIENCE
+ :oidc-client-id            #env LRSQL_OIDC_CLIENT_ID
+ :oidc-client-template      #or [#env LRSQL_OIDC_CLIENT_TEMPLATE "config/oidc_client.json.template"]
  :oidc-verify-remote-issuer #or [#env LRSQL_OIDC_VERIFY_REMOTE_ISSUER true]}

--- a/resources/lrsql/config/prod/default/webserver.edn
+++ b/resources/lrsql/config/prod/default/webserver.edn
@@ -1,19 +1,19 @@
-{:key-file          #or [#env LRSQL_KEY_FILE "config/keystore.jks"]
- :key-alias         #or [#env LRSQL_KEY_ALIAS "lrsql_keystore"]
- :key-password      #or [#env LRSQL_KEY_PASSWORD "lrsql_pass"]
- :key-pkey-file     #or [#env LRSQL_KEY_PKEY_FILE "config/server.key.pem"]
- :key-cert-chain    #or [#env LRSQL_KEY_CERT_FILE "config/server.crt.pem,config/cacert.pem"]
- :key-enable-selfie #boolean #or [#env LRSQL_KEY_ENABLE_SELFIE true]
- :jwt-exp-time      #long #or [#env LRSQL_JWT_EXP_TIME 3600]
- :jwt-exp-leeway    #long #or [#env LRSQL_JWT_EXP_LEEWAY 1]
- :enable-http       #boolean #or [#env LRSQL_ENABLE_HTTP true]
- :enable-http2      #boolean #or [#env LRSQL_ENABLE_HTTP2 true]
- :http-host         #or [#env LRSQL_HTTP_HOST "0.0.0.0"]
- :http-port         #long #or [#env LRSQL_HTTP_PORT 8080]
- :ssl-port          #long #or [#env LRSQL_SSL_PORT 8443]
- :url-prefix        #or [#env LRSQL_URL_PREFIX "/xapi"]
- :enable-admin-ui   #boolean #or [#env LRSQL_ENABLE_ADMIN_UI true]
- :enable-stmt-html  #boolean #or [#env LRSQL_ENABLE_STMT_HTML true]
- :oidc-issuer       #env LRSQL_OIDC_ISSUER
- :oidc-config       #env LRSQL_OIDC_CONFIG
- :jwks-uri          #env LRSQL_JWKS_URI}
+{:key-file                  #or [#env LRSQL_KEY_FILE "config/keystore.jks"]
+ :key-alias                 #or [#env LRSQL_KEY_ALIAS "lrsql_keystore"]
+ :key-password              #or [#env LRSQL_KEY_PASSWORD "lrsql_pass"]
+ :key-pkey-file             #or [#env LRSQL_KEY_PKEY_FILE "config/server.key.pem"]
+ :key-cert-chain            #or [#env LRSQL_KEY_CERT_FILE "config/server.crt.pem,config/cacert.pem"]
+ :key-enable-selfie         #boolean #or [#env LRSQL_KEY_ENABLE_SELFIE true]
+ :jwt-exp-time              #long #or [#env LRSQL_JWT_EXP_TIME 3600]
+ :jwt-exp-leeway            #long #or [#env LRSQL_JWT_EXP_LEEWAY 1]
+ :enable-http               #boolean #or [#env LRSQL_ENABLE_HTTP true]
+ :enable-http2              #boolean #or [#env LRSQL_ENABLE_HTTP2 true]
+ :http-host                 #or [#env LRSQL_HTTP_HOST "0.0.0.0"]
+ :http-port                 #long #or [#env LRSQL_HTTP_PORT 8080]
+ :ssl-port                  #long #or [#env LRSQL_SSL_PORT 8443]
+ :url-prefix                #or [#env LRSQL_URL_PREFIX "/xapi"]
+ :enable-admin-ui           #boolean #or [#env LRSQL_ENABLE_ADMIN_UI true]
+ :enable-stmt-html          #boolean #or [#env LRSQL_ENABLE_STMT_HTML true]
+ :oidc-issuer               #env LRSQL_OIDC_ISSUER
+ :oidc-audience             #env LRSQL_OIDC_AUDIENCE
+ :oidc-verify-remote-issuer #or [#env LRSQL_OIDC_VERIFY_REMOTE_ISSUER true]}

--- a/resources/lrsql/config/prod/default/webserver.edn
+++ b/resources/lrsql/config/prod/default/webserver.edn
@@ -14,6 +14,6 @@
  :url-prefix        #or [#env LRSQL_URL_PREFIX "/xapi"]
  :enable-admin-ui   #boolean #or [#env LRSQL_ENABLE_ADMIN_UI true]
  :enable-stmt-html  #boolean #or [#env LRSQL_ENABLE_STMT_HTML true]
- :openid-issuer     #env LRSQL_OPENID_ISSUER
- :openid-config     #env LRSQL_OPENID_CONFIG
+ :oidc-issuer       #env LRSQL_OIDC_ISSUER
+ :oidc-config       #env LRSQL_OIDC_CONFIG
  :jwks-uri          #env LRSQL_JWKS_URI}

--- a/resources/lrsql/config/test/default/lrs.edn
+++ b/resources/lrsql/config/test/default/lrs.edn
@@ -1,11 +1,13 @@
-{:admin-user-default "username"
- :admin-pass-default "password"
- :api-key-default    "username"
- :api-secret-default "password"
- :stmt-get-default   50
- :stmt-get-max       50
- :stmt-url-prefix    "/xapi"
- :authority-template "config/authority.json.template"
- :authority-url      "http://example.org"
- :stmt-retry-limit   20
- :stmt-retry-budget  10000}
+{:admin-user-default      "username"
+ :admin-pass-default      "password"
+ :api-key-default         "username"
+ :api-secret-default      "password"
+ :stmt-get-default        50
+ :stmt-get-max            50
+ :stmt-url-prefix         "/xapi"
+ :authority-template      "config/authority.json.template"
+ :authority-url           "http://example.org"
+ :oidc-authority-template "config/oidc_authority.json.template"
+ :oidc-scope-prefix       ""
+ :stmt-retry-limit        20
+ :stmt-retry-budget       10000}

--- a/resources/lrsql/config/test/default/webserver.edn
+++ b/resources/lrsql/config/test/default/webserver.edn
@@ -13,4 +13,5 @@
  :enable-admin-ui           true
  :enable-stmt-html          true
  :oidc-verify-remote-issuer true
- :oidc-client-template      "config/oidc_client.json.template"}
+ :oidc-client-template      "config/oidc_client.json.template"
+ :oidc-enable-local-admin   false}

--- a/resources/lrsql/config/test/default/webserver.edn
+++ b/resources/lrsql/config/test/default/webserver.edn
@@ -12,4 +12,5 @@
  :url-prefix                "/xapi"
  :enable-admin-ui           true
  :enable-stmt-html          true
- :oidc-verify-remote-issuer true}
+ :oidc-verify-remote-issuer true
+ :oidc-client-template      "config/oidc_client.json.template"}

--- a/resources/lrsql/config/test/default/webserver.edn
+++ b/resources/lrsql/config/test/default/webserver.edn
@@ -1,14 +1,15 @@
-{:key-file          "config/keystore.jks"
- :key-alias         "lrsql_keystore"
- :key-password      "lrsql_pass"
- :key-enable-selfie true
- :jwt-exp-time      3600
- :jwt-exp-leeway    1
- :enable-http       true
- :enable-http2      true
- :ssl-port          8443
- :http-host         "0.0.0.0"
- :http-port         8080
- :url-prefix        "/xapi"
- :enable-admin-ui   true
- :enable-stmt-html  true}
+{:key-file                  "config/keystore.jks"
+ :key-alias                 "lrsql_keystore"
+ :key-password              "lrsql_pass"
+ :key-enable-selfie         true
+ :jwt-exp-time              3600
+ :jwt-exp-leeway            1
+ :enable-http               true
+ :enable-http2              true
+ :ssl-port                  8443
+ :http-host                 "0.0.0.0"
+ :http-port                 8080
+ :url-prefix                "/xapi"
+ :enable-admin-ui           true
+ :enable-stmt-html          true
+ :oidc-verify-remote-issuer true}

--- a/resources/lrsql/config/test/oidc/lrs.edn
+++ b/resources/lrsql/config/test/oidc/lrs.edn
@@ -1,0 +1,4 @@
+#merge
+[#include "test/default/lrs.edn"
+ {:oidc-scope-prefix "lrs:"
+  :oidc-client-id    "lrs_admin_ui"}]

--- a/resources/lrsql/config/test/oidc/lrs.edn
+++ b/resources/lrsql/config/test/oidc/lrs.edn
@@ -1,4 +1,3 @@
 #merge
 [#include "test/default/lrs.edn"
- {:oidc-scope-prefix "lrs:"
-  :oidc-client-id    "lrs_admin_ui"}]
+ {:oidc-scope-prefix "lrs:"}]

--- a/resources/lrsql/config/test/oidc/webserver.edn
+++ b/resources/lrsql/config/test/oidc/webserver.edn
@@ -1,0 +1,5 @@
+#merge
+[#include "test/default/webserver.edn"
+ {:oidc-issuer               "http://0.0.0.0:8081/auth/realms/test"
+  :oidc-audience             "http://0.0.0.0:8080"
+  :oidc-verify-remote-issuer true}]

--- a/resources/lrsql/config/test/oidc/webserver.edn
+++ b/resources/lrsql/config/test/oidc/webserver.edn
@@ -2,4 +2,5 @@
 [#include "test/default/webserver.edn"
  {:oidc-issuer               "http://0.0.0.0:8081/auth/realms/test"
   :oidc-audience             "http://0.0.0.0:8080"
+  :oidc-client-id            "lrs_admin_ui"
   :oidc-verify-remote-issuer true}]

--- a/resources/lrsql/config/test/oidc/webserver.edn
+++ b/resources/lrsql/config/test/oidc/webserver.edn
@@ -1,6 +1,5 @@
 #merge
 [#include "test/default/webserver.edn"
- {:oidc-issuer               "http://0.0.0.0:8081/auth/realms/test"
-  :oidc-audience             "http://0.0.0.0:8080"
-  :oidc-client-id            "lrs_admin_ui"
-  :oidc-verify-remote-issuer true}]
+ {:oidc-issuer    "http://0.0.0.0:8081/auth/realms/test"
+  :oidc-audience  "http://0.0.0.0:8080"
+  :oidc-client-id "lrs_admin_ui"}]

--- a/src/db/h2/lrsql/h2/main.clj
+++ b/src/db/h2/lrsql/h2/main.clj
@@ -10,8 +10,10 @@
   "Run an H2-backed LRSQL instance based on the `:test-h2` (if `:persistent?`
    is set to `true`) or `:test-h2-mem` (if not) config profile. For use with
    `clojure -X:db-h2`."
-  [{:keys [persistent?]}]
-  (let [profile (if persistent? :test-h2 :test-h2-mem)]
+  [{:keys [persistent?
+           override-profile]}]
+  (let [profile (or override-profile
+                  (if persistent? :test-h2 :test-h2-mem))]
     (component/start (system/system h2-backend profile))))
 
 (defn -main

--- a/src/db/h2/lrsql/h2/record.clj
+++ b/src/db/h2/lrsql/h2/record.clj
@@ -42,9 +42,9 @@
     (create-admin-account-table! tx)
     (create-credential-table! tx)
     (create-credential-to-scope-table! tx))
-  (-update-all! [_ _tx]
-    ;; No-op for now; add functions if updates are needed
-    nil)
+  (-update-all! [_ tx]
+    (alter-admin-account-passhash-optional! tx)
+    (alter-admin-account-add-openid-issuer! tx))
 
   bp/BackendUtil
   (-txn-retry? [_ ex]
@@ -143,12 +143,16 @@
   bp/AdminAccountBackend
   (-insert-admin-account! [_ tx input]
     (insert-admin-account! tx input))
+  (-insert-admin-account-oidc! [_ tx input]
+    (insert-admin-account-oidc! tx input))
   (-query-all-admin-accounts [_ tx]
     (query-all-accounts tx))
   (-delete-admin-account! [_ tx input]
     (delete-admin-account! tx input))
   (-query-account [_ tx input]
     (query-account tx input))
+  (-query-account-oidc [_ tx input]
+    (query-account-oidc tx input))
   (-query-account-exists [_ tx input]
     (query-account-exists tx input))
 

--- a/src/db/h2/lrsql/h2/sql/ddl.sql
+++ b/src/db/h2/lrsql/h2/sql/ddl.sql
@@ -177,3 +177,17 @@ CREATE TABLE IF NOT EXISTS credential_to_scope (
     REFERENCES lrs_credential(api_key, secret_key)
     ON DELETE CASCADE
 )
+
+/* Migration 2022-02-22-00 - Set admin_account.passhash to optional */
+
+-- :name alter-admin-account-passhash-optional!
+-- :command :execute
+-- :doc Set `admin_account.passhash` to optional.
+ALTER TABLE IF EXISTS admin_account ALTER COLUMN IF EXISTS passhash SET NULL
+
+/* Migration 2022-02-23-00 - Add oidc_issuer to admin_account */
+
+-- :name alter-admin-account-add-openid-issuer!
+-- :command :execute
+-- :doc Add `admin_account.oidc_issuer` to record OIDC identity source.
+ALTER TABLE IF EXISTS admin_account ADD COLUMN IF NOT EXISTS oidc_issuer VARCHAR(255)

--- a/src/db/h2/lrsql/h2/sql/insert.sql
+++ b/src/db/h2/lrsql/h2/sql/insert.sql
@@ -126,6 +126,14 @@ id = :primary-key,
 username = :username,
 passhash = :passhash
 
+-- :name insert-admin-account-oidc!
+-- :command :insert
+-- :doc Insert a new admin account to shadow an OIDC user.
+INSERT INTO admin_account SET
+id = :primary-key,
+username = :username,
+oidc_issuer = :oidc-issuer
+
 /* Credentials */
 
 -- :name insert-credential!

--- a/src/db/h2/lrsql/h2/sql/query.sql
+++ b/src/db/h2/lrsql/h2/sql/query.sql
@@ -217,6 +217,13 @@ WHERE activity_iri = :activity-iri
 SELECT id, passhash FROM admin_account
 WHERE username = :username
 
+-- :name query-account-oidc
+-- :command :query
+-- :result :one
+-- :doc Given an account `username`, return the ID and OIDC issuer, which can be used to verify the OIDC identity.
+SELECT id, oidc_issuer FROM admin_account
+WHERE username = :username
+
 -- :name query-all-accounts
 -- :command :query
 -- :result :many

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -49,9 +49,9 @@
     (create-admin-account-table! tx)
     (create-credential-table! tx)
     (create-credential-to-scope-table! tx))
-  (-update-all! [_ _]
-    ;; No-op for now; add functions if updates are needed
-    nil)
+  (-update-all! [_ tx]
+    (alter-admin-account-passhash-optional! tx)
+    (alter-admin-account-add-openid-issuer! tx))
 
   bp/BackendUtil
   (-txn-retry? [_ ex]
@@ -151,12 +151,16 @@
   bp/AdminAccountBackend
   (-insert-admin-account! [_ tx input]
     (insert-admin-account! tx input))
+  (-insert-admin-account-oidc! [_ tx input]
+    (insert-admin-account-oidc! tx input))
   (-query-all-admin-accounts [_ tx]
     (query-all-accounts tx))
   (-delete-admin-account! [_ tx input]
     (delete-admin-account! tx input))
   (-query-account [_ tx input]
     (query-account tx input))
+  (-query-account-oidc [_ tx input]
+    (query-account-oidc tx input))
   (-query-account-exists [_ tx input]
     (query-account-exists tx input))
 

--- a/src/db/postgres/lrsql/postgres/sql/ddl.sql
+++ b/src/db/postgres/lrsql/postgres/sql/ddl.sql
@@ -239,3 +239,17 @@ CREATE TABLE IF NOT EXISTS credential_to_scope (
     ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS cred_keypair_fk ON credential_to_scope(api_key, secret_key);
+
+/* Migration 2022-02-22-00 - Set admin_account.passhash to optional */
+
+-- :name alter-admin-account-passhash-optional!
+-- :command :execute
+-- :doc Set `admin_account.passhash` to optional.
+ALTER TABLE IF EXISTS admin_account ALTER COLUMN passhash DROP NOT NULL;
+
+/* Migration 2022-02-23-00 - Add oidc_issuer to admin_account */
+
+-- :name alter-admin-account-add-openid-issuer!
+-- :command :execute
+-- :doc Add `admin_account.oidc_issuer` to record OIDC identity source.
+ALTER TABLE IF EXISTS admin_account ADD COLUMN IF NOT EXISTS oidc_issuer VARCHAR(255);

--- a/src/db/postgres/lrsql/postgres/sql/insert.sql
+++ b/src/db/postgres/lrsql/postgres/sql/insert.sql
@@ -119,6 +119,15 @@ INSERT INTO admin_account (
   :primary-key, :username, :passhash
 );
 
+-- :name insert-admin-account-oidc!
+-- :command :insert
+-- :doc Insert a new admin account to shadow an OIDC user.
+INSERT INTO admin_account (
+  id, username, oidc_issuer
+) VALUES (
+  :primary-key, :username, :oidc-issuer
+);
+
 /* Credentials */
 
 -- :name insert-credential!

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -218,6 +218,13 @@ WHERE activity_iri = :activity-iri
 SELECT id, passhash FROM admin_account
 WHERE username = :username;
 
+-- :name query-account-oidc
+-- :command :query
+-- :result :one
+-- :doc Given an account `username`, return the ID and OIDC issuer, which can be used to verify the OIDC identity.
+SELECT id, oidc_issuer FROM admin_account
+WHERE username = :username;
+
 -- :name query-all-accounts
 -- :command :query
 -- :result :many

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -1,5 +1,6 @@
 (ns lrsql.sqlite.record
-  (:require [com.stuartsierra.component :as cmp]
+  (:require [clojure.tools.logging :as log]
+            [com.stuartsierra.component :as cmp]
             [lrsql.backend.protocol :as bp]
             [lrsql.backend.data :as bd]
             [lrsql.init :refer [init-hugsql-adapter!]]
@@ -15,6 +16,23 @@
 (u/def-hugsql-db-fns "lrsql/sqlite/sql/query.sql")
 (u/def-hugsql-db-fns "lrsql/sqlite/sql/update.sql")
 (u/def-hugsql-db-fns "lrsql/sqlite/sql/delete.sql")
+
+;; Schema Update Helpers
+
+#_{:clj-kondo/ignore [:unresolved-symbol]}
+(defn- update-schema-simple!
+  "Given a tx and a db-fn that updates schema to remove CHECK or FOREIGN KEY or NOT NULL constraints or to add, remove, or change default values on a column, wraps it with an update to the schema version and associated checks.
+
+  See https://www.sqlite.org/lang_altertable.html Section 7 part 2"
+  [tx db-fn]
+  (enable-writable-schema! tx)
+  (db-fn tx)
+  (update-schema-version!
+   tx
+   (update (query-schema-version tx)
+           :schema_version inc))
+  (disable-writable-schema! tx)
+  (run-integrity-check tx))
 
 ;; Define record
 
@@ -60,9 +78,13 @@
     (create-admin-account-table! tx)
     (create-credential-table! tx)
     (create-credential-to-scope-table! tx))
-  (-update-all! [_ _]
-    ;; No-op for now; add functions if updates are needed
-    nil)
+  (-update-all! [_ tx]
+    (when (= 1 (:notnull (query-admin-account-passhash-notnull tx)))
+      (update-schema-simple! tx alter-admin-account-passhash-optional!))
+    (when-not (some? (query-admin-account-oidc-issuer-exists tx))
+      (alter-admin-account-add-openid-issuer! tx))
+    (log/infof "sqlite schema_version: %d"
+               (:schema_version (query-schema-version tx))))
 
   bp/BackendUtil
   (-txn-retry? [_ _ex]
@@ -158,12 +180,16 @@
   bp/AdminAccountBackend
   (-insert-admin-account! [_ tx input]
     (insert-admin-account! tx input))
+  (-insert-admin-account-oidc! [_ tx input]
+    (insert-admin-account-oidc! tx input))
   (-query-all-admin-accounts [_ tx]
     (query-all-accounts tx))
   (-delete-admin-account! [_ tx input]
     (delete-admin-account! tx input))
   (-query-account [_ tx input]
     (query-account tx input))
+  (-query-account-oidc [_ tx input]
+    (query-account-oidc tx input))
   (-query-account-exists [_ tx input]
     (query-account-exists tx input))
 

--- a/src/db/sqlite/lrsql/sqlite/sql/insert.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/insert.sql
@@ -119,6 +119,15 @@ INSERT INTO admin_account (
   :primary-key, :username, :passhash
 )
 
+-- :name insert-admin-account-oidc!
+-- :command :insert
+-- :doc Insert a new admin account to shadow an OIDC user.
+INSERT INTO admin_account (
+  id, username, oidc_issuer
+) VALUES (
+  :primary-key, :username, :oidc-issuer
+)
+
 /* Credentials */
 
 -- :name insert-credential!

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -187,6 +187,13 @@ WHERE activity_iri = :activity-iri
 SELECT id, passhash FROM admin_account
 WHERE username = :username
 
+-- :name query-account-oidc
+-- :command :query
+-- :result :one
+-- :doc Given an account `username`, return the ID and OIDC issuer, which can be used to verify the OIDC identity.
+SELECT id, oidc_issuer FROM admin_account
+WHERE username = :username
+
 -- :name query-all-accounts
 -- :command :query
 -- :result :many

--- a/src/main/lrsql/admin/interceptors/oidc.clj
+++ b/src/main/lrsql/admin/interceptors/oidc.clj
@@ -87,3 +87,13 @@
                  [:request :session ::jwt/data :account-id]
                  result))))
         ctx))}))
+
+(defn inject-client-config-interceptor
+  "Inject an OIDC client configuration to be picked up by the admin env
+  interceptor."
+  [client-config]
+  (interceptor
+   {:name ::inject-client-config
+    :enter
+    (fn inject-client-config [ctx]
+      (assoc ctx ::client-config client-config))}))

--- a/src/main/lrsql/admin/interceptors/oidc.clj
+++ b/src/main/lrsql/admin/interceptors/oidc.clj
@@ -1,0 +1,89 @@
+(ns lrsql.admin.interceptors.oidc
+  (:require [io.pedestal.interceptor :refer [interceptor]]
+            [io.pedestal.interceptor.chain :as chain]
+            [lrsql.admin.interceptors.jwt :as jwt]
+            [lrsql.admin.protocol :as adp]
+            [lrsql.util.oidc :as oidc]))
+
+(def validate-oidc-identity
+  "If the context has OIDC token claims, parses out data for OIDC admin identity.
+  If claims are invalid, return a 401. If no clams are present, a no-op."
+  (interceptor
+   {:name ::validate-oidc-identity
+    :enter
+    (fn validate-oidc-identity [{lrs :com.yetanalytics/lrs
+                                 :as ctx}]
+      (if-let [ret (oidc/token-auth-admin-identity
+                    ctx
+                    (get-in lrs [:config :oidc-scope-prefix]))]
+        (if (= ::oidc/unauthorized ret)
+          (assoc (chain/terminate ctx)
+                 :response
+                 {:status 401
+                  :body   {:error "Invalid JWT Claims!"}})
+          (assoc ctx ::admin-identity ret))
+        ;; No OIDC
+        ctx))}))
+
+;; NOTE: Right now there is only one blanket :scope/admin
+;; Currently only applied when OIDC is used.
+(def authorize-oidc-request
+  "If an admin identity is present, check if it has the proper scope(s) for the
+  given action. No-op with no identity."
+  (interceptor
+   {:name ::authorize-oidc-request
+    :enter
+    (fn authorize-oidc-request [{admin-identity ::admin-identity
+                                 :as            ctx}]
+      (if admin-identity
+        (if (oidc/authorize-admin-action ctx admin-identity)
+          ctx
+          (assoc (chain/terminate ctx)
+                 :response
+                 {:status 401
+                  :body   {:error "Unauthorized Admin Action!"}}))
+        ctx))}))
+
+(defn- disable-jwt-interceptors
+  [{queue ::chain/queue :as ctx}]
+  (assoc ctx
+         ::chain/queue
+         (into (empty queue)
+               (remove
+                (comp
+                 #{::jwt/validate-jwt
+                   ::jwt/validate-jwt-account}
+                 :name)
+                queue))))
+
+(def ensure-oidc-identity
+  "If an admin identity is present, create or return the user, validating the
+  issuer. On success, inject the account ID and disable subsequent JWT
+  interceptors. No-op with no identity."
+  (interceptor
+   {:name ::ensure-oidc-identity
+    :enter
+    (fn ensure-oidc-identity [{lrs            :com.yetanalytics/lrs
+                               admin-identity ::admin-identity
+                               :as            ctx}]
+      (if admin-identity
+        (let [{:keys [username
+                      oidc-issuer]} admin-identity
+              {:keys [result]} (adp/-ensure-account-oidc
+                                lrs
+                                username
+                                oidc-issuer)]
+          (if (= :lrsql.admin/oidc-issuer-mismatch-error result)
+            (assoc (chain/terminate ctx)
+                   :response
+                   {:status 401
+                    :body   {:error "OIDC Issuer Mismatch!"}})
+            (-> ctx
+                disable-jwt-interceptors
+                (assoc-in [::jwt/data :account-id] result)
+                ;; NOTE: I do this to follow what is done for native JWT
+                ;; Don't think this app actually uses a session at all?
+                (assoc-in
+                 [:request :session ::jwt/data :account-id]
+                 result))))
+        ctx))}))

--- a/src/main/lrsql/admin/interceptors/oidc.clj
+++ b/src/main/lrsql/admin/interceptors/oidc.clj
@@ -88,12 +88,25 @@
                  result))))
         ctx))}))
 
-(defn inject-client-config-interceptor
-  "Inject an OIDC client configuration to be picked up by the admin env
-  interceptor."
-  [client-config]
+(defn inject-admin-env
+  "Inject OIDC client configuration to merge with the admin env."
+  [admin-env]
   (interceptor
-   {:name ::inject-client-config
+   {:name ::inject-admin-env
     :enter
-    (fn inject-client-config [ctx]
-      (assoc ctx ::client-config client-config))}))
+    (fn inject-admin-env [ctx]
+      (assoc ctx ::admin-env admin-env))}))
+
+(def require-oidc-identity
+  "Verify that there is an OIDC admin identity or return a 401.
+  Used to implement the oidc-enable-local-admin webserver config variable."
+  (interceptor
+   {:name ::require-oidc-identity
+    :enter
+    (fn require-oidc-identity [ctx]
+      (if (::admin-identity ctx)
+        ctx
+        (assoc (chain/terminate ctx)
+               :response
+               {:status 401
+                :body   {:error "Admin authentication requires OIDC!"}})))}))

--- a/src/main/lrsql/admin/interceptors/ui.clj
+++ b/src/main/lrsql/admin/interceptors/ui.clj
@@ -17,13 +17,12 @@
     (fn get-env [ctx]
       (let [{url-prefix          ::i/path-prefix
              enable-stmt-html    ::i/statement-html?
-             ?oidc-client-config ::oidc-i/client-config} ctx]
+             oidc-env            ::oidc-i/admin-env} ctx]
         (assoc ctx
                :response
                {:status 200
                 :body
-                (cond-> {:url-prefix       url-prefix
-                         :enable-stmt-html (some? enable-stmt-html)}
-                  ?oidc-client-config
-                  (assoc :oidc
-                         ?oidc-client-config))})))}))
+                (merge
+                 {:url-prefix       url-prefix
+                  :enable-stmt-html (some? enable-stmt-html)}
+                 oidc-env)})))}))

--- a/src/main/lrsql/admin/interceptors/ui.clj
+++ b/src/main/lrsql/admin/interceptors/ui.clj
@@ -1,7 +1,8 @@
 (ns lrsql.admin.interceptors.ui
   (:require [ring.util.response :as resp]
             [io.pedestal.interceptor :refer [interceptor]]
-            [com.yetanalytics.lrs.pedestal.interceptor :as i]))
+            [com.yetanalytics.lrs.pedestal.interceptor :as i]
+            [lrsql.admin.interceptors.oidc :as oidc-i]))
 
 (defn admin-ui-redirect
   "Handler function to redirect to the admin ui"
@@ -14,8 +15,15 @@
    {:name ::get-env
     :enter
     (fn get-env [ctx]
-      (let [{url-prefix ::i/path-prefix
-             enable-stmt-html ::i/statement-html?} ctx]
-        (assoc ctx :response
-               {:status 200 :body {:url-prefix url-prefix
-                                   :enable-stmt-html (some? enable-stmt-html)}})))}))
+      (let [{url-prefix          ::i/path-prefix
+             enable-stmt-html    ::i/statement-html?
+             ?oidc-client-config ::oidc-i/client-config} ctx]
+        (assoc ctx
+               :response
+               {:status 200
+                :body
+                (cond-> {:url-prefix       url-prefix
+                         :enable-stmt-html (some? enable-stmt-html)}
+                  ?oidc-client-config
+                  (assoc :oidc
+                         ?oidc-client-config))})))}))

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -12,7 +12,9 @@
   (-existing-account? [this account-id]
     "Check that the account with the given ID exists in the account table. Returns a boolean.")
   (-delete-account [this account-id]
-    "Delete the account and all associated creds. Assumes the account has already been authenticated."))
+    "Delete the account and all associated creds. Assumes the account has already been authenticated.")
+  (-ensure-account-oidc [this username oidc-issuer]
+    "Create or verify an existing admin account with the given username and oidc-issuer."))
 
 (defprotocol APIKeyManager
   (-create-api-keys [this account-id scopes]

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -102,15 +102,19 @@
            leeway
            secret
            enable-admin-ui
+           enable-account-routes
            oidc-interceptors
            oidc-ui-interceptors]
-    :or {oidc-interceptors    []
-         oidc-ui-interceptors []}}
+    :or   {oidc-interceptors     []
+           oidc-ui-interceptors  []
+           enable-account-routes true}}
    routes]
-  (let [common-interceptors (make-common-interceptors lrs)
+  (let [common-interceptors      (make-common-interceptors lrs)
         common-interceptors-oidc (into common-interceptors oidc-interceptors)]
     (cset/union routes
-                (admin-account-routes common-interceptors-oidc secret exp leeway)
+                (when enable-account-routes
+                  (admin-account-routes
+                   common-interceptors-oidc secret exp leeway))
                 (admin-cred-routes common-interceptors-oidc secret leeway)
                 (when enable-admin-ui
                   (admin-ui-routes

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -102,8 +102,10 @@
            leeway
            secret
            enable-admin-ui
-           oidc-interceptors]
-    :or {oidc-interceptors []}}
+           oidc-interceptors
+           oidc-ui-interceptors]
+    :or {oidc-interceptors    []
+         oidc-ui-interceptors []}}
    routes]
   (let [common-interceptors (make-common-interceptors lrs)
         common-interceptors-oidc (into common-interceptors oidc-interceptors)]
@@ -111,4 +113,6 @@
                 (admin-account-routes common-interceptors-oidc secret exp leeway)
                 (admin-cred-routes common-interceptors-oidc secret leeway)
                 (when enable-admin-ui
-                  (admin-ui-routes common-interceptors)))))
+                  (admin-ui-routes
+                   (into common-interceptors
+                         oidc-ui-interceptors))))))

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -97,10 +97,18 @@
   "Given a set of routes `routes` for a default LRS implementation,
    add additional routes specific to creating and updating admin
    accounts."
-  [{:keys [lrs exp leeway secret enable-admin-ui]} routes]
-  (let [common-interceptors (make-common-interceptors lrs)]
+  [{:keys [lrs
+           exp
+           leeway
+           secret
+           enable-admin-ui
+           oidc-interceptors]
+    :or {oidc-interceptors []}}
+   routes]
+  (let [common-interceptors (make-common-interceptors lrs)
+        common-interceptors-oidc (into common-interceptors oidc-interceptors)]
     (cset/union routes
-                (admin-account-routes common-interceptors secret exp leeway)
-                (admin-cred-routes common-interceptors secret leeway)
+                (admin-account-routes common-interceptors-oidc secret exp leeway)
+                (admin-cred-routes common-interceptors-oidc secret leeway)
                 (when enable-admin-ui
                   (admin-ui-routes common-interceptors)))))

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -89,9 +89,11 @@
 (defprotocol AdminAccountBackend
   ;; Commands
   (-insert-admin-account! [this tx input])
+  (-insert-admin-account-oidc! [this tx input])
   (-delete-admin-account! [this tx input])
   ;; Queries
   (-query-account [this tx input])
+  (-query-account-oidc [this tx input])
   (-query-account-exists [this tx input])
   (-query-all-admin-accounts [this tx]))
 

--- a/src/main/lrsql/init/oidc.clj
+++ b/src/main/lrsql/init/oidc.clj
@@ -92,11 +92,15 @@
          (oidc-i/decode-interceptor
           (fn [_]
             (fn [kid]
-              (get @keyset-cache kid
-                   ;; If kid is not found in the keyset, attempt refresh and try
-                   ;; again
-                   (get (reset! keyset-cache (jwt/get-keyset jwks-uri))
-                        kid))))
+              (or
+               (get @keyset-cache kid)
+               ;; If kid is not found in the keyset, attempt refresh and try
+               ;; again
+               (do
+                 (log/debugf "key id %s not found in cache, retrieving from %s"
+                             kid jwks-uri)
+                 (get (reset! keyset-cache (jwt/get-keyset jwks-uri))
+                      kid)))))
           :required? false
           :unauthorized
           ;; Allow unknown/nil key IDs through for possible subsequent handling

--- a/src/main/lrsql/init/oidc.clj
+++ b/src/main/lrsql/init/oidc.clj
@@ -1,0 +1,138 @@
+(ns lrsql.init.oidc
+  "OIDC initialization"
+  (:require [clojure.core.memoize :as mem]
+            [clojure.java.io :as io]
+            [clojure.spec.alpha :as s]
+            [com.yetanalytics.pedestal-oidc.discovery :as disco]
+            [com.yetanalytics.pedestal-oidc.interceptor :as oidc-i]
+            [com.yetanalytics.pedestal-oidc.jwt :as jwt]
+            [io.pedestal.interceptor :as i]
+            [lrsql.init.authority :as authority]
+            [lrsql.spec.config :as config]
+            [lrsql.spec.oidc :as oidc]
+            [selmer.parser :as selm-parser]
+            xapi-schema.spec)
+  (:import [java.io File]))
+
+(defn- select-config
+  [config]
+  (select-keys
+   config
+   [:oidc-issuer
+    :oidc-config
+    :jwks-uri]))
+
+(def partial-config-spec
+  (s/keys :opt-un [::config/oidc-issuer
+                   ::config/oidc-config
+                   ::config/jwks-uri]))
+
+(s/fdef get-configuration
+  :args (s/cat :config partial-config-spec)
+  :ret (s/nilable map?))
+
+(defn get-configuration
+  "Given webserver config, return an openid configuration if one is specified
+  via :oidc-issuer or :oidc-config."
+  [{:keys [oidc-issuer
+           oidc-config] :as config}]
+  (try
+    (when-let [config-uri (or oidc-config
+                              (and oidc-issuer
+                                   (disco/issuer->config-uri oidc-issuer)))]
+      (disco/get-openid-config config-uri))
+    (catch AssertionError ae
+      (ex-info "Invalid OIDC Config"
+               {:type        ::invalid-config
+                :oidc-config (select-config config)}
+               ae))))
+
+(s/fdef resource-interceptors
+  :args (s/cat :config partial-config-spec)
+  :ret (s/every i/interceptor?))
+
+(defn resource-interceptors
+  "Given a webserver config, return a (possibly empty) vector of interceptors.
+  Interceptors will enable token auth against OIDC"
+  [{:keys [jwks-uri] :as config}]
+  (try
+    (if-let [jwks-uri (or jwks-uri
+                          (some-> config
+                                  get-configuration
+                                  (get "jwks_uri")))]
+      (let [keyset-cache (atom (jwt/get-keyset jwks-uri))]
+        [;; Decode/Unsign tokens
+         (oidc-i/decode-interceptor
+          (fn [_]
+            (fn [kid]
+              (get @keyset-cache kid
+                   ;; If kid is not found in the keyset, attempt refresh and try
+                   ;; again
+                   (get (reset! keyset-cache (jwt/get-keyset jwks-uri))
+                        kid))))
+          :required? false)
+         ;; This is a vector in case we need additional interceptors. At present
+         ;; we do not.
+         ])
+      ;; If no config, don't return any
+      [])
+    (catch Exception ex
+      (throw
+       (ex-info
+        "OIDC Initialization Failure"
+        {:type        ::init-failure
+         :oidc-config (select-config config)}
+        ex)))))
+
+;; Authority
+
+(s/fdef resolve-authority-claims
+  :args (s/cat :claims ::oidc/claims)
+  :ret ::oidc/authority-claims)
+
+(defn resolve-authority-claims
+  "Given claims from an Access Token derive and add:
+  * :lrsql/resolved-client-id - a reliable client id to use in the authority
+    template."
+  [{:keys [aud
+           azp
+           client_id]
+    :as claims}]
+  (assoc claims
+         :lrsql/resolved-client-id
+         (or client_id
+             azp
+             (if (string? aud)
+               aud
+               (first aud)))))
+
+(s/fdef make-authority-fn
+  :args (s/cat :template-path (s/nilable string?)
+               :threshold (s/? pos-int?))
+  :ret (s/fspec
+        :args (s/cat :context-map ::oidc/claims)
+        :ret :statement/authority))
+
+(def default-authority-fn
+  "The default precompiled function to render authority"
+  (-> "lrsql/config/oidc_authority.json.template"
+      io/resource
+      selm-parser/parse*
+      authority/make-authority-fn*))
+
+(defn make-authority-fn
+  "Like authority/make-authority-fn but produces a function expecting OIDC
+  claims."
+  [template-path & [threshold]]
+  (let [^File f
+        (io/file template-path)
+        authority-fn
+        (if (and f (.exists f))
+          ;; Override template supplied - use that
+          (let [template (selm-parser/parse* f)]
+            (authority/make-authority-fn* template))
+          ;; Override template not supplied - fall back to default
+          default-authority-fn)]
+    (mem/lru (comp authority-fn
+                   resolve-authority-claims)
+             :lru/threshold (or threshold 512))))

--- a/src/main/lrsql/input/admin.clj
+++ b/src/main/lrsql/input/admin.clj
@@ -16,6 +16,28 @@
    :username    username
    :passhash    (adu/hash-password password)})
 
+(s/fdef ensure-admin-oidc-input
+  :args (s/cat :username ::ads/username
+               :oidc-issuer :lrsql.spec.admin.input/oidc-issuer)
+  :ret ads/ensure-admin-oidc-input-spec)
+
+(defn ensure-admin-oidc-input
+  "Given `username` and `oidc-issuer`, construct the input param map for
+  `ensure-admin-oidc!`"
+  [username oidc-issuer]
+  {:username    username
+   :oidc-issuer oidc-issuer})
+
+(s/fdef insert-admin-oidc-input
+  :args (s/cat :ensure-input ads/ensure-admin-oidc-input-spec)
+  :ret ads/insert-admin-oidc-input-spec)
+
+(defn insert-admin-oidc-input
+  "Given an input from ensure-admin-oidc-input, add a primary key for use in
+  `insert-admin-oidc!`"
+  [ensure-input]
+  (u/add-primary-key ensure-input))
+
 (s/fdef delete-admin-input
   :args (s/cat :account-id ::ads/account-id)
   :ret ads/admin-id-input-spec)

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -1,6 +1,7 @@
 (ns lrsql.ops.command.admin
   (:require [clojure.spec.alpha :as s]
             [lrsql.backend.protocol :as bp]
+            [lrsql.input.admin :as admin-i]
             [lrsql.spec.common :refer [transaction?]]
             [lrsql.spec.admin :as ads]))
 
@@ -44,3 +45,31 @@
       (bp/-delete-admin-account! bk tx input)
       {:result (:account-id input)})
     {:result :lrsql.admin/missing-account-error}))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Ensure Admin Account from OIDC
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(s/fdef ensure-admin-oidc!
+  :args (s/cat :bk ads/admin-backend?
+               :tx transaction?
+               :input ads/ensure-admin-oidc-input-spec)
+  :ret ads/ensure-admin-ret-spec)
+
+(defn ensure-admin-oidc!
+  "Create a new admin with OIDC issuer or verify issuer of an existing admin.
+  Returns a map where `:result` is the account ID."
+  [bk tx {:keys [username oidc-issuer]
+          :as   ensure-input}]
+  (if-let [{extant-issuer :oidc_issuer ;; TODO: is not coerced to kebab?
+            id            :id} (bp/-query-account-oidc
+                                bk tx {:username username})]
+    {:result
+     (if (= oidc-issuer extant-issuer)
+       id
+       :lrsql.admin/oidc-issuer-mismatch-error)}
+    (let [{:keys [primary-key]
+           :as   insert-input} (admin-i/insert-admin-oidc-input
+                                ensure-input)]
+      (bp/-insert-admin-account-oidc! bk tx insert-input)
+      {:result primary-key})))

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -61,7 +61,7 @@
   Returns a map where `:result` is the account ID."
   [bk tx {:keys [username oidc-issuer]
           :as   ensure-input}]
-  (if-let [{extant-issuer :oidc_issuer ;; TODO: is not coerced to kebab?
+  (if-let [{extant-issuer :oidc_issuer
             id            :id} (bp/-query-account-oidc
                                 bk tx {:username username})]
     {:result

--- a/src/main/lrsql/ops/query/admin.clj
+++ b/src/main/lrsql/ops/query/admin.clj
@@ -43,7 +43,7 @@
     (cond
       (nil? res)
       {:result :lrsql.admin/missing-account-error}
-      (au/valid-password? (:password input) (:passhash res))
+      (and (:passhash res) (au/valid-password? (:password input) (:passhash res)))
       {:result (:account-id res)}
       :else
       {:result :lrsql.admin/invalid-password-error})))

--- a/src/main/lrsql/spec/admin.clj
+++ b/src/main/lrsql/spec/admin.clj
@@ -19,8 +19,16 @@
 (s/def ::account-id ::c/primary-key)
 (s/def ::username string?)
 (s/def ::password string?)
-(s/def ::passhash string?) ; format may vary by password lib
+;; passhash format may vary by password lib
+;; Input passhash is not nilable
+(s/def :lrsql.spec.admin.input/passhash string?)
+;; Ret passhash (from SQL) is nilable
+(s/def :lrsql.spec.admin.ret/passhash (s/nilable string?))
 (s/def ::uuid ::xs/uuid)
+;; Likewise, OIDC issuer is not nilable for inputs
+(s/def :lrsql.spec.admin.input/oidc-issuer string?)
+;; But is for ret
+(s/def :lrsql.spec.admin.ret/oidc-issuer (s/nilable string?))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Inputs
@@ -36,7 +44,16 @@
 (def insert-admin-input-spec
   (s/keys :req-un [::c/primary-key
                    ::username
-                   ::passhash]))
+                   :lrsql.spec.admin.input/passhash]))
+
+(def ensure-admin-oidc-input-spec
+  (s/keys :req-un [:lrsql.spec.admin.input/oidc-issuer
+                   ::username]))
+
+(def insert-admin-oidc-input-spec
+  (s/keys :req-un [::c/primary-key
+                   ::username
+                   :lrsql.spec.admin.input/oidc-issuer]))
 
 (def query-validate-admin-input-spec
   (s/keys :req-un [::username
@@ -57,6 +74,14 @@
 (def insert-admin-ret-spec
   (s/keys :req-un [:lrsql.spec.admin.insert/result]))
 
+(s/def :lrsql.spec.admin.ensure/result
+  (s/nonconforming
+   (s/or :success uuid?
+         :failure #{:lrsql.admin/oidc-issuer-mismatch-error})))
+
+(def ensure-admin-ret-spec
+  (s/keys :req-un [:lrsql.spec.admin.ensure/result]))
+
 (s/def :lrsql.spec.admin.delete/result
   (s/nonconforming
    (s/or :success uuid?
@@ -73,7 +98,7 @@
 
 (def query-admin-ret-spec
   (s/keys :req-un [::account-id
-                   ::passhash]))
+                   :lrsql.spec.admin.ret/passhash]))
 
 (def query-all-admin-accounts-ret-spec
   (s/every (s/keys :req-un [::account-id

--- a/src/main/lrsql/spec/config.clj
+++ b/src/main/lrsql/spec/config.clj
@@ -148,6 +148,10 @@
 (s/def ::enable-admin-ui boolean?)
 (s/def ::enable-stmt-html boolean?)
 
+(s/def ::openid-issuer string?)
+(s/def ::openid-config string?)
+(s/def ::jwks-uri string?)
+
 (s/def ::webserver
   (s/keys :req-un [::http-host
                    ::http-port
@@ -164,7 +168,10 @@
                    ::enable-stmt-html]
           :opt-un [::key-file
                    ::key-pkey-file
-                   ::key-cert-chain]))
+                   ::key-cert-chain
+                   ::openid-issuer
+                   ::openid-config
+                   ::jwks-uri]))
 
 (def config-spec
   (s/keys :req-un [::connection

--- a/src/main/lrsql/spec/config.clj
+++ b/src/main/lrsql/spec/config.clj
@@ -159,6 +159,8 @@
 
 (s/def ::oidc-issuer (s/nilable string?))
 (s/def ::oidc-audience (s/nilable string?))
+(s/def ::oidc-client-id (s/nilable string?))
+(s/def ::oidc-client-template string?)
 (s/def ::oidc-verify-remote-issuer boolean?)
 
 (s/def ::webserver
@@ -175,12 +177,14 @@
                    ::jwt-exp-leeway
                    ::enable-admin-ui
                    ::enable-stmt-html
-                   ::oidc-verify-remote-issuer]
+                   ::oidc-verify-remote-issuer
+                   ::oidc-client-template]
           :opt-un [::key-file
                    ::key-pkey-file
                    ::key-cert-chain
                    ::oidc-issuer
-                   ::oidc-audience]))
+                   ::oidc-audience
+                   ::oidc-client-id]))
 
 (def config-spec
   (s/keys :req-un [::connection

--- a/src/main/lrsql/spec/config.clj
+++ b/src/main/lrsql/spec/config.clj
@@ -113,6 +113,8 @@
 
 (s/def ::authority-template string?)
 (s/def ::authority-url ::xs/irl)
+(s/def ::oidc-authority-template string?)
+(s/def ::oidc-scope-prefix string?)
 
 (s/def ::lrs
   (s/and (s/conformer u/remove-nil-vals)
@@ -121,7 +123,9 @@
                           ::stmt-get-max
                           ::stmt-url-prefix
                           ::authority-template
-                          ::authority-url]
+                          ::authority-url
+                          ::oidc-authority-template
+                          ::oidc-scope-prefix]
                  :opt-un [::admin-user-default
                           ::admin-pass-default
                           ::api-key-default
@@ -148,9 +152,9 @@
 (s/def ::enable-admin-ui boolean?)
 (s/def ::enable-stmt-html boolean?)
 
-(s/def ::openid-issuer string?)
-(s/def ::openid-config string?)
-(s/def ::jwks-uri string?)
+(s/def ::oidc-issuer (s/nilable string?))
+(s/def ::oidc-config (s/nilable string?))
+(s/def ::jwks-uri (s/nilable string?))
 
 (s/def ::webserver
   (s/keys :req-un [::http-host
@@ -169,8 +173,8 @@
           :opt-un [::key-file
                    ::key-pkey-file
                    ::key-cert-chain
-                   ::openid-issuer
-                   ::openid-config
+                   ::oidc-issuer
+                   ::oidc-config
                    ::jwks-uri]))
 
 (def config-spec

--- a/src/main/lrsql/spec/config.clj
+++ b/src/main/lrsql/spec/config.clj
@@ -162,6 +162,7 @@
 (s/def ::oidc-client-id (s/nilable string?))
 (s/def ::oidc-client-template string?)
 (s/def ::oidc-verify-remote-issuer boolean?)
+(s/def ::oidc-enable-local-admin boolean?)
 
 (s/def ::webserver
   (s/keys :req-un [::http-host
@@ -178,7 +179,8 @@
                    ::enable-admin-ui
                    ::enable-stmt-html
                    ::oidc-verify-remote-issuer
-                   ::oidc-client-template]
+                   ::oidc-client-template
+                   ::oidc-enable-local-admin]
           :opt-un [::key-file
                    ::key-pkey-file
                    ::key-cert-chain

--- a/src/main/lrsql/spec/config.clj
+++ b/src/main/lrsql/spec/config.clj
@@ -158,8 +158,8 @@
 (s/def ::enable-stmt-html boolean?)
 
 (s/def ::oidc-issuer (s/nilable string?))
-(s/def ::oidc-config (s/nilable string?))
-(s/def ::jwks-uri (s/nilable string?))
+(s/def ::oidc-audience (s/nilable string?))
+(s/def ::oidc-verify-remote-issuer boolean?)
 
 (s/def ::webserver
   (s/keys :req-un [::http-host
@@ -174,13 +174,13 @@
                    ::jwt-exp-time
                    ::jwt-exp-leeway
                    ::enable-admin-ui
-                   ::enable-stmt-html]
+                   ::enable-stmt-html
+                   ::oidc-verify-remote-issuer]
           :opt-un [::key-file
                    ::key-pkey-file
                    ::key-cert-chain
                    ::oidc-issuer
-                   ::oidc-config
-                   ::jwks-uri]))
+                   ::oidc-audience]))
 
 (def config-spec
   (s/keys :req-un [::connection

--- a/src/main/lrsql/spec/oidc.clj
+++ b/src/main/lrsql/spec/oidc.clj
@@ -1,0 +1,44 @@
+(ns lrsql.spec.oidc
+  (:require [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as sgen]))
+
+;; Claims https://www.iana.org/assignments/jwt/jwt.xhtml
+
+(s/def ::scope
+  (s/with-gen string?
+    (fn []
+      (sgen/return
+       "openid all"))))
+
+(s/def ::iss string?)
+(s/def ::sub string?)
+(s/def ::aud
+  (s/or :scalar string?
+        :array (s/every string? :min-count 1)))
+
+(s/def ::azp string?)
+(s/def ::client_id string?)
+
+(s/def ::claims
+  (s/with-gen
+    (s/keys :req-un [::scope
+                     ::iss
+                     ::sub
+                     ::aud]
+            :opt-un [::azp
+                     ::client_id])
+    (fn []
+      (sgen/return {:scope "openid all"
+                    :iss   "http://example.com/realm"
+                    :aud   "someapp"
+                    :sub   "1234"}))))
+
+;; This is a special namespaced keyword with a single segment (so we don't need
+;; to escape the dots) for inclusion in the OIDC authority template
+;; https://github.com/yogthos/Selmer#namespaced-keys
+(s/def :lrsql/resolved-client-id string?)
+
+(s/def ::authority-claims
+  (s/merge
+   (s/keys :req [:lrsql/resolved-client-id])
+   ::claims))

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -5,7 +5,8 @@
             [next.jdbc :as jdbc]
             [com.yetanalytics.lrs.protocol :as lrsp]
             [lrsql.admin.protocol :as adp]
-            [lrsql.init :as init]
+            [lrsql.init      :as init]
+            [lrsql.init.oidc :as oidc-init]
             [lrsql.backend.protocol :as bp]
             [lrsql.input.actor     :as agent-input]
             [lrsql.input.activity  :as activity-input]
@@ -26,6 +27,7 @@
             [lrsql.spec.config :as cs]
             [lrsql.system.util :refer [assert-config]]
             [lrsql.util.auth      :as auth-util]
+            [lrsql.util.oidc      :as oidc-util]
             [lrsql.util.statement :as stmt-util]
             [lrsql.init.authority   :refer [make-authority-fn]]
             [lrsql.util.concurrency :refer [with-rerunable-txn]])
@@ -38,7 +40,11 @@
       :connection
       :conn-pool))
 
-(defrecord LearningRecordStore [connection backend config authority-fn]
+(defrecord LearningRecordStore [connection
+                                backend
+                                config
+                                authority-fn
+                                oidc-authority-fn]
   cmp/Lifecycle
   (start
     [lrs]
@@ -46,14 +52,16 @@
     (let [;; Destructuring
           {conn :conn-pool}
           connection
-          {uname   :admin-user-default
-           pass    :admin-pass-default
-           api-key :api-key-default
-           srt-key :api-secret-default
-           auth-tp :authority-template}
+          {uname        :admin-user-default
+           pass         :admin-pass-default
+           api-key      :api-key-default
+           srt-key      :api-secret-default
+           auth-tp      :authority-template
+           oidc-auth-tp :oidc-authority-template}
           config
           ;; Authority function
-          auth-fn (make-authority-fn auth-tp)]
+          auth-fn      (make-authority-fn auth-tp)
+          oidc-auth-fn (oidc-init/make-authority-fn oidc-auth-tp)]
       ;; Combine all init ops into a single txn, since the user would expect
       ;; such actions to happen as a single unit. If init-backend! succeeds
       ;; but insert-default-creds! fails, this would constitute a partial
@@ -62,7 +70,10 @@
         (init/init-backend! backend tx)
         (init/insert-default-creds! backend tx uname pass api-key srt-key)
         (log/info "Starting new LRS")
-        (assoc lrs :connection connection :authority-fn auth-fn))))
+        (assoc lrs
+               :connection connection
+               :authority-fn auth-fn
+               :oidc-authority-fn oidc-auth-fn))))
   (stop
     [lrs]
     (log/info "Stopping LRS...")
@@ -196,18 +207,26 @@
   lrsp/LRSAuth
   (-authenticate
     [lrs ctx]
-    (let [conn   (lrs-conn lrs)
-          header (get-in ctx [:request :headers "authorization"])]
-      (if-some [key-pair (auth-util/header->key-pair header)]
-        (let [{:keys [authority-url]} config
-              input (auth-input/query-credential-scopes-input
-                     authority-fn
-                     authority-url
-                     key-pair)]
-          (jdbc/with-transaction [tx conn]
-            (auth-q/query-credential-scopes backend tx input)))
-        ;; No authorization header = no entry
-        {:result :com.yetanalytics.lrs.auth/unauthorized})))
+    (or
+     ;; Token Authentication
+     (let [{:keys [oidc-scope-prefix]} config]
+       (oidc-util/token-auth-identity
+        ctx
+        oidc-authority-fn
+        oidc-scope-prefix))
+     ;; Basic Authentication
+     (let [conn   (lrs-conn lrs)
+           header (get-in ctx [:request :headers "authorization"])]
+       (if-some [key-pair (auth-util/header->key-pair header)]
+         (let [{:keys [authority-url]} config
+               input (auth-input/query-credential-scopes-input
+                      authority-fn
+                      authority-url
+                      key-pair)]
+           (jdbc/with-transaction [tx conn]
+             (auth-q/query-credential-scopes backend tx input)))
+         ;; No authorization header = no entry
+         {:result :com.yetanalytics.lrs.auth/unauthorized}))))
   (-authorize
     [_lrs ctx auth-identity]
     (auth-util/authorize-action ctx auth-identity))
@@ -265,7 +284,7 @@
       (jdbc/with-transaction [tx conn]
         (auth-q/query-credentials backend tx input))))
   (-update-api-keys
-   ;; TODO: Verify the key pair is associated with the account ID
+    ;; TODO: Verify the key pair is associated with the account ID
     [this _account-id api-key secret-key scopes]
     (let [conn  (lrs-conn this)
           input (auth-input/query-credential-scopes*-input api-key secret-key)]

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -261,6 +261,12 @@
           input (admin-input/delete-admin-input account-id)]
       (jdbc/with-transaction [tx conn]
         (admin-cmd/delete-admin! backend tx input))))
+  (-ensure-account-oidc
+    [this username oidc-issuer]
+    (let [conn  (lrs-conn this)
+          input (admin-input/ensure-admin-oidc-input username oidc-issuer)]
+      (jdbc/with-transaction [tx conn]
+        (admin-cmd/ensure-admin-oidc! backend tx input))))
 
   adp/APIKeyManager
   (-create-api-keys

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -32,11 +32,12 @@
         ;; The private key is used as the JWT symmetric secret
         {:keys [keystore
                 private-key]} (cu/init-keystore config)
-        ;; OIDC Interceptors
-        {oidc-resource-interceptors :resource-interceptors
-         oidc-admin-interceptors    :admin-interceptors
-         oidc-admin-ui-interceptors :admin-ui-interceptors}
-        (oidc/interceptors
+        ;; OIDC Interceptors & derived settings
+        {{oidc-resource-interceptors :resource-interceptors
+          oidc-admin-interceptors    :admin-interceptors
+          oidc-admin-ui-interceptors :admin-ui-interceptors} :interceptors
+         :keys                                               [enable-local-admin]}
+        (oidc/init
          config
          (:config lrs))
 
@@ -49,13 +50,15 @@
                                          [i/error-interceptor
                                           (handle-json-parse-exn)]
                                          oidc-resource-interceptors)})
-             (add-admin-routes {:lrs                  lrs
-                                :exp                  jwt-exp
-                                :leeway               jwt-lwy
-                                :secret               private-key
-                                :enable-admin-ui      enable-admin-ui
-                                :oidc-interceptors    oidc-admin-interceptors
-                                :oidc-ui-interceptors oidc-admin-ui-interceptors}))]
+             (add-admin-routes
+              {:lrs                   lrs
+               :exp                   jwt-exp
+               :leeway                jwt-lwy
+               :secret                private-key
+               :enable-admin-ui       enable-admin-ui
+               :enable-account-routes enable-local-admin
+               :oidc-interceptors     oidc-admin-interceptors
+               :oidc-ui-interceptors  oidc-admin-ui-interceptors}))]
     {:env                      :prod
      ::http/routes             routes
      ;; only serve assets if the admin ui is enabled

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -6,6 +6,7 @@
             [com.yetanalytics.lrs.pedestal.routes :refer [build]]
             [com.yetanalytics.lrs.pedestal.interceptor :as i]
             [lrsql.admin.routes :refer [add-admin-routes]]
+            [lrsql.init.oidc :as oidc]
             [lrsql.spec.config :as cs]
             [lrsql.system.util :refer [assert-config redact-config-vars]]
             [lrsql.util.cert :as cu]
@@ -35,8 +36,11 @@
         ;; start to all lrs routes
         routes (->> (build {:lrs               lrs
                             :path-prefix       url-prefix
-                            :wrap-interceptors [i/error-interceptor
-                                                (handle-json-parse-exn)]})
+                            :wrap-interceptors (into
+                                                [i/error-interceptor
+                                                 (handle-json-parse-exn)]
+                                                (oidc/resource-interceptors
+                                                 config))})
                     (add-admin-routes {:lrs    lrs
                                        :exp    jwt-exp
                                        :leeway jwt-lwy

--- a/src/main/lrsql/util.clj
+++ b/src/main/lrsql/util.clj
@@ -10,7 +10,7 @@
             [com.yetanalytics.squuid :as squuid]
             [com.yetanalytics.lrs.xapi.document :refer [json-bytes-gen-fn]]
             [com.yetanalytics.lrs.xapi.statements.timestamp :refer [normalize]]
-            [lrsql.spec.common :refer [instant-spec]])
+            [lrsql.spec.common :as cs :refer [instant-spec]])
   (:import [java.util UUID]
            [java.time Instant]
            [java.io StringReader PushbackReader ByteArrayOutputStream]))
@@ -168,6 +168,15 @@
   "Convert a UUID into a string."
   [uuid]
   (clj-uuid/to-string uuid))
+
+(s/fdef add-primary-key
+  :args (s/cat :input map?)
+  :ret (s/keys :req-un [::cs/primary-key]))
+
+(defn add-primary-key
+  "Add a :primary-key squuid to an input map."
+  [input]
+  (assoc input :primary-key (generate-squuid)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; JSON

--- a/src/main/lrsql/util/oidc.clj
+++ b/src/main/lrsql/util/oidc.clj
@@ -1,19 +1,90 @@
 (ns lrsql.util.oidc
   "OpenID Connect Utilities"
   (:require [clojure.spec.alpha :as s]
-            [com.yetanalytics.pedestal-oidc.discovery :as disco]
-            [lrsql.spec.config :as config]))
+            [clojure.string :as cs]
+            [clojure.tools.logging :as log]
+            [com.yetanalytics.lrs.auth :as lrs-auth]
+            [lrsql.init.authority :as authority]
+            [lrsql.spec.config :as config]
+            [lrsql.util.auth :as auth])
+  (:import [java.io File]))
 
-(s/fdef get-configuration
-  :args (s/cat :webserver ::config/webserver)
-  :ret (s/nilable map?))
+(defn- get-scope-map*
+  [prefix]
+  (reduce-kv
+   (fn [m k v]
+     (assoc
+      m
+      (str prefix k)
+      v))
+   {}
+   auth/scope-str-kw-map))
 
-(defn get-configuration
-  "Given webserver config, return an openid configuration if one is specified
-  via :openid-issuer or :openid-config."
-  [{:keys [openid-issuer
-           openid-config]}]
-  (when-let [config-uri (or openid-config
-                            (and openid-issuer
-                                 (disco/issuer->config-uri openid-issuer)))]
-    (disco/get-openid-config config-uri)))
+(def get-scope-map
+  (memoize get-scope-map*))
+
+(s/def ::scope-prefix ::config/oidc-scope-prefix)
+
+(s/fdef parse-scope-claim
+  :args (s/cat :scope-str string?
+               :kwargs (s/keys*
+                        :opt-un [::scope-prefix]))
+  :ret (s/every ::auth/scope))
+
+(defn parse-scope-claim
+  "Parse the scope claim and match to lrsql scope keywords, prepending
+  any scope-prefix provided before matching"
+  [scope-str
+   & {:keys [scope-prefix]
+      :or   {scope-prefix ""}}]
+  (keep (get-scope-map scope-prefix)
+        (cs/split scope-str #"\s")))
+
+(s/fdef token-auth-identity
+  :args (s/cat :ctx map?
+               :authority-fn fn?
+               :scope-prefix ::config/oidc-scope-prefix)
+  :ret (s/nilable
+        ::lrs-auth/identity))
+
+(defn token-auth-identity
+  "For the given context, return a valid auth identity from token claims. If no
+  claims are present, return nil.
+  args:
+    ctx - Pedestal context.
+    authority-fn - A function that accepts claims and returns an authority.
+    scope-prefix - Prefix to add to expected scopes.
+  "
+  [ctx
+   authority-fn
+   scope-prefix]
+  (when-let [token (:com.yetanalytics.pedestal-oidc/token ctx)]
+    (let [{:keys [scope]
+           :as   claims} (get-in ctx
+                               [:request
+                                :com.yetanalytics.pedestal-oidc/claims])]
+      {:result
+       (if-let [scopes (some-> scope
+                               (parse-scope-claim
+                                :scope-prefix scope-prefix)
+                               not-empty
+                               (->> (into #{})))]
+         (try
+           {:scopes scopes
+            :prefix ""
+            :auth   {:token token}
+            :agent  (authority-fn claims)}
+           (catch clojure.lang.ExceptionInfo ex
+             (let [{ex-type :type} (ex-data ex)]
+               (case ex-type
+                 ::authority/unknown-variable
+                 (do
+                   (log/warn "Could not render authority for OIDC claims")
+                   :com.yetanalytics.lrs.auth/unauthorized)
+                 ::authority/invalid-json
+                 (do
+                   (log/warn "Could not render authority for OIDC, json invalid")
+                   :com.yetanalytics.lrs.auth/unauthorized)
+                 (throw ex)))))
+         ;; no valid scopes, can't do anything
+         :com.yetanalytics.lrs.auth/unauthorized)})))

--- a/src/main/lrsql/util/oidc.clj
+++ b/src/main/lrsql/util/oidc.clj
@@ -1,0 +1,19 @@
+(ns lrsql.util.oidc
+  "OpenID Connect Utilities"
+  (:require [clojure.spec.alpha :as s]
+            [com.yetanalytics.pedestal-oidc.discovery :as disco]
+            [lrsql.spec.config :as config]))
+
+(s/fdef get-configuration
+  :args (s/cat :webserver ::config/webserver)
+  :ret (s/nilable map?))
+
+(defn get-configuration
+  "Given webserver config, return an openid configuration if one is specified
+  via :openid-issuer or :openid-config."
+  [{:keys [openid-issuer
+           openid-config]}]
+  (when-let [config-uri (or openid-config
+                            (and openid-issuer
+                                 (disco/issuer->config-uri openid-issuer)))]
+    (disco/get-openid-config config-uri)))

--- a/src/test/lrsql/admin/protocol_test.clj
+++ b/src/test/lrsql/admin/protocol_test.clj
@@ -62,6 +62,21 @@
         (is (-> (adp/-authenticate-account lrs test-username test-password)
                 :result
                 (= :lrsql.admin/missing-account-error)))))
+    (testing "Admin account OIDC bootstrap"
+      (let [username    "oidcsub"
+            oidc-issuer "https://example.com/realm"
+            bad-issuer  "https://impostor.com/realm"]
+        ;; Creates if does not exist
+        (is (-> (adp/-ensure-account-oidc lrs username oidc-issuer)
+                :result
+                uuid?))
+        ;; Idempotent
+        (is (= (adp/-ensure-account-oidc lrs username oidc-issuer)
+               (adp/-ensure-account-oidc lrs username oidc-issuer)))
+        ;; OIDC issuer must match
+        (is (-> (adp/-ensure-account-oidc lrs username bad-issuer)
+                :result
+                (= :lrsql.admin/oidc-issuer-mismatch-error)))))
     (component/stop sys')))
 
 ;; TODO: Add tests for creds with no explicit scopes, once

--- a/src/test/lrsql/init/oidc_test.clj
+++ b/src/test/lrsql/init/oidc_test.clj
@@ -8,12 +8,8 @@
   (testing "Slurps configuration"
     (testing "From issuer"
       (is (= "https://server.example.com"
-             (-> {:oidc-issuer "dev-resources/oidc"}
-                 get-configuration
-                 (get "issuer")))))
-    (testing "From custom config loc"
-      (is (= "https://server.example.com"
-             (-> {:oidc-config "dev-resources/oidc/.well-known/openid-configuration"}
+             (-> {:oidc-issuer "dev-resources/oidc"
+                  :oidc-verify-remote-issuer false}
                  get-configuration
                  (get "issuer")))))))
 

--- a/src/test/lrsql/init/oidc_test.clj
+++ b/src/test/lrsql/init/oidc_test.clj
@@ -1,0 +1,62 @@
+(ns lrsql.init.oidc-test
+  (:require [clojure.test    :refer [deftest is testing are]]
+            [lrsql.init.oidc :refer [get-configuration
+                                     resolve-authority-claims
+                                     make-authority-fn]]))
+
+(deftest get-configuration-test
+  (testing "Slurps configuration"
+    (testing "From issuer"
+      (is (= "https://server.example.com"
+             (-> {:oidc-issuer "dev-resources/oidc"}
+                 get-configuration
+                 (get "issuer")))))
+    (testing "From custom config loc"
+      (is (= "https://server.example.com"
+             (-> {:oidc-config "dev-resources/oidc/.well-known/openid-configuration"}
+                 get-configuration
+                 (get "issuer")))))))
+
+(deftest resolve-authority-claims-test
+  (testing "resolves client id"
+    (are [claims resolved-id]
+        (= (:lrsql/resolved-client-id
+            (resolve-authority-claims
+             (merge
+              ;; other unrelated claims so spec is satisfied
+              {:scope "openid all"
+               :iss   "http://example.com/realm"
+               :sub   "1234"}
+              claims)))
+           resolved-id)
+      {:aud "foo"}         "foo"
+      {:aud ["foo" "bar"]} "foo"
+      {:aud       "foo"
+       :client_id "bar"
+       :azp       "baz"}   "bar"
+      {:aud       "foo"
+       :azp       "baz"}   "baz")))
+
+(deftest make-authority-fn-test
+  (testing "default, from resource"
+    (let [a-fn (make-authority-fn nil)]
+      (is
+       (= {"objectType" "Group",
+           "member"
+           [{"account" {"homePage" "foo", "name" "bar"}}
+            {"account" {"homePage" "foo", "name" "baz"}}]}
+          (a-fn {:scope "openid all"
+                 :iss   "foo"
+                 :aud   "bar"
+                 :sub   "baz"})))))
+  (testing "from file path"
+    (let [a-fn (make-authority-fn "resources/lrsql/config/oidc_authority.json.template")]
+      (is
+       (= {"objectType" "Group",
+           "member"
+           [{"account" {"homePage" "foo", "name" "bar"}}
+            {"account" {"homePage" "foo", "name" "baz"}}]}
+          (a-fn {:scope "openid all"
+                 :iss   "foo"
+                 :aud   "bar"
+                 :sub   "baz"}))))))

--- a/src/test/lrsql/init/oidc_test.clj
+++ b/src/test/lrsql/init/oidc_test.clj
@@ -1,8 +1,12 @@
 (ns lrsql.init.oidc-test
-  (:require [clojure.test    :refer [deftest is testing are]]
-            [lrsql.init.oidc :refer [get-configuration
-                                     resolve-authority-claims
-                                     make-authority-fn]]))
+  (:require [clojure.test       :refer [deftest is testing are]]
+            [lrsql.init.oidc    :refer [get-configuration
+                                        resolve-authority-claims
+                                        make-authority-fn
+                                        render-client-config]]
+            [lrsql.test-support :refer [instrument-lrsql]]))
+
+(instrument-lrsql)
 
 (deftest get-configuration-test
   (testing "Slurps configuration"
@@ -56,3 +60,22 @@
                  :iss   "foo"
                  :aud   "bar"
                  :sub   "baz"}))))))
+
+(deftest render-client-config-test
+  (testing "Renders OIDC Client config."
+    (is
+     (= {"authority"                "https://idp.example.com/realm",
+         "automaticSilentRenew"     true,
+         "extraQueryParams"         {"audience" "https://lrs.example.com"},
+         "monitorSession"           false,
+         "filterProtocolClaims"     false,
+         "response_type"            "code",
+         "scope"                    "openid profile lrs:admin",
+         "client_id"                "1234"}
+        (render-client-config
+         {:webserver {:oidc-issuer    "https://idp.example.com/realm"
+                      :oidc-audience  "https://lrs.example.com"
+                      :oidc-client-id "1234"
+                      :oidc-client-template
+                      "resources/lrsql/config/oidc_client.json.template"}
+          :lrs       {:oidc-scope-prefix "lrs:"}})))))

--- a/src/test/lrsql/input/input_test.clj
+++ b/src/test/lrsql/input/input_test.clj
@@ -51,6 +51,7 @@
 (deftest test-admin
   (testing "admin account inputs"
     (is (nil? (check-validate `i-admin/insert-admin-input 3)))
+    (is (nil? (check-validate `i-admin/insert-admin-oidc-input 3)))
     (is (nil? (check-validate `i-admin/query-validate-admin-input)))
     (is (nil? (check-validate `i-admin/query-admin-exists-input)))
     (is (nil? (check-validate `i-admin/delete-admin-input)))))

--- a/src/test/lrsql/util/oidc_test.clj
+++ b/src/test/lrsql/util/oidc_test.clj
@@ -1,16 +1,70 @@
 (ns lrsql.util.oidc-test
-  (:require [clojure.test :refer :all]
-            [lrsql.util.oidc :refer :all]))
+  (:require [clojure.test    :refer [deftest is testing are]]
+            [lrsql.util.oidc :refer [parse-scope-claim
+                                     token-auth-identity]]
+            [lrsql.init.oidc :refer [make-authority-fn]]))
 
-(deftest get-configuration-test
-  (testing "Slurps configuration"
-    (testing "From issuer"
-      (is (= "https://server.example.com"
-             (-> {:openid-issuer "dev-resources/oidc"}
-                 get-configuration
-                 (get "issuer")))))
-    (testing "From custom config loc"
-      (is (= "https://server.example.com"
-             (-> {:openid-config "dev-resources/oidc/.well-known/openid-configuration"}
-                 get-configuration
-                 (get "issuer")))))))
+(deftest parse-scope-claim-test
+  (testing "Gets valid scopes, skips others"
+    (is (= #{:scope/all
+             :scope/all.read
+             :scope/statements.read
+             :scope/statements.write}
+           (into #{}
+                 (parse-scope-claim
+                  "openid profile all all/read statements/read statements/write")))))
+  (testing "Configurable scope-prefix"
+    (is (= #{:scope/all
+             :scope/all.read
+             :scope/statements.read
+             :scope/statements.write}
+           (into #{}
+                 (parse-scope-claim
+                  "openid profile lrsql:all lrsql:all/read lrsql:statements/read lrsql:statements/write"
+                  :scope-prefix "lrsql:"))))))
+
+(deftest token-auth-identity-test
+  (let [auth-fn (make-authority-fn nil)
+        scope-prefix ""]
+    (testing "Returns an LRS identity"
+      (is (= {:result
+              {:scopes #{:scope/all}
+               :prefix ""
+               :auth   {:token "foo"}
+               :agent  {"objectType" "Group"
+                        "member"     [{"account"
+                                       {"homePage" "http://example.com/realm"
+                                        "name"     "someapp"}}
+                                      {"account"
+                                       {"homePage" "http://example.com/realm"
+                                        "name"     "1234"}}]}}}
+             (token-auth-identity
+              {:com.yetanalytics.pedestal-oidc/token "foo"
+               :request
+               {:com.yetanalytics.pedestal-oidc/claims
+                {:scope "openid all"
+                 :iss   "http://example.com/realm"
+                 :aud   "someapp"
+                 :sub   "1234"}}}
+              auth-fn
+              scope-prefix))))
+    (testing "Fails without any valid scopes"
+      (is (= {:result
+              :com.yetanalytics.lrs.auth/unauthorized}
+             (token-auth-identity
+              {:com.yetanalytics.pedestal-oidc/token "foo"
+               :request
+               {:com.yetanalytics.pedestal-oidc/claims
+                {:scope "openid"
+                 :iss   "http://example.com/realm"
+                 :aud   "someapp"
+                 :sub   "1234"}}}
+              auth-fn
+              scope-prefix))))
+    (testing "nil w/o token"
+      (is (nil?
+           (token-auth-identity
+            {:request
+             {}}
+            auth-fn
+            scope-prefix))))))

--- a/src/test/lrsql/util/oidc_test.clj
+++ b/src/test/lrsql/util/oidc_test.clj
@@ -1,0 +1,16 @@
+(ns lrsql.util.oidc-test
+  (:require [clojure.test :refer :all]
+            [lrsql.util.oidc :refer :all]))
+
+(deftest get-configuration-test
+  (testing "Slurps configuration"
+    (testing "From issuer"
+      (is (= "https://server.example.com"
+             (-> {:openid-issuer "dev-resources/oidc"}
+                 get-configuration
+                 (get "issuer")))))
+    (testing "From custom config loc"
+      (is (= "https://server.example.com"
+             (-> {:openid-config "dev-resources/oidc/.well-known/openid-configuration"}
+                 get-configuration
+                 (get "issuer")))))))


### PR DESCRIPTION
[SQL-132] Support OIDC authentication (authn) and authorization(authz) in SQL LRS.

This includes:
- [x] Direct use of the LRS as an OAuth 2.0 resource server, expecting OIDC tokens + claims.
- [x] Authn to the LRS Admin SPA and authn/z to the admin API to manipulate long-lived credentials.
- [x] Implement enable/disable of local account auth when OIDC is used

[SQL-132]: https://yet.atlassian.net/browse/SQL-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ