### PR TITLE
[SQL-137] Admin API OIDC

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -49,7 +49,7 @@
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript]}
   com.yetanalytics/pedestal-oidc
-  {:mvn/version "0.0.7"
+  {:mvn/version "0.0.8"
    :exclusions [org.clojure/clojure]}}
  :aliases
  {:db-h2

--- a/deps.edn
+++ b/deps.edn
@@ -49,7 +49,7 @@
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript]}
   com.yetanalytics/pedestal-oidc
-  {:mvn/version "0.0.6"
+  {:mvn/version "0.0.7"
    :exclusions [org.clojure/clojure]}}
  :aliases
  {:db-h2

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -115,6 +115,7 @@ You may have noted that some options are not available:
 | `LRSQL_OIDC_ISSUER` | `oidcIssuer` | OIDC Issuer address used for [discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig) | Not set |
 | `LRSQL_OIDC_CONFIG` | `oidcConfig` | Custom OIDC configuration location | Not set |
 | `LRSQL_OIDC_AUDIENCE` | `oidcAudience` | Optional OIDC audience for token claim verification. | Not set |
+| `LRSQL_OIDC_VERIFY_REMOTE_ISSUER` | `oidcVerifyRemoteIssuer` | Verify on startup that the issuer in remote configuration matches `LRSQL_OIDC_ISSUER` (if provided). | `true` |
 | `LRSQL_JWKS_URI` | `jwksUri` | Custom JWKS [keyset](https://datatracker.ietf.org/doc/html/rfc7517#section-5) location | Not set |
 
 [<- Back to Index](index.md)

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -112,10 +112,8 @@ You may have noted that some options are not available:
 | `LRSQL_URL_PREFIX` | `urlPrefix` | The prefix of the webserver URL path, e.g. the prefix in `http://0.0.0.0:8080/xapi` is `/xapi`. Used when constructing the `more` value for multi-statement queries. | `/xapi` |
 | `LRSQL_ENABLE_ADMIN_UI` | `enableAdminUi` | Whether or not to serve the administrative UI at `/admin` | `true` |
 | `LRSQL_ENABLE_STMT_HTML` | `enableStmtHtml` | Whether or not HTML data is returned in the LRS HTTP response. If `false` disables HTML rendering even if `LRSQL_ENABLE_ADMIN_UI` is `true`. In that case the UI will not display the Statement Browser feature. | `true` |
-| `LRSQL_OIDC_ISSUER` | `oidcIssuer` | OIDC Issuer address used for [discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig) | Not set |
-| `LRSQL_OIDC_CONFIG` | `oidcConfig` | Custom OIDC configuration location | Not set |
+| `LRSQL_OIDC_ISSUER` | `oidcIssuer` | OIDC Issuer address used for [discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). Will enable OIDC if present. | Not set |
 | `LRSQL_OIDC_AUDIENCE` | `oidcAudience` | Optional OIDC audience for token claim verification. | Not set |
 | `LRSQL_OIDC_VERIFY_REMOTE_ISSUER` | `oidcVerifyRemoteIssuer` | Verify on startup that the issuer in remote configuration matches `LRSQL_OIDC_ISSUER` (if provided). | `true` |
-| `LRSQL_JWKS_URI` | `jwksUri` | Custom JWKS [keyset](https://datatracker.ietf.org/doc/html/rfc7517#section-5) location | Not set |
 
 [<- Back to Index](index.md)

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -113,7 +113,7 @@ You may have noted that some options are not available:
 | `LRSQL_ENABLE_ADMIN_UI` | `enableAdminUi` | Whether or not to serve the administrative UI at `/admin` | `true` |
 | `LRSQL_ENABLE_STMT_HTML` | `enableStmtHtml` | Whether or not HTML data is returned in the LRS HTTP response. If `false` disables HTML rendering even if `LRSQL_ENABLE_ADMIN_UI` is `true`. In that case the UI will not display the Statement Browser feature. | `true` |
 | `LRSQL_OIDC_ISSUER` | `oidcIssuer` | OIDC Issuer address used for [discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig). Will enable OIDC if present. | Not set |
-| `LRSQL_OIDC_AUDIENCE` | `oidcAudience` | Optional OIDC audience for token claim verification. | Not set |
-| `LRSQL_OIDC_VERIFY_REMOTE_ISSUER` | `oidcVerifyRemoteIssuer` | Verify on startup that the issuer in remote configuration matches `LRSQL_OIDC_ISSUER` (if provided). | `true` |
+| `LRSQL_OIDC_AUDIENCE` | `oidcAudience` | Optional OIDC audience for token claim verification. No effect if `LRSQL_OIDC_ISSUER` is not set. | Not set |
+| `LRSQL_OIDC_VERIFY_REMOTE_ISSUER` | `oidcVerifyRemoteIssuer` | Verify on startup that the issuer in remote configuration matches `LRSQL_OIDC_ISSUER`. No effect if `LRSQL_OIDC_ISSUER` is not set. | `true` |
 
 [<- Back to Index](index.md)

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -114,6 +114,7 @@ You may have noted that some options are not available:
 | `LRSQL_ENABLE_STMT_HTML` | `enableStmtHtml` | Whether or not HTML data is returned in the LRS HTTP response. If `false` disables HTML rendering even if `LRSQL_ENABLE_ADMIN_UI` is `true`. In that case the UI will not display the Statement Browser feature. | `true` |
 | `LRSQL_OIDC_ISSUER` | `oidcIssuer` | OIDC Issuer address used for [discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig) | Not set |
 | `LRSQL_OIDC_CONFIG` | `oidcConfig` | Custom OIDC configuration location | Not set |
+| `LRSQL_OIDC_AUDIENCE` | `oidcAudience` | Optional OIDC audience for token claim verification. | Not set |
 | `LRSQL_JWKS_URI` | `jwksUri` | Custom JWKS [keyset](https://datatracker.ietf.org/doc/html/rfc7517#section-5) location | Not set |
 
 [<- Back to Index](index.md)

--- a/resources/lrsql/config/prod/default/webserver.edn
+++ b/resources/lrsql/config/prod/default/webserver.edn
@@ -16,4 +16,5 @@
  :enable-stmt-html  #boolean #or [#env LRSQL_ENABLE_STMT_HTML true]
  :oidc-issuer       #env LRSQL_OIDC_ISSUER
  :oidc-config       #env LRSQL_OIDC_CONFIG
+ :oidc-audience     #env LRSQL_OIDC_AUDIENCE
  :jwks-uri          #env LRSQL_JWKS_URI}

--- a/resources/lrsql/config/prod/default/webserver.edn
+++ b/resources/lrsql/config/prod/default/webserver.edn
@@ -1,20 +1,21 @@
-{:key-file          #or [#env LRSQL_KEY_FILE "config/keystore.jks"]
- :key-alias         #or [#env LRSQL_KEY_ALIAS "lrsql_keystore"]
- :key-password      #or [#env LRSQL_KEY_PASSWORD "lrsql_pass"]
- :key-pkey-file     #or [#env LRSQL_KEY_PKEY_FILE "config/server.key.pem"]
- :key-cert-chain    #or [#env LRSQL_KEY_CERT_FILE "config/server.crt.pem,config/cacert.pem"]
- :key-enable-selfie #boolean #or [#env LRSQL_KEY_ENABLE_SELFIE true]
- :jwt-exp-time      #long #or [#env LRSQL_JWT_EXP_TIME 3600]
- :jwt-exp-leeway    #long #or [#env LRSQL_JWT_EXP_LEEWAY 1]
- :enable-http       #boolean #or [#env LRSQL_ENABLE_HTTP true]
- :enable-http2      #boolean #or [#env LRSQL_ENABLE_HTTP2 true]
- :http-host         #or [#env LRSQL_HTTP_HOST "0.0.0.0"]
- :http-port         #long #or [#env LRSQL_HTTP_PORT 8080]
- :ssl-port          #long #or [#env LRSQL_SSL_PORT 8443]
- :url-prefix        #or [#env LRSQL_URL_PREFIX "/xapi"]
- :enable-admin-ui   #boolean #or [#env LRSQL_ENABLE_ADMIN_UI true]
- :enable-stmt-html  #boolean #or [#env LRSQL_ENABLE_STMT_HTML true]
- :oidc-issuer       #env LRSQL_OIDC_ISSUER
- :oidc-config       #env LRSQL_OIDC_CONFIG
- :oidc-audience     #env LRSQL_OIDC_AUDIENCE
- :jwks-uri          #env LRSQL_JWKS_URI}
+{:key-file                  #or [#env LRSQL_KEY_FILE "config/keystore.jks"]
+ :key-alias                 #or [#env LRSQL_KEY_ALIAS "lrsql_keystore"]
+ :key-password              #or [#env LRSQL_KEY_PASSWORD "lrsql_pass"]
+ :key-pkey-file             #or [#env LRSQL_KEY_PKEY_FILE "config/server.key.pem"]
+ :key-cert-chain            #or [#env LRSQL_KEY_CERT_FILE "config/server.crt.pem,config/cacert.pem"]
+ :key-enable-selfie         #boolean #or [#env LRSQL_KEY_ENABLE_SELFIE true]
+ :jwt-exp-time              #long #or [#env LRSQL_JWT_EXP_TIME 3600]
+ :jwt-exp-leeway            #long #or [#env LRSQL_JWT_EXP_LEEWAY 1]
+ :enable-http               #boolean #or [#env LRSQL_ENABLE_HTTP true]
+ :enable-http2              #boolean #or [#env LRSQL_ENABLE_HTTP2 true]
+ :http-host                 #or [#env LRSQL_HTTP_HOST "0.0.0.0"]
+ :http-port                 #long #or [#env LRSQL_HTTP_PORT 8080]
+ :ssl-port                  #long #or [#env LRSQL_SSL_PORT 8443]
+ :url-prefix                #or [#env LRSQL_URL_PREFIX "/xapi"]
+ :enable-admin-ui           #boolean #or [#env LRSQL_ENABLE_ADMIN_UI true]
+ :enable-stmt-html          #boolean #or [#env LRSQL_ENABLE_STMT_HTML true]
+ :oidc-issuer               #env LRSQL_OIDC_ISSUER
+ :oidc-config               #env LRSQL_OIDC_CONFIG
+ :oidc-audience             #env LRSQL_OIDC_AUDIENCE
+ :oidc-verify-remote-issuer #or [#env LRSQL_OIDC_VERIFY_REMOTE_ISSUER true]
+ :jwks-uri                  #env LRSQL_JWKS_URI}

--- a/resources/lrsql/config/prod/default/webserver.edn
+++ b/resources/lrsql/config/prod/default/webserver.edn
@@ -15,7 +15,5 @@
  :enable-admin-ui           #boolean #or [#env LRSQL_ENABLE_ADMIN_UI true]
  :enable-stmt-html          #boolean #or [#env LRSQL_ENABLE_STMT_HTML true]
  :oidc-issuer               #env LRSQL_OIDC_ISSUER
- :oidc-config               #env LRSQL_OIDC_CONFIG
  :oidc-audience             #env LRSQL_OIDC_AUDIENCE
- :oidc-verify-remote-issuer #or [#env LRSQL_OIDC_VERIFY_REMOTE_ISSUER true]
- :jwks-uri                  #env LRSQL_JWKS_URI}
+ :oidc-verify-remote-issuer #or [#env LRSQL_OIDC_VERIFY_REMOTE_ISSUER true]}

--- a/resources/lrsql/config/test/default/webserver.edn
+++ b/resources/lrsql/config/test/default/webserver.edn
@@ -1,14 +1,15 @@
-{:key-file          "config/keystore.jks"
- :key-alias         "lrsql_keystore"
- :key-password      "lrsql_pass"
- :key-enable-selfie true
- :jwt-exp-time      3600
- :jwt-exp-leeway    1
- :enable-http       true
- :enable-http2      true
- :ssl-port          8443
- :http-host         "0.0.0.0"
- :http-port         8080
- :url-prefix        "/xapi"
- :enable-admin-ui   true
- :enable-stmt-html  true}
+{:key-file                  "config/keystore.jks"
+ :key-alias                 "lrsql_keystore"
+ :key-password              "lrsql_pass"
+ :key-enable-selfie         true
+ :jwt-exp-time              3600
+ :jwt-exp-leeway            1
+ :enable-http               true
+ :enable-http2              true
+ :ssl-port                  8443
+ :http-host                 "0.0.0.0"
+ :http-port                 8080
+ :url-prefix                "/xapi"
+ :enable-admin-ui           true
+ :enable-stmt-html          true
+ :oidc-verify-remote-issuer true}

--- a/src/db/h2/lrsql/h2/record.clj
+++ b/src/db/h2/lrsql/h2/record.clj
@@ -143,6 +143,8 @@
   bp/AdminAccountBackend
   (-insert-admin-account! [_ tx input]
     (insert-admin-account! tx input))
+  (-insert-admin-account-oidc! [_ tx input]
+    (insert-admin-account-oidc! tx input))
   (-query-all-admin-accounts [_ tx]
     (query-all-accounts tx))
   (-delete-admin-account! [_ tx input]

--- a/src/db/h2/lrsql/h2/record.clj
+++ b/src/db/h2/lrsql/h2/record.clj
@@ -151,6 +151,8 @@
     (delete-admin-account! tx input))
   (-query-account [_ tx input]
     (query-account tx input))
+  (-query-account-oidc [_ tx input]
+    (query-account-oidc tx input))
   (-query-account-exists [_ tx input]
     (query-account-exists tx input))
 

--- a/src/db/h2/lrsql/h2/record.clj
+++ b/src/db/h2/lrsql/h2/record.clj
@@ -43,7 +43,8 @@
     (create-credential-table! tx)
     (create-credential-to-scope-table! tx))
   (-update-all! [_ tx]
-    (alter-admin-account-passhash-optional! tx))
+    (alter-admin-account-passhash-optional! tx)
+    (alter-admin-account-add-openid-issuer! tx))
 
   bp/BackendUtil
   (-txn-retry? [_ ex]

--- a/src/db/h2/lrsql/h2/record.clj
+++ b/src/db/h2/lrsql/h2/record.clj
@@ -42,9 +42,8 @@
     (create-admin-account-table! tx)
     (create-credential-table! tx)
     (create-credential-to-scope-table! tx))
-  (-update-all! [_ _tx]
-    ;; No-op for now; add functions if updates are needed
-    nil)
+  (-update-all! [_ tx]
+    (alter-admin-account-passhash-optional! tx))
 
   bp/BackendUtil
   (-txn-retry? [_ ex]

--- a/src/db/h2/lrsql/h2/sql/ddl.sql
+++ b/src/db/h2/lrsql/h2/sql/ddl.sql
@@ -184,3 +184,10 @@ CREATE TABLE IF NOT EXISTS credential_to_scope (
 -- :command :execute
 -- :doc Set `admin_account.passhash` to optional.
 ALTER TABLE IF EXISTS admin_account ALTER COLUMN IF EXISTS passhash SET NULL
+
+/* Migration 2022-02-23-00 - Add oidc_issuer to admin_account */
+
+-- :name alter-admin-account-add-openid-issuer!
+-- :command :execute
+-- :doc Add `admin_account.oidc_issuer` to record OIDC identity source.
+ALTER TABLE IF EXISTS admin_account ADD COLUMN IF NOT EXISTS oidc_issuer VARCHAR(255)

--- a/src/db/h2/lrsql/h2/sql/ddl.sql
+++ b/src/db/h2/lrsql/h2/sql/ddl.sql
@@ -178,6 +178,8 @@ CREATE TABLE IF NOT EXISTS credential_to_scope (
     ON DELETE CASCADE
 )
 
+/* Migration 2022-02-22-00 - Set admin_account.passhash to optional */
+
 -- :name alter-admin-account-passhash-optional!
 -- :command :execute
 -- :doc Set `admin_account.passhash` to optional.

--- a/src/db/h2/lrsql/h2/sql/ddl.sql
+++ b/src/db/h2/lrsql/h2/sql/ddl.sql
@@ -177,3 +177,8 @@ CREATE TABLE IF NOT EXISTS credential_to_scope (
     REFERENCES lrs_credential(api_key, secret_key)
     ON DELETE CASCADE
 )
+
+-- :name alter-admin-account-passhash-optional!
+-- :command :execute
+-- :doc Set `admin_account.passhash` to optional.
+ALTER TABLE IF EXISTS admin_account ALTER COLUMN IF EXISTS passhash SET NULL

--- a/src/db/h2/lrsql/h2/sql/insert.sql
+++ b/src/db/h2/lrsql/h2/sql/insert.sql
@@ -126,6 +126,14 @@ id = :primary-key,
 username = :username,
 passhash = :passhash
 
+-- :name insert-admin-account-oidc!
+-- :command :insert
+-- :doc Insert a new admin account to shadow an OIDC user.
+INSERT INTO admin_account SET
+id = :primary-key,
+username = :username,
+oidc_issuer = :oidc-issuer
+
 /* Credentials */
 
 -- :name insert-credential!

--- a/src/db/h2/lrsql/h2/sql/query.sql
+++ b/src/db/h2/lrsql/h2/sql/query.sql
@@ -217,6 +217,13 @@ WHERE activity_iri = :activity-iri
 SELECT id, passhash FROM admin_account
 WHERE username = :username
 
+-- :name query-account-oidc
+-- :command :query
+-- :result :one
+-- :doc Given an account `username`, return the ID and OIDC issuer, which can be used to verify the OIDC identity.
+SELECT id, oidc_issuer FROM admin_account
+WHERE username = :username
+
 -- :name query-all-accounts
 -- :command :query
 -- :result :many

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -50,7 +50,8 @@
     (create-credential-table! tx)
     (create-credential-to-scope-table! tx))
   (-update-all! [_ tx]
-    (alter-admin-account-passhash-optional! tx))
+    (alter-admin-account-passhash-optional! tx)
+    (alter-admin-account-add-openid-issuer! tx))
 
   bp/BackendUtil
   (-txn-retry? [_ ex]

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -49,9 +49,8 @@
     (create-admin-account-table! tx)
     (create-credential-table! tx)
     (create-credential-to-scope-table! tx))
-  (-update-all! [_ _]
-    ;; No-op for now; add functions if updates are needed
-    nil)
+  (-update-all! [_ tx]
+    (alter-admin-account-passhash-optional! tx))
 
   bp/BackendUtil
   (-txn-retry? [_ ex]

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -150,6 +150,8 @@
   bp/AdminAccountBackend
   (-insert-admin-account! [_ tx input]
     (insert-admin-account! tx input))
+  (-insert-admin-account-oidc! [_ tx input]
+    (insert-admin-account-oidc! tx input))
   (-query-all-admin-accounts [_ tx]
     (query-all-accounts tx))
   (-delete-admin-account! [_ tx input]

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -158,6 +158,8 @@
     (delete-admin-account! tx input))
   (-query-account [_ tx input]
     (query-account tx input))
+  (-query-account-oidc [_ tx input]
+    (query-account-oidc tx input))
   (-query-account-exists [_ tx input]
     (query-account-exists tx input))
 

--- a/src/db/postgres/lrsql/postgres/sql/ddl.sql
+++ b/src/db/postgres/lrsql/postgres/sql/ddl.sql
@@ -243,4 +243,4 @@ CREATE INDEX IF NOT EXISTS cred_keypair_fk ON credential_to_scope(api_key, secre
 -- :name alter-admin-account-passhash-optional!
 -- :command :execute
 -- :doc Set `admin_account.passhash` to optional.
-ALTER TABLE IF EXISTS admin_account ALTER COLUMN IF EXISTS passhash SET NULL;
+ALTER TABLE IF EXISTS admin_account ALTER COLUMN passhash DROP NOT NULL;

--- a/src/db/postgres/lrsql/postgres/sql/ddl.sql
+++ b/src/db/postgres/lrsql/postgres/sql/ddl.sql
@@ -239,3 +239,8 @@ CREATE TABLE IF NOT EXISTS credential_to_scope (
     ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS cred_keypair_fk ON credential_to_scope(api_key, secret_key);
+
+-- :name alter-admin-account-passhash-optional!
+-- :command :execute
+-- :doc Set `admin_account.passhash` to optional.
+ALTER TABLE IF EXISTS admin_account ALTER COLUMN IF EXISTS passhash SET NULL;

--- a/src/db/postgres/lrsql/postgres/sql/ddl.sql
+++ b/src/db/postgres/lrsql/postgres/sql/ddl.sql
@@ -240,6 +240,8 @@ CREATE TABLE IF NOT EXISTS credential_to_scope (
 );
 CREATE INDEX IF NOT EXISTS cred_keypair_fk ON credential_to_scope(api_key, secret_key);
 
+/* Migration 2022-02-22-00 - Set admin_account.passhash to optional */
+
 -- :name alter-admin-account-passhash-optional!
 -- :command :execute
 -- :doc Set `admin_account.passhash` to optional.

--- a/src/db/postgres/lrsql/postgres/sql/ddl.sql
+++ b/src/db/postgres/lrsql/postgres/sql/ddl.sql
@@ -246,3 +246,10 @@ CREATE INDEX IF NOT EXISTS cred_keypair_fk ON credential_to_scope(api_key, secre
 -- :command :execute
 -- :doc Set `admin_account.passhash` to optional.
 ALTER TABLE IF EXISTS admin_account ALTER COLUMN passhash DROP NOT NULL;
+
+/* Migration 2022-02-23-00 - Add oidc_issuer to admin_account */
+
+-- :name alter-admin-account-add-openid-issuer!
+-- :command :execute
+-- :doc Add `admin_account.oidc_issuer` to record OIDC identity source.
+ALTER TABLE IF EXISTS admin_account ADD COLUMN IF NOT EXISTS oidc_issuer VARCHAR(255);

--- a/src/db/postgres/lrsql/postgres/sql/insert.sql
+++ b/src/db/postgres/lrsql/postgres/sql/insert.sql
@@ -119,6 +119,15 @@ INSERT INTO admin_account (
   :primary-key, :username, :passhash
 );
 
+-- :name insert-admin-account-oidc!
+-- :command :insert
+-- :doc Insert a new admin account to shadow an OIDC user.
+INSERT INTO admin_account (
+  id, username, oidc_issuer
+) VALUES (
+  :primary-key, :username, :oidc-issuer
+);
+
 /* Credentials */
 
 -- :name insert-credential!

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -218,6 +218,13 @@ WHERE activity_iri = :activity-iri
 SELECT id, passhash FROM admin_account
 WHERE username = :username;
 
+-- :name query-account-oidc
+-- :command :query
+-- :result :one
+-- :doc Given an account `username`, return the ID and OIDC issuer, which can be used to verify the OIDC identity.
+SELECT id, oidc_issuer FROM admin_account
+WHERE username = :username;
+
 -- :name query-all-accounts
 -- :command :query
 -- :result :many

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -179,6 +179,8 @@
   bp/AdminAccountBackend
   (-insert-admin-account! [_ tx input]
     (insert-admin-account! tx input))
+  (-insert-admin-account-oidc! [_ tx input]
+    (insert-admin-account-oidc! tx input))
   (-query-all-admin-accounts [_ tx]
     (query-all-accounts tx))
   (-delete-admin-account! [_ tx input]

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -187,6 +187,8 @@
     (delete-admin-account! tx input))
   (-query-account [_ tx input]
     (query-account tx input))
+  (-query-account-oidc [_ tx input]
+    (query-account-oidc tx input))
   (-query-account-exists [_ tx input]
     (query-account-exists tx input))
 

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -80,6 +80,8 @@
   (-update-all! [_ tx]
     (when (= 1 (:notnull (query-admin-account-passhash-notnull tx)))
       (update-schema-simple tx alter-admin-account-passhash-optional!))
+    (when-not (some? (query-admin-account-oidc-issuer-exists tx))
+      (alter-admin-account-add-openid-issuer! tx))
     (log/infof "sqlite schema_version: %d"
                (:schema_version (query-schema-version tx))))
 

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -19,6 +19,7 @@
 
 ;; Schema Update Helpers
 
+#_{:clj-kondo/ignore [:unresolved-symbol]}
 (defn- update-schema-simple!
   "Given a tx and a db-fn that updates schema to remove CHECK or FOREIGN KEY or NOT NULL constraints or to add, remove, or change default values on a column, wraps it with an update to the schema version and associated checks.
 

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -19,7 +19,7 @@
 
 ;; Schema Update Helpers
 
-(defn- update-schema-simple
+(defn- update-schema-simple!
   "Given a tx and a db-fn that updates schema to remove CHECK or FOREIGN KEY or NOT NULL constraints or to add, remove, or change default values on a column, wraps it with an update to the schema version and associated checks.
 
   See https://www.sqlite.org/lang_altertable.html Section 7 part 2"
@@ -79,7 +79,7 @@
     (create-credential-to-scope-table! tx))
   (-update-all! [_ tx]
     (when (= 1 (:notnull (query-admin-account-passhash-notnull tx)))
-      (update-schema-simple tx alter-admin-account-passhash-optional!))
+      (update-schema-simple! tx alter-admin-account-passhash-optional!))
     (when-not (some? (query-admin-account-oidc-issuer-exists tx))
       (alter-admin-account-add-openid-issuer! tx))
     (log/infof "sqlite schema_version: %d"

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -60,9 +60,8 @@
     (create-admin-account-table! tx)
     (create-credential-table! tx)
     (create-credential-to-scope-table! tx))
-  (-update-all! [_ _]
-    ;; No-op for now; add functions if updates are needed
-    nil)
+  (-update-all! [_ tx]
+    (alter-admin-account-passhash-optional! tx))
 
   bp/BackendUtil
   (-txn-retry? [_ _ex]

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -67,11 +67,11 @@
     (when (= 1 (:notnull (query-admin-account-passhash-notnull tx)))
       (let [{schema-version :schema_version} (query-schema-version tx)]
         (log/info "Setting admin account passhash to optional")
-        (enable-writable-schema-snip tx)
+        (enable-writable-schema! tx)
         (alter-admin-account-passhash-optional! tx)
-        (update-schema-version! tx {:schema-version (inc schema-version)})
-        (disable-writable-schema-snip tx)
-        (integrity-check-snip tx))))
+        (update-schema-version! tx {:version (inc schema-version)})
+        (disable-writable-schema! tx)
+        (run-integrity-check tx))))
 
   bp/BackendUtil
   (-txn-retry? [_ _ex]

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -282,3 +282,16 @@ SELECT "notnull" FROM pragma_table_info('admin_account') where name='passhash'
 -- :command :execute
 -- :doc Set `admin_account.passhash` to optional.
 UPDATE sqlite_schema SET sql='CREATE TABLE admin_account (id TEXT NOT NULL PRIMARY KEY, username TEXT NOT NULL UNIQUE, passhash TEXT)' WHERE type='table' AND name='admin_account'
+
+/* Migration 2022-02-23-00 - Add oidc_issuer to admin_account */
+
+-- :name query-admin-account-oidc-issuer-exists
+-- :command :query
+-- :result :one
+-- :doc Query to see if `admin_account.oidc_issuer` exists.
+SELECT 1 FROM pragma_table_info('admin_account') where name='oidc_issuer'
+
+-- :name alter-admin-account-add-openid-issuer!
+-- :command :execute
+-- :doc Add `admin_account.oidc_issuer` to record OIDC identity source.
+ALTER TABLE admin_account ADD COLUMN oidc_issuer TEXT

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -6,15 +6,6 @@
 -- :snip ensure-foreign-keys-snip
 PRAGMA foreign_keys = ON;
 
--- :snip enable-writable-schema-snip
-PRAGMA writable_schema = ON;
-
--- :snip disable-writable-schema-snip
-PRAGMA writable_schema = OFF;
-
--- :snip integrity-check-snip
-PRAGMA integrity_check;
-
 /* Statement + Attachment Tables */
 
 -- :name create-statement-table!
@@ -251,6 +242,36 @@ CREATE TABLE IF NOT EXISTS credential_to_scope (
     ON DELETE CASCADE
 )
 
+/* Migration */
+
+-- :name enable-writable-schema!
+-- :command :execute
+PRAGMA writable_schema = ON
+
+-- :name disable-writable-schema!
+-- :command :execute
+PRAGMA writable_schema = OFF
+
+-- :name run-integrity-check
+-- :command :execute
+PRAGMA integrity_check
+
+-- :name query-admin-account-passhash-notnull
+-- :command :query
+-- :result :one
+-- :doc Query to see if admin_account passhash is required.
+SELECT "notnull" FROM pragma_table_info('admin_account') where name='passhash'
+
+-- :name query-schema-version
+-- :command :query
+-- :result :one
+-- :doc Query the db schema version
+PRAGMA schema_version
+
+-- :name update-schema-version!
+-- :command :execute
+PRAGMA schema_version = :sql:version
+
 -- :name alter-admin-account-passhash-optional!
 -- :command :execute
 -- :doc Set `admin_account.passhash` to optional.
@@ -258,4 +279,4 @@ UPDATE sqlite_schema SET sql='CREATE TABLE IF NOT EXISTS admin_account (
 id       TEXT NOT NULL PRIMARY KEY,
 username TEXT NOT NULL UNIQUE,
 passhash TEXT
-)' WHERE type='table' AND name='admin_account';
+)' WHERE type='table' AND name='admin_account'

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -281,8 +281,4 @@ SELECT "notnull" FROM pragma_table_info('admin_account') where name='passhash'
 -- :name alter-admin-account-passhash-optional!
 -- :command :execute
 -- :doc Set `admin_account.passhash` to optional.
-UPDATE sqlite_schema SET sql='CREATE TABLE IF NOT EXISTS admin_account (
-id       TEXT NOT NULL PRIMARY KEY,
-username TEXT NOT NULL UNIQUE,
-passhash TEXT
-)' WHERE type='table' AND name='admin_account'
+UPDATE sqlite_schema SET sql='CREATE TABLE admin_account (id TEXT NOT NULL PRIMARY KEY, username TEXT NOT NULL UNIQUE, passhash TEXT)' WHERE type='table' AND name='admin_account'

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -6,6 +6,15 @@
 -- :snip ensure-foreign-keys-snip
 PRAGMA foreign_keys = ON;
 
+-- :snip enable-writable-schema-snip
+PRAGMA writable_schema = ON;
+
+-- :snip disable-writable-schema-snip
+PRAGMA writable_schema = OFF;
+
+-- :snip integrity-check-snip
+PRAGMA integrity_check;
+
 /* Statement + Attachment Tables */
 
 -- :name create-statement-table!
@@ -245,4 +254,8 @@ CREATE TABLE IF NOT EXISTS credential_to_scope (
 -- :name alter-admin-account-passhash-optional!
 -- :command :execute
 -- :doc Set `admin_account.passhash` to optional.
-ALTER TABLE IF EXISTS admin_account ALTER COLUMN IF EXISTS passhash SET NULL
+UPDATE sqlite_schema SET sql='CREATE TABLE IF NOT EXISTS admin_account (
+id       TEXT NOT NULL PRIMARY KEY,
+username TEXT NOT NULL UNIQUE,
+passhash TEXT
+)' WHERE type='table' AND name='admin_account';

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -268,7 +268,7 @@ PRAGMA schema_version
 -- :name update-schema-version!
 -- :command :execute
 -- :doc Set the db schema version.
-PRAGMA schema_version = :sql:version
+PRAGMA schema_version = :sql:schema_version
 
 /* Migration 2022-02-22-00 - Set admin_account.passhash to optional */
 

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -242,35 +242,41 @@ CREATE TABLE IF NOT EXISTS credential_to_scope (
     ON DELETE CASCADE
 )
 
-/* Migration */
+/* Schema Update */
 
 -- :name enable-writable-schema!
 -- :command :execute
+-- :doc Enable writing to the sqlite schema.
 PRAGMA writable_schema = ON
 
 -- :name disable-writable-schema!
 -- :command :execute
+-- :doc Disable writing to the sqlite schema.
 PRAGMA writable_schema = OFF
 
 -- :name run-integrity-check
 -- :command :execute
+-- :doc Run the sqlite schema integrity check.
 PRAGMA integrity_check
+
+-- :name query-schema-version
+-- :command :query
+-- :result :one
+-- :doc Query the db schema version.
+PRAGMA schema_version
+
+-- :name update-schema-version!
+-- :command :execute
+-- :doc Set the db schema version.
+PRAGMA schema_version = :sql:version
+
+/* Migration 2022-02-22-00 - Set admin_account.passhash to optional */
 
 -- :name query-admin-account-passhash-notnull
 -- :command :query
 -- :result :one
 -- :doc Query to see if admin_account passhash is required.
 SELECT "notnull" FROM pragma_table_info('admin_account') where name='passhash'
-
--- :name query-schema-version
--- :command :query
--- :result :one
--- :doc Query the db schema version
-PRAGMA schema_version
-
--- :name update-schema-version!
--- :command :execute
-PRAGMA schema_version = :sql:version
 
 -- :name alter-admin-account-passhash-optional!
 -- :command :execute

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -241,3 +241,8 @@ CREATE TABLE IF NOT EXISTS credential_to_scope (
     REFERENCES lrs_credential(api_key, secret_key)
     ON DELETE CASCADE
 )
+
+-- :name alter-admin-account-passhash-optional!
+-- :command :execute
+-- :doc Set `admin_account.passhash` to optional.
+ALTER TABLE IF EXISTS admin_account ALTER COLUMN IF EXISTS passhash SET NULL

--- a/src/db/sqlite/lrsql/sqlite/sql/insert.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/insert.sql
@@ -119,6 +119,15 @@ INSERT INTO admin_account (
   :primary-key, :username, :passhash
 )
 
+-- :name insert-admin-account-oidc!
+-- :command :insert
+-- :doc Insert a new admin account to shadow an OIDC user.
+INSERT INTO admin_account (
+  id, username, oidc_issuer
+) VALUES (
+  :primary-key, :username, :oidc-issuer
+)
+
 /* Credentials */
 
 -- :name insert-credential!

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -225,17 +225,3 @@ AND secret_key = :secret-key
 SELECT scope FROM credential_to_scope
 WHERE api_key = :api-key
 AND secret_key = :secret-key
-
-/* Migration Utility Queries */
-
--- :name query-admin-account-passhash-notnull
--- :command :query
--- :result :one
--- :doc Query to see if admin_account passhash is required.
-SELECT "notnull" FROM pragma_table_info('admin_account') where name='passhash'
-
--- :name query-schema-version
--- :command :query
--- :result :one
--- :doc Query the db schema version
-PRAGMA schema_version;

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -187,6 +187,13 @@ WHERE activity_iri = :activity-iri
 SELECT id, passhash FROM admin_account
 WHERE username = :username
 
+-- :name query-account-oidc
+-- :command :query
+-- :result :one
+-- :doc Given an account `username`, return the ID and OIDC issuer, which can be used to verify the OIDC identity.
+SELECT id, oidc_issuer FROM admin_account
+WHERE username = :username
+
 -- :name query-all-accounts
 -- :command :query
 -- :result :many

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -225,3 +225,17 @@ AND secret_key = :secret-key
 SELECT scope FROM credential_to_scope
 WHERE api_key = :api-key
 AND secret_key = :secret-key
+
+/* Migration Utility Queries */
+
+-- :name query-admin-account-passhash-notnull
+-- :command :query
+-- :result :one
+-- :doc Query to see if admin_account passhash is required.
+SELECT "notnull" FROM pragma_table_info('admin_account') where name='passhash'
+
+-- :name query-schema-version
+-- :command :query
+-- :result :one
+-- :doc Query the db schema version
+PRAGMA schema_version;

--- a/src/db/sqlite/lrsql/sqlite/sql/update.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/update.sql
@@ -62,3 +62,8 @@ SET
   last_modified = :last-modified
 WHERE profile_id = :profile-id
 AND activity_iri = :activity-iri
+
+-- :name update-schema-version!
+-- :command :execute
+-- :result :affected
+PRAGMA schema_version = :schema-version;

--- a/src/db/sqlite/lrsql/sqlite/sql/update.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/update.sql
@@ -62,8 +62,3 @@ SET
   last_modified = :last-modified
 WHERE profile_id = :profile-id
 AND activity_iri = :activity-iri
-
--- :name update-schema-version!
--- :command :execute
--- :result :affected
-PRAGMA schema_version = :schema-version;

--- a/src/main/lrsql/admin/interceptors/oidc.clj
+++ b/src/main/lrsql/admin/interceptors/oidc.clj
@@ -3,7 +3,6 @@
             [io.pedestal.interceptor.chain :as chain]
             [lrsql.admin.interceptors.jwt :as jwt]
             [lrsql.admin.protocol :as adp]
-            [lrsql.util.auth :as auth]
             [lrsql.util.oidc :as oidc]))
 
 (def validate-oidc-identity

--- a/src/main/lrsql/admin/interceptors/oidc.clj
+++ b/src/main/lrsql/admin/interceptors/oidc.clj
@@ -1,0 +1,90 @@
+(ns lrsql.admin.interceptors.oidc
+  (:require [io.pedestal.interceptor :refer [interceptor]]
+            [io.pedestal.interceptor.chain :as chain]
+            [lrsql.admin.interceptors.jwt :as jwt]
+            [lrsql.admin.protocol :as adp]
+            [lrsql.util.auth :as auth]
+            [lrsql.util.oidc :as oidc]))
+
+(def validate-oidc-identity
+  "If the context has OIDC token claims, parses out data for OIDC admin identity.
+  If claims are invalid, return a 401. If no clams are present, a no-op."
+  (interceptor
+   {:name ::validate-oidc-identity
+    :enter
+    (fn validate-oidc-identity [{lrs :com.yetanalytics/lrs
+                                 :as ctx}]
+      (if-let [ret (oidc/token-auth-admin-identity
+                    ctx
+                    (get-in lrs [:config :oidc-scope-prefix]))]
+        (if (= ::oidc/unauthorized ret)
+          (assoc (chain/terminate ctx)
+                 :response
+                 {:status 401
+                  :body   {:error "Invalid JWT Claims!"}})
+          (assoc ctx ::admin-identity ret))
+        ;; No OIDC
+        ctx))}))
+
+;; NOTE: Right now there is only one blanket :scope/admin
+;; Currently only applied when OIDC is used.
+(def authorize-oidc-request
+  "If an admin identity is present, check if it has the proper scope(s) for the
+  given action. No-op with no identity."
+  (interceptor
+   {:name ::authorize-oidc-request
+    :enter
+    (fn authorize-oidc-request [{admin-identity ::admin-identity
+                                 :as            ctx}]
+      (if admin-identity
+        (if (auth/authorize-action ctx admin-identity)
+          ctx
+          (assoc (chain/terminate ctx)
+                 :response
+                 {:status 401
+                  :body   {:error "Unauthorized Admin Action!"}}))
+        ctx))}))
+
+(defn- disable-jwt-interceptors
+  [{queue ::chain/queue :as ctx}]
+  (assoc ctx
+         ::chain/queue
+         (into (empty queue)
+               (remove
+                (comp
+                 #{::jwt/validate-jwt
+                   ::jwt/validate-jwt-account}
+                 :name)
+                queue))))
+
+(def ensure-oidc-identity
+  "If an admin identity is present, create or return the user, validating the
+  issuer. On success, inject the account ID and disable subsequent JWT
+  interceptors. No-op with no identity."
+  (interceptor
+   {:name ::ensure-oidc-identity
+    :enter
+    (fn ensure-oidc-identity [{lrs            :com.yetanalytics/lrs
+                               admin-identity ::admin-identity
+                               :as            ctx}]
+      (if admin-identity
+        (let [{:keys [username
+                      oidc-issuer]} admin-identity
+              {:keys [result]} (adp/-ensure-account-oidc
+                                lrs
+                                username
+                                oidc-issuer)]
+          (if (= :lrsql.admin/oidc-issuer-mismatch-error result)
+            (assoc (chain/terminate ctx)
+                   :response
+                   {:status 401
+                    :body   {:error "OIDC Issuer Mismatch!"}})
+            (-> ctx
+                disable-jwt-interceptors
+                (assoc-in [::jwt/data :account-id] result)
+                ;; NOTE: I do this to follow what is done for native JWT
+                ;; Don't think this app actually uses a session at all?
+                (assoc-in
+                 [:request :session ::jwt/data :account-id]
+                 result))))
+        ctx))}))

--- a/src/main/lrsql/admin/interceptors/oidc.clj
+++ b/src/main/lrsql/admin/interceptors/oidc.clj
@@ -37,7 +37,7 @@
     (fn authorize-oidc-request [{admin-identity ::admin-identity
                                  :as            ctx}]
       (if admin-identity
-        (if (auth/authorize-action ctx admin-identity)
+        (if (oidc/authorize-admin-action ctx admin-identity)
           ctx
           (assoc (chain/terminate ctx)
                  :response

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -12,7 +12,9 @@
   (-existing-account? [this account-id]
     "Check that the account with the given ID exists in the account table. Returns a boolean.")
   (-delete-account [this account-id]
-    "Delete the account and all associated creds. Assumes the account has already been authenticated."))
+    "Delete the account and all associated creds. Assumes the account has already been authenticated.")
+  (-ensure-account-oidc [this username oidc-issuer]
+    "Create or verify an existing admin account with the given username and oidc-issuer."))
 
 (defprotocol APIKeyManager
   (-create-api-keys [this account-id scopes]

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -97,10 +97,18 @@
   "Given a set of routes `routes` for a default LRS implementation,
    add additional routes specific to creating and updating admin
    accounts."
-  [{:keys [lrs exp leeway secret enable-admin-ui]} routes]
-  (let [common-interceptors (make-common-interceptors lrs)]
+  [{:keys [lrs
+           exp
+           leeway
+           secret
+           enable-admin-ui
+           oidc-interceptors]
+    :or {oidc-interceptors []}}
+   routes]
+  (let [common-interceptors (make-common-interceptors lrs)
+        common-interceptors-oidc (into common-interceptors)]
     (cset/union routes
-                (admin-account-routes common-interceptors secret exp leeway)
-                (admin-cred-routes common-interceptors secret leeway)
+                (admin-account-routes common-interceptors-oidc secret exp leeway)
+                (admin-cred-routes common-interceptors-oidc secret leeway)
                 (when enable-admin-ui
                   (admin-ui-routes common-interceptors)))))

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -106,7 +106,7 @@
     :or {oidc-interceptors []}}
    routes]
   (let [common-interceptors (make-common-interceptors lrs)
-        common-interceptors-oidc (into common-interceptors)]
+        common-interceptors-oidc (into common-interceptors oidc-interceptors)]
     (cset/union routes
                 (admin-account-routes common-interceptors-oidc secret exp leeway)
                 (admin-cred-routes common-interceptors-oidc secret leeway)

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -93,6 +93,7 @@
   (-delete-admin-account! [this tx input])
   ;; Queries
   (-query-account [this tx input])
+  (-query-account-oidc [this tx input])
   (-query-account-exists [this tx input])
   (-query-all-admin-accounts [this tx]))
 

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -89,6 +89,7 @@
 (defprotocol AdminAccountBackend
   ;; Commands
   (-insert-admin-account! [this tx input])
+  (-insert-admin-account-oidc! [this tx input])
   (-delete-admin-account! [this tx input])
   ;; Queries
   (-query-account [this tx input])

--- a/src/main/lrsql/init/oidc.clj
+++ b/src/main/lrsql/init/oidc.clj
@@ -123,7 +123,7 @@
   "Given a webserver config, return a (possibly empty) vector of interceptors
   for use with the admin API. These validate token claims and ensure an admin
   account is made."
-  [{:keys [oidc-issuer] :as config}]
+  [{:keys [oidc-issuer]}]
   (if oidc-issuer
     [admin-oidc/validate-oidc-identity
      admin-oidc/authorize-oidc-request

--- a/src/main/lrsql/init/oidc.clj
+++ b/src/main/lrsql/init/oidc.clj
@@ -70,7 +70,13 @@
                    ;; again
                    (get (reset! keyset-cache (jwt/get-keyset jwks-uri))
                         kid))))
-          :required? false)
+          :required? false
+          :unauthorized
+          ;; Allow unknown/nil key IDs through for possible subsequent handling
+          (fn [ctx failure & rest-args]
+            (if (= :kid-not-found failure)
+              ctx
+              (apply oidc-i/default-unauthorized ctx failure rest-args))))
          ;; This is a vector in case we need additional interceptors. At present
          ;; we do not.
          ])

--- a/src/main/lrsql/input/admin.clj
+++ b/src/main/lrsql/input/admin.clj
@@ -16,17 +16,27 @@
    :username    username
    :passhash    (adu/hash-password password)})
 
+(s/fdef ensure-admin-oidc-input
+  :args (s/cat :username ::ads/username
+               :oidc-issuer :lrsql.spec.admin.input/oidc-issuer)
+  :ret ads/ensure-admin-oidc-input-spec)
+
+(defn ensure-admin-oidc-input
+  "Given `username` and `oidc-issuer`, construct the input param map for
+  `ensure-admin-oidc!`"
+  [username oidc-issuer]
+  {:username    username
+   :oidc-issuer oidc-issuer})
+
 (s/fdef insert-admin-oidc-input
-  :args (s/cat :username ::ads/username :oidc-issuer :lrsql.spec.admin.input/oidc-issuer)
+  :args (s/cat :ensure-input ads/ensure-admin-oidc-input-spec)
   :ret ads/insert-admin-oidc-input-spec)
 
 (defn insert-admin-oidc-input
-  "Given `username` and `oidc-issuer`, construct the input param map for
+  "Given an input from ensure-admin-oidc-input, add a primary key for use in
   `insert-admin-oidc!`"
-  [username oidc-issuer]
-  {:primary-key (u/generate-squuid)
-   :username    username
-   :oidc-issuer oidc-issuer})
+  [ensure-input]
+  (u/add-primary-key ensure-input))
 
 (s/fdef delete-admin-input
   :args (s/cat :account-id ::ads/account-id)

--- a/src/main/lrsql/input/admin.clj
+++ b/src/main/lrsql/input/admin.clj
@@ -16,6 +16,18 @@
    :username    username
    :passhash    (adu/hash-password password)})
 
+(s/fdef insert-admin-oidc-input
+  :args (s/cat :username ::ads/username :oidc-issuer ::ads/oidc-issuer)
+  :ret ads/insert-admin-oidc-input-spec)
+
+(defn insert-admin-oidc-input
+  "Given `username` and `oidc-issuer`, construct the input param map for
+  `insert-admin-oidc!`"
+  [username oidc-issuer]
+  {:primary-key (u/generate-squuid)
+   :username    username
+   :oidc-issuer oidc-issuer})
+
 (s/fdef delete-admin-input
   :args (s/cat :account-id ::ads/account-id)
   :ret ads/admin-id-input-spec)

--- a/src/main/lrsql/input/admin.clj
+++ b/src/main/lrsql/input/admin.clj
@@ -12,18 +12,9 @@
   "Given `username` and `password`, construct the input param map for
    `insert-admin!`."
   [username password]
-  {:username    username
+  {:primary-key (u/generate-squuid)
+   :username    username
    :passhash    (adu/hash-password password)})
-
-(s/fdef insert-admin-account-input
-  :args (s/cat :insert-admin-input ads/insert-admin-input-spec)
-  :ret ads/insert-admin-account-input-spec)
-
-(defn insert-admin-account-input
-  "Given an input for the insert-admin! command, add a primary key suitable for
-  `-insert-admin-account!`"
-  [insert-admin-input]
-  (u/add-primary-key insert-admin-input))
 
 (s/fdef ensure-admin-oidc-input
   :args (s/cat :username ::ads/username

--- a/src/main/lrsql/input/admin.clj
+++ b/src/main/lrsql/input/admin.clj
@@ -12,9 +12,18 @@
   "Given `username` and `password`, construct the input param map for
    `insert-admin!`."
   [username password]
-  {:primary-key (u/generate-squuid)
-   :username    username
+  {:username    username
    :passhash    (adu/hash-password password)})
+
+(s/fdef insert-admin-account-input
+  :args (s/cat :insert-admin-input ads/insert-admin-input-spec)
+  :ret ads/insert-admin-account-input-spec)
+
+(defn insert-admin-account-input
+  "Given an input for the insert-admin! command, add a primary key suitable for
+  `-insert-admin-account!`"
+  [insert-admin-input]
+  (u/add-primary-key insert-admin-input))
 
 (s/fdef ensure-admin-oidc-input
   :args (s/cat :username ::ads/username

--- a/src/main/lrsql/input/admin.clj
+++ b/src/main/lrsql/input/admin.clj
@@ -17,7 +17,7 @@
    :passhash    (adu/hash-password password)})
 
 (s/fdef insert-admin-oidc-input
-  :args (s/cat :username ::ads/username :oidc-issuer ::ads/oidc-issuer)
+  :args (s/cat :username ::ads/username :oidc-issuer :lrsql.spec.admin.input/oidc-issuer)
   :ret ads/insert-admin-oidc-input-spec)
 
 (defn insert-admin-oidc-input

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -12,18 +12,18 @@
 (s/fdef insert-admin!
   :args (s/cat :bk ads/admin-backend?
                :tx transaction?
-               :input ads/insert-admin-input-spec)
+               :admin-input ads/insert-admin-input-spec)
   :ret ads/insert-admin-ret-spec)
 
 (defn insert-admin!
   "Insert a new admin username, hashed password, and the hash salt into the
    `admin_account` table. Returns a map with `:result` either being the
    account ID on success or an error keyword on failure."
-  [bk tx input]
-  (if-not (bp/-query-account-exists bk tx (select-keys input [:username]))
-    (do
-      (bp/-insert-admin-account! bk tx input)
-      {:result (:primary-key input)})
+  [bk tx admin-input]
+  (if-not (bp/-query-account-exists bk tx (select-keys admin-input [:username]))
+    (let [account-input (admin-i/insert-admin-account-input admin-input)]
+      (bp/-insert-admin-account! bk tx account-input)
+      {:result (:primary-key account-input)})
     {:result :lrsql.admin/existing-account-error}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -53,7 +53,7 @@
 (s/fdef ensure-admin-oidc!
   :args (s/cat :bk ads/admin-backend?
                :tx transaction?
-               :input ads/ensure-admin-oidc-input-spec)
+               :ensure-input ads/ensure-admin-oidc-input-spec)
   :ret ads/ensure-admin-ret-spec)
 
 (defn ensure-admin-oidc!

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -60,7 +60,7 @@
   "Create a new admin with OIDC issuer or verify issuer of an existing admin.
   Returns a map where `:result` is the account ID."
   [bk tx {:keys [username oidc-issuer]}]
-  (if-let [{extant-issuer :oidc-issuer
+  (if-let [{extant-issuer :oidc_issuer ;; TODO: is not coerced to kebab?
             id            :id} (bp/-query-account-oidc
                                 bk tx {:username username})]
     {:result

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -12,18 +12,18 @@
 (s/fdef insert-admin!
   :args (s/cat :bk ads/admin-backend?
                :tx transaction?
-               :admin-input ads/insert-admin-input-spec)
+               :input ads/insert-admin-input-spec)
   :ret ads/insert-admin-ret-spec)
 
 (defn insert-admin!
   "Insert a new admin username, hashed password, and the hash salt into the
    `admin_account` table. Returns a map with `:result` either being the
    account ID on success or an error keyword on failure."
-  [bk tx admin-input]
-  (if-not (bp/-query-account-exists bk tx (select-keys admin-input [:username]))
-    (let [account-input (admin-i/insert-admin-account-input admin-input)]
-      (bp/-insert-admin-account! bk tx account-input)
-      {:result (:primary-key account-input)})
+  [bk tx input]
+  (if-not (bp/-query-account-exists bk tx (select-keys input [:username]))
+    (do
+      (bp/-insert-admin-account! bk tx input)
+      {:result (:primary-key input)})
     {:result :lrsql.admin/existing-account-error}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -53,7 +53,7 @@
 (s/fdef ensure-admin-oidc!
   :args (s/cat :bk ads/admin-backend?
                :tx transaction?
-               :ensure-input ads/ensure-admin-oidc-input-spec)
+               :input ads/ensure-admin-oidc-input-spec)
   :ret ads/ensure-admin-ret-spec)
 
 (defn ensure-admin-oidc!

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -59,7 +59,8 @@
 (defn ensure-admin-oidc!
   "Create a new admin with OIDC issuer or verify issuer of an existing admin.
   Returns a map where `:result` is the account ID."
-  [bk tx {:keys [username oidc-issuer]}]
+  [bk tx {:keys [username oidc-issuer]
+          :as   ensure-input}]
   (if-let [{extant-issuer :oidc_issuer ;; TODO: is not coerced to kebab?
             id            :id} (bp/-query-account-oidc
                                 bk tx {:username username})]
@@ -68,7 +69,8 @@
        id
        :lrsql.admin/oidc-issuer-mismatch-error)}
     (let [{:keys [primary-key]
-           :as   input} (admin-i/insert-admin-oidc-input username oidc-issuer)]
+           :as   insert-input} (admin-i/insert-admin-oidc-input
+                                ensure-input)]
       (do
-        (bp/-insert-admin-account-oidc! bk tx input)
+        (bp/-insert-admin-account-oidc! bk tx insert-input)
         {:result primary-key}))))

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -71,6 +71,5 @@
     (let [{:keys [primary-key]
            :as   insert-input} (admin-i/insert-admin-oidc-input
                                 ensure-input)]
-      (do
-        (bp/-insert-admin-account-oidc! bk tx insert-input)
-        {:result primary-key}))))
+      (bp/-insert-admin-account-oidc! bk tx insert-input)
+      {:result primary-key})))

--- a/src/main/lrsql/ops/query/admin.clj
+++ b/src/main/lrsql/ops/query/admin.clj
@@ -43,7 +43,7 @@
     (cond
       (nil? res)
       {:result :lrsql.admin/missing-account-error}
-      (au/valid-password? (:password input) (:passhash res))
+      (and (:passhash res) (au/valid-password? (:password input) (:passhash res)))
       {:result (:account-id res)}
       :else
       {:result :lrsql.admin/invalid-password-error})))

--- a/src/main/lrsql/spec/admin.clj
+++ b/src/main/lrsql/spec/admin.clj
@@ -42,10 +42,6 @@
   (s/keys :req-un [::account-id]))
 
 (def insert-admin-input-spec
-  (s/keys :req-un [::username
-                   :lrsql.spec.admin.input/passhash]))
-
-(def insert-admin-account-input-spec
   (s/keys :req-un [::c/primary-key
                    ::username
                    :lrsql.spec.admin.input/passhash]))

--- a/src/main/lrsql/spec/admin.clj
+++ b/src/main/lrsql/spec/admin.clj
@@ -19,7 +19,9 @@
 (s/def ::account-id ::c/primary-key)
 (s/def ::username string?)
 (s/def ::password string?)
-(s/def ::passhash string?) ; format may vary by password lib
+;; passhash format may vary by password lib
+;; admins with nil passhash have not set passwords (for instance OIDC)
+(s/def ::passhash (s/nilable string?))
 (s/def ::uuid ::xs/uuid)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/main/lrsql/spec/admin.clj
+++ b/src/main/lrsql/spec/admin.clj
@@ -46,6 +46,10 @@
                    ::username
                    :lrsql.spec.admin.input/passhash]))
 
+(def ensure-admin-oidc-input-spec
+  (s/keys :req-un [:lrsql.spec.admin.input/oidc-issuer
+                   ::username]))
+
 (def insert-admin-oidc-input-spec
   (s/keys :req-un [::c/primary-key
                    ::username
@@ -69,6 +73,14 @@
 
 (def insert-admin-ret-spec
   (s/keys :req-un [:lrsql.spec.admin.insert/result]))
+
+(s/def :lrsql.spec.admin.ensure/result
+  (s/nonconforming
+   (s/or :success uuid?
+         :failure #{:lrsql.admin/oidc-issuer-mismatch-error})))
+
+(def ensure-admin-ret-spec
+  (s/keys :req-un [:lrsql.spec.admin.ensure/result]))
 
 (s/def :lrsql.spec.admin.delete/result
   (s/nonconforming

--- a/src/main/lrsql/spec/admin.clj
+++ b/src/main/lrsql/spec/admin.clj
@@ -42,6 +42,10 @@
   (s/keys :req-un [::account-id]))
 
 (def insert-admin-input-spec
+  (s/keys :req-un [::username
+                   :lrsql.spec.admin.input/passhash]))
+
+(def insert-admin-account-input-spec
   (s/keys :req-un [::c/primary-key
                    ::username
                    :lrsql.spec.admin.input/passhash]))

--- a/src/main/lrsql/spec/admin.clj
+++ b/src/main/lrsql/spec/admin.clj
@@ -20,8 +20,10 @@
 (s/def ::username string?)
 (s/def ::password string?)
 ;; passhash format may vary by password lib
-;; admins with nil passhash have not set passwords (for instance OIDC)
-(s/def ::passhash (s/nilable string?))
+;; Input passhash is not nilable
+(s/def :lrsql.spec.admin.input/passhash string?)
+;; Ret passhash (from SQL) is nilable
+(s/def :lrsql.spec.admin.ret/passhash (s/nilable string?))
 (s/def ::uuid ::xs/uuid)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -38,7 +40,7 @@
 (def insert-admin-input-spec
   (s/keys :req-un [::c/primary-key
                    ::username
-                   ::passhash]))
+                   :lrsql.spec.admin.input/passhash]))
 
 (def query-validate-admin-input-spec
   (s/keys :req-un [::username
@@ -75,7 +77,7 @@
 
 (def query-admin-ret-spec
   (s/keys :req-un [::account-id
-                   ::passhash]))
+                   :lrsql.spec.admin.ret/passhash]))
 
 (def query-all-admin-accounts-ret-spec
   (s/every (s/keys :req-un [::account-id

--- a/src/main/lrsql/spec/admin.clj
+++ b/src/main/lrsql/spec/admin.clj
@@ -25,6 +25,10 @@
 ;; Ret passhash (from SQL) is nilable
 (s/def :lrsql.spec.admin.ret/passhash (s/nilable string?))
 (s/def ::uuid ::xs/uuid)
+;; Likewise, OIDC issuer is not nilable for inputs
+(s/def :lrsql.spec.admin.input/oidc-issuer string?)
+;; But is for ret
+(s/def :lrsql.spec.admin.ret/oidc-issuer (s/nilable string?))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Inputs
@@ -41,6 +45,11 @@
   (s/keys :req-un [::c/primary-key
                    ::username
                    :lrsql.spec.admin.input/passhash]))
+
+(def insert-admin-oidc-input-spec
+  (s/keys :req-un [::c/primary-key
+                   ::username
+                   :lrsql.spec.admin.input/oidc-issuer]))
 
 (def query-validate-admin-input-spec
   (s/keys :req-un [::username

--- a/src/main/lrsql/spec/config.clj
+++ b/src/main/lrsql/spec/config.clj
@@ -154,6 +154,7 @@
 
 (s/def ::oidc-issuer (s/nilable string?))
 (s/def ::oidc-config (s/nilable string?))
+(s/def ::oidc-audience (s/nilable string?))
 (s/def ::jwks-uri (s/nilable string?))
 
 (s/def ::webserver
@@ -175,6 +176,7 @@
                    ::key-cert-chain
                    ::oidc-issuer
                    ::oidc-config
+                   ::oidc-audience
                    ::jwks-uri]))
 
 (def config-spec

--- a/src/main/lrsql/spec/config.clj
+++ b/src/main/lrsql/spec/config.clj
@@ -153,10 +153,8 @@
 (s/def ::enable-stmt-html boolean?)
 
 (s/def ::oidc-issuer (s/nilable string?))
-(s/def ::oidc-config (s/nilable string?))
 (s/def ::oidc-audience (s/nilable string?))
 (s/def ::oidc-verify-remote-issuer boolean?)
-(s/def ::jwks-uri (s/nilable string?))
 
 (s/def ::webserver
   (s/keys :req-un [::http-host
@@ -177,9 +175,7 @@
                    ::key-pkey-file
                    ::key-cert-chain
                    ::oidc-issuer
-                   ::oidc-config
-                   ::oidc-audience
-                   ::jwks-uri]))
+                   ::oidc-audience]))
 
 (def config-spec
   (s/keys :req-un [::connection

--- a/src/main/lrsql/spec/config.clj
+++ b/src/main/lrsql/spec/config.clj
@@ -155,6 +155,7 @@
 (s/def ::oidc-issuer (s/nilable string?))
 (s/def ::oidc-config (s/nilable string?))
 (s/def ::oidc-audience (s/nilable string?))
+(s/def ::oidc-verify-remote-issuer boolean?)
 (s/def ::jwks-uri (s/nilable string?))
 
 (s/def ::webserver
@@ -170,7 +171,8 @@
                    ::jwt-exp-time
                    ::jwt-exp-leeway
                    ::enable-admin-ui
-                   ::enable-stmt-html]
+                   ::enable-stmt-html
+                   ::oidc-verify-remote-issuer]
           :opt-un [::key-file
                    ::key-pkey-file
                    ::key-cert-chain

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -263,10 +263,10 @@
         (admin-cmd/delete-admin! backend tx input))))
   (-ensure-account-oidc
     [this username oidc-issuer]
-    (let [conn  (lrs-conn this)]
+    (let [conn  (lrs-conn this)
+          input (admin-input/ensure-admin-oidc-input username oidc-issuer)]
       (jdbc/with-transaction [tx conn]
-        (admin-cmd/ensure-admin-oidc! backend tx {:username    username
-                                                  :oidc-issuer oidc-issuer}))))
+        (admin-cmd/ensure-admin-oidc! backend tx input))))
 
   adp/APIKeyManager
   (-create-api-keys

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -261,6 +261,12 @@
           input (admin-input/delete-admin-input account-id)]
       (jdbc/with-transaction [tx conn]
         (admin-cmd/delete-admin! backend tx input))))
+  (-ensure-account-oidc
+    [this username oidc-issuer]
+    (let [conn  (lrs-conn this)]
+      (jdbc/with-transaction [tx conn]
+        (admin-cmd/ensure-admin-oidc! backend tx {:username    username
+                                                  :oidc-issuer oidc-issuer}))))
 
   adp/APIKeyManager
   (-create-api-keys

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -34,20 +34,25 @@
                 private-key]} (cu/init-keystore config)
         ;; OIDC Resource Interceptors
         oidc-interceptors (oidc/resource-interceptors config)
+        ;; OIDC Admin Interceptors
+        oidc-admin-interceptors
+        (into oidc-interceptors
+              (oidc/admin-interceptors config))
         ;; Make routes - the lrs error interceptor is appended to the
         ;; start to all lrs routes
-        routes (->> (build {:lrs               lrs
-                            :path-prefix       url-prefix
-                            :wrap-interceptors (into
-                                                [i/error-interceptor
-                                                 (handle-json-parse-exn)]
-                                                oidc-interceptors)})
-                    (add-admin-routes {:lrs               lrs
-                                       :exp               jwt-exp
-                                       :leeway            jwt-lwy
-                                       :secret            private-key
-                                       :enable-admin-ui   enable-admin-ui
-                                       :oidc-interceptors oidc-interceptors}))]
+        routes
+        (->> (build {:lrs               lrs
+                     :path-prefix       url-prefix
+                     :wrap-interceptors (into
+                                         [i/error-interceptor
+                                          (handle-json-parse-exn)]
+                                         oidc-interceptors)})
+             (add-admin-routes {:lrs               lrs
+                                :exp               jwt-exp
+                                :leeway            jwt-lwy
+                                :secret            private-key
+                                :enable-admin-ui   enable-admin-ui
+                                :oidc-interceptors oidc-admin-interceptors}))]
     {:env                      :prod
      ::http/routes             routes
      ;; only serve assets if the admin ui is enabled

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -32,6 +32,8 @@
         ;; The private key is used as the JWT symmetric secret
         {:keys [keystore
                 private-key]} (cu/init-keystore config)
+        ;; OIDC Resource Interceptors
+        oidc-interceptors (oidc/resource-interceptors config)
         ;; Make routes - the lrs error interceptor is appended to the
         ;; start to all lrs routes
         routes (->> (build {:lrs               lrs
@@ -39,13 +41,13 @@
                             :wrap-interceptors (into
                                                 [i/error-interceptor
                                                  (handle-json-parse-exn)]
-                                                (oidc/resource-interceptors
-                                                 config))})
-                    (add-admin-routes {:lrs    lrs
-                                       :exp    jwt-exp
-                                       :leeway jwt-lwy
-                                       :secret private-key
-                                       :enable-admin-ui enable-admin-ui}))]
+                                                oidc-interceptors)})
+                    (add-admin-routes {:lrs               lrs
+                                       :exp               jwt-exp
+                                       :leeway            jwt-lwy
+                                       :secret            private-key
+                                       :enable-admin-ui   enable-admin-ui
+                                       :oidc-interceptors oidc-interceptors}))]
     {:env                      :prod
      ::http/routes             routes
      ;; only serve assets if the admin ui is enabled

--- a/src/main/lrsql/util.clj
+++ b/src/main/lrsql/util.clj
@@ -10,7 +10,7 @@
             [com.yetanalytics.squuid :as squuid]
             [com.yetanalytics.lrs.xapi.document :refer [json-bytes-gen-fn]]
             [com.yetanalytics.lrs.xapi.statements.timestamp :refer [normalize]]
-            [lrsql.spec.common :refer [instant-spec]])
+            [lrsql.spec.common :as cs :refer [instant-spec]])
   (:import [java.util UUID]
            [java.time Instant]
            [java.io StringReader PushbackReader ByteArrayOutputStream]))
@@ -168,6 +168,15 @@
   "Convert a UUID into a string."
   [uuid]
   (clj-uuid/to-string uuid))
+
+(s/fdef add-primary-key
+  :args (s/cat :input map?)
+  :ret (s/keys :req-un [::cs/primary-key]))
+
+(defn add-primary-key
+  "Add a :primary-key squuid to an input map."
+  [input]
+  (assoc input :primary-key (generate-squuid)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; JSON

--- a/src/main/lrsql/util/auth.clj
+++ b/src/main/lrsql/util/auth.clj
@@ -14,8 +14,7 @@
   {"all"                  :scope/all
    "all/read"             :scope/all.read
    "statements/read"      :scope/statements.read
-   "statements/write"     :scope/statements.write
-   "admin"                :scope/admin})
+   "statements/write"     :scope/statements.write})
 
 (def scope-kw-str-map
   (cset/map-invert scope-str-kw-map))
@@ -79,8 +78,7 @@
 (s/def ::scope #{:scope/all
                  :scope/all.read
                  :scope/statements.read
-                 :scope/statements.write
-                 :scope/admin})
+                 :scope/statements.write})
 (s/def ::scopes (s/coll-of ::scope :kind set?))
 
 (s/def ::result boolean?)
@@ -102,9 +100,6 @@
   {:result
    (boolean
     (or
-     ;; Admin access via OIDC
-     (and (cstr/starts-with? path-info "/admin")
-          (contains? scopes :scope/admin))
      ;; `all` scope: everything is permitted
      (contains? scopes :scope/all)
      ;; `all/read` scope: only GET/HEAD requests permitted

--- a/src/main/lrsql/util/auth.clj
+++ b/src/main/lrsql/util/auth.clj
@@ -14,7 +14,8 @@
   {"all"                  :scope/all
    "all/read"             :scope/all.read
    "statements/read"      :scope/statements.read
-   "statements/write"     :scope/statements.write})
+   "statements/write"     :scope/statements.write
+   "admin"                :scope/admin})
 
 (def scope-kw-str-map
   (cset/map-invert scope-str-kw-map))
@@ -78,7 +79,8 @@
 (s/def ::scope #{:scope/all
                  :scope/all.read
                  :scope/statements.read
-                 :scope/statements.write})
+                 :scope/statements.write
+                 :scope/admin})
 (s/def ::scopes (s/coll-of ::scope :kind set?))
 
 (s/def ::result boolean?)
@@ -100,6 +102,9 @@
   {:result
    (boolean
     (or
+     ;; Admin access via OIDC
+     (and (cstr/starts-with? path-info "/admin")
+          (contains? scopes :scope/admin))
      ;; `all` scope: everything is permitted
      (contains? scopes :scope/all)
      ;; `all/read` scope: only GET/HEAD requests permitted

--- a/src/main/lrsql/util/oidc.clj
+++ b/src/main/lrsql/util/oidc.clj
@@ -7,8 +7,7 @@
             [lrsql.init.authority :as authority]
             [lrsql.spec.admin :as admin]
             [lrsql.spec.config :as config]
-            [lrsql.util.auth :as auth])
-  (:import [java.io File]))
+            [lrsql.util.auth :as auth]))
 
 ;; OIDC supports an additional scope `admin` that allows all admin actions
 
@@ -142,11 +141,10 @@
     scope-prefix - Prefix to add to expected scopes."
   [ctx
    scope-prefix]
-  (when-let [token (:com.yetanalytics.pedestal-oidc/token ctx)]
-    (let [{:keys [scope iss sub]
-           :as   claims} (get-in ctx
-                                 [:request
-                                  :com.yetanalytics.pedestal-oidc/claims])]
+  (when (:com.yetanalytics.pedestal-oidc/token ctx)
+    (let [{:keys [scope iss sub]} (get-in ctx
+                                          [:request
+                                           :com.yetanalytics.pedestal-oidc/claims])]
       (if-let [scopes (and (not-empty iss)
                            (not-empty sub)
                            (some-> scope
@@ -168,7 +166,7 @@
 
 (defn authorize-admin-action
   "Given a pedestal context and an OIDC admin auth identity, authorize or deny."
-  [{{:keys [request-method path-info]} :request
+  [{{:keys [path-info]} :request
     :as _ctx}
    {:keys [scopes]
     :as _auth-identity}]

--- a/src/main/lrsql/util/oidc.clj
+++ b/src/main/lrsql/util/oidc.clj
@@ -10,8 +10,17 @@
             [lrsql.util.auth :as auth])
   (:import [java.io File]))
 
+;; OIDC supports an additional scope `admin` that allows all admin actions
+
+(def oidc-scope-str-kw-map
+  {"admin" :scope/admin})
+
+(s/def ::scope
+  #{:scope/admin})
+
 (defn- get-scope-map*
-  [prefix]
+  [scope-map
+   prefix]
   (reduce-kv
    (fn [m k v]
      (assoc
@@ -19,34 +28,48 @@
       (str prefix k)
       v))
    {}
-   auth/scope-str-kw-map))
+   scope-map))
 
 (def get-scope-map
   (memoize get-scope-map*))
 
 (s/def ::scope-prefix ::config/oidc-scope-prefix)
+(s/def ::scope-map (s/map-of string? qualified-keyword?))
 
 (s/fdef parse-scope-claim
   :args (s/cat :scope-str string?
                :kwargs (s/keys*
-                        :opt-un [::scope-prefix]))
-  :ret (s/every ::auth/scope))
+                        :opt-un [::scope-prefix
+                                 ::scope-map]))
+  :ret (s/nonconforming
+        (s/or
+         :lrs-scopes
+         (s/every ::auth/scope)
+         :admin-scopes
+         (s/every ::scope))))
 
 (defn parse-scope-claim
   "Parse the scope claim and match to lrsql scope keywords, prepending
   any scope-prefix provided before matching"
   [scope-str
-   & {:keys [scope-prefix]
-      :or   {scope-prefix ""}}]
-  (keep (get-scope-map scope-prefix)
+   & {:keys [scope-map
+             scope-prefix]
+      :or   {scope-map    auth/scope-str-kw-map
+             scope-prefix ""}}]
+  (keep (get-scope-map scope-map scope-prefix)
         (cs/split scope-str #"\s")))
+
+(s/def :lrsql.util.oidc.token-auth-identity/result
+  (s/nonconforming
+   (s/or :unauthorized #{::lrs-auth/unauthorized}
+         :auth-identity (s/keys :req-un [::auth/scopes]))))
 
 (s/fdef token-auth-identity
   :args (s/cat :ctx map?
                :authority-fn fn?
                :scope-prefix ::config/oidc-scope-prefix)
   :ret (s/nilable
-        ::lrs-auth/identity))
+        (s/keys :req-un [:lrsql.util.oidc.token-auth-identity/result])))
 
 (defn token-auth-identity
   "For the given context, return a valid auth identity from token claims. If no
@@ -90,16 +113,26 @@
          ;; no valid scopes, can't do anything
          :com.yetanalytics.lrs.auth/unauthorized)})))
 
+;; Only auth scopes
+(s/def ::scopes
+  (s/every ::scope :kind set? :into #{}))
+
+(s/def ::oidc-admin-identity
+  (s/keys :req-un [::scopes
+                   ::admin/username
+                   :lrsql.spec.admin.input/oidc-issuer]))
+
+(s/def :lrsql.util.oidc.token-auth-admin-identity/result
+  (s/nonconforming
+   (s/or :unauthorized #{::unauthorized}
+         :auth-identity
+         ::oidc-admin-identity)))
+
 (s/fdef token-auth-admin-identity
   :args (s/cat :ctx map?
                :scope-prefix ::config/oidc-scope-prefix)
   :ret (s/nilable
-        (s/nonconforming
-         (s/or :unauthorized #{::unauthorized}
-               :admin-identity
-               (s/keys :req-un [::auth/scopes
-                                ::admin/username
-                                :lrsql.spec.admin.input/oidc-issuer])))))
+        :lrsql.util.oidc.token-auth-admin-identity/result))
 
 (defn token-auth-admin-identity
   "For the given context, return a valid OIDC admin auth identity from token
@@ -118,7 +151,8 @@
                            (not-empty sub)
                            (some-> scope
                                    (parse-scope-claim
-                                    :scope-prefix scope-prefix)
+                                    :scope-prefix scope-prefix
+                                    :scope-map oidc-scope-str-kw-map)
                                    not-empty
                                    (->> (into #{}))))]
         {:scopes      scopes
@@ -126,3 +160,19 @@
          :oidc-issuer iss}
         ;; no valid scopes, can't do anything
         ::unauthorized))))
+
+(s/fdef authorize-admin-action
+  :args (s/cat :ctx           (s/keys :req-un [::auth/request])
+               :auth-identity (s/keys :req-un [::scopes]))
+  :ret (s/keys :req-un [::auth/result]))
+
+(defn authorize-admin-action
+  "Given a pedestal context and an OIDC admin auth identity, authorize or deny."
+  [{{:keys [request-method path-info]} :request
+    :as _ctx}
+   {:keys [scopes]
+    :as _auth-identity}]
+  {:result
+   (boolean
+    (and (cs/starts-with? path-info "/admin")
+         (contains? scopes :scope/admin)))})

--- a/src/main/lrsql/util/oidc.clj
+++ b/src/main/lrsql/util/oidc.clj
@@ -94,9 +94,12 @@
   :args (s/cat :ctx map?
                :scope-prefix ::config/oidc-scope-prefix)
   :ret (s/nilable
-        (s/keys :req-un [::auth/scopes
-                         ::admin/username
-                         :lrsql.spec.admin.input/oidc-issuer])))
+        (s/nonconforming
+         (s/or :unauthorized #{::unauthorized}
+               :admin-identity
+               (s/keys :req-un [::auth/scopes
+                                ::admin/username
+                                :lrsql.spec.admin.input/oidc-issuer])))))
 
 (defn token-auth-admin-identity
   "For the given context, return a valid OIDC admin auth identity from token

--- a/src/test/lrsql/admin/protocol_test.clj
+++ b/src/test/lrsql/admin/protocol_test.clj
@@ -62,6 +62,21 @@
         (is (-> (adp/-authenticate-account lrs test-username test-password)
                 :result
                 (= :lrsql.admin/missing-account-error)))))
+    (testing "Admin account OIDC bootstrap"
+      (let [username    "oidcsub"
+            oidc-issuer "https://example.com/realm"
+            bad-issuer  "https://impostor.com/realm"]
+        ;; Creates if does not exist
+        (is (-> (adp/-ensure-account-oidc lrs username oidc-issuer)
+                :result
+                uuid?))
+        ;; Idempotent
+        (is (= (adp/-ensure-account-oidc lrs username oidc-issuer)
+               (adp/-ensure-account-oidc lrs username oidc-issuer)))
+        ;; OIDC issuer must match
+        (is (-> (adp/-ensure-account-oidc lrs username bad-issuer)
+                :result
+                (= :lrsql.admin/oidc-issuer-mismatch-error)))))
     (component/stop sys')))
 
 ;; TODO: Add tests for creds with no explicit scopes, once

--- a/src/test/lrsql/init/oidc_test.clj
+++ b/src/test/lrsql/init/oidc_test.clj
@@ -8,12 +8,14 @@
   (testing "Slurps configuration"
     (testing "From issuer"
       (is (= "https://server.example.com"
-             (-> {:oidc-issuer "dev-resources/oidc"}
+             (-> {:oidc-issuer "dev-resources/oidc"
+                  :oidc-verify-remote-issuer false}
                  get-configuration
                  (get "issuer")))))
     (testing "From custom config loc"
       (is (= "https://server.example.com"
-             (-> {:oidc-config "dev-resources/oidc/.well-known/openid-configuration"}
+             (-> {:oidc-config "dev-resources/oidc/.well-known/openid-configuration"
+                  :oidc-verify-remote-issuer false}
                  get-configuration
                  (get "issuer")))))))
 

--- a/src/test/lrsql/init/oidc_test.clj
+++ b/src/test/lrsql/init/oidc_test.clj
@@ -11,12 +11,6 @@
              (-> {:oidc-issuer "dev-resources/oidc"
                   :oidc-verify-remote-issuer false}
                  get-configuration
-                 (get "issuer")))))
-    (testing "From custom config loc"
-      (is (= "https://server.example.com"
-             (-> {:oidc-config "dev-resources/oidc/.well-known/openid-configuration"
-                  :oidc-verify-remote-issuer false}
-                 get-configuration
                  (get "issuer")))))))
 
 (deftest resolve-authority-claims-test

--- a/src/test/lrsql/input/input_test.clj
+++ b/src/test/lrsql/input/input_test.clj
@@ -51,6 +51,7 @@
 (deftest test-admin
   (testing "admin account inputs"
     (is (nil? (check-validate `i-admin/insert-admin-input 3)))
+    (is (nil? (check-validate `i-admin/insert-admin-oidc-input 3)))
     (is (nil? (check-validate `i-admin/query-validate-admin-input)))
     (is (nil? (check-validate `i-admin/query-admin-exists-input)))
     (is (nil? (check-validate `i-admin/delete-admin-input)))))

--- a/src/test/lrsql/util/auth_test.clj
+++ b/src/test/lrsql/util/auth_test.clj
@@ -119,14 +119,6 @@
              :scopes         #{}}
       false {:request-method :delete
              :path-info      "xapi/activities/state"
-             :scopes         #{}}
-      ;; Admin Scope
-      ;; Not used for xAPI, only for Admin requests
-      true {:request-method :get
-            :path-info      "/admin/account"
-            :scopes         #{:scope/admin}}
-      false {:request-method :get
-             :path-info      "/admin/account"
              :scopes         #{}}))
   (testing "authorize-action gentest"
     (is (nil? (check-validate `au/authorize-action)))))

--- a/src/test/lrsql/util/auth_test.clj
+++ b/src/test/lrsql/util/auth_test.clj
@@ -119,6 +119,14 @@
              :scopes         #{}}
       false {:request-method :delete
              :path-info      "xapi/activities/state"
+             :scopes         #{}}
+      ;; Admin Scope
+      ;; Not used for xAPI, only for Admin requests
+      true {:request-method :get
+            :path-info      "/admin/account"
+            :scopes         #{:scope/admin}}
+      false {:request-method :get
+             :path-info      "/admin/account"
              :scopes         #{}}))
   (testing "authorize-action gentest"
     (is (nil? (check-validate `au/authorize-action)))))


### PR DESCRIPTION
[SQL-137][SQL-139] Enable OIDC auth + admin account shadowing.

This PR wraps the admin API with interceptors that will:
* Decode an OIDC token
* Check it for claim scope (right now there is just a blanket `admin` scope)
* Ensure that a local admin account is created to shadow
  * When an account exists, verifies that the OIDC issuer matches
* Passes the identity for use by identified admin operations, disabling the subsequent native JWT checks.

This enables OIDC clients to directly hit the admin API, enabling a wide range of use cases and not limiting administration to the provided UI.

Additional OIDC base improvements:
* Removed alternate config in favor of issuer
* Added optional token audience verification

[SQL-137]: https://yet.atlassian.net/browse/SQL-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SQL-139]: https://yet.atlassian.net/browse/SQL-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ