### PR TITLE
SQL-137 example triggering migrations by expected schema_version

### DIFF
--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -78,7 +78,8 @@
     (create-credential-table! tx)
     (create-credential-to-scope-table! tx))
   (-update-all! [_ tx]
-    (when (= 1 (:notnull (query-admin-account-passhash-notnull tx)))
+    ;; For each update, expect a version. Requery on each
+    (when (= 23 (:schema_version (query-schema-version tx)))
       (update-schema-simple tx alter-admin-account-passhash-optional!))
     (log/infof "sqlite schema_version: %d"
                (:schema_version (query-schema-version tx))))

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -272,12 +272,6 @@ PRAGMA schema_version = :sql:schema_version
 
 /* Migration 2022-02-22-00 - Set admin_account.passhash to optional */
 
--- :name query-admin-account-passhash-notnull
--- :command :query
--- :result :one
--- :doc Query to see if admin_account passhash is required.
-SELECT "notnull" FROM pragma_table_info('admin_account') where name='passhash'
-
 -- :name alter-admin-account-passhash-optional!
 -- :command :execute
 -- :doc Set `admin_account.passhash` to optional.


### PR DESCRIPTION
Example of serial migrations by expected `schema_version` in sqlite. Don't know if this is the right approach, offering this for discussion