### PR TITLE
SQL-143 add CCG client to keycloak demo

### DIFF
--- a/dev-resources/keycloak_demo/test-realm.json
+++ b/dev-resources/keycloak_demo/test-realm.json
@@ -1,2084 +1,2060 @@
 {
-    "id" : "test",
-    "realm" : "test",
-    "notBefore" : 1642523586,
-    "defaultSignatureAlgorithm" : "RS256",
-    "revokeRefreshToken" : false,
-    "refreshTokenMaxReuse" : 0,
-    "accessTokenLifespan" : 300,
-    "accessTokenLifespanForImplicitFlow" : 900,
-    "ssoSessionIdleTimeout" : 1800,
-    "ssoSessionMaxLifespan" : 36000,
-    "ssoSessionIdleTimeoutRememberMe" : 0,
-    "ssoSessionMaxLifespanRememberMe" : 0,
-    "offlineSessionIdleTimeout" : 2592000,
-    "offlineSessionMaxLifespanEnabled" : false,
-    "offlineSessionMaxLifespan" : 5184000,
-    "clientSessionIdleTimeout" : 0,
-    "clientSessionMaxLifespan" : 0,
-    "clientOfflineSessionIdleTimeout" : 0,
-    "clientOfflineSessionMaxLifespan" : 0,
-    "accessCodeLifespan" : 60,
-    "accessCodeLifespanUserAction" : 300,
-    "accessCodeLifespanLogin" : 1800,
-    "actionTokenGeneratedByAdminLifespan" : 43200,
-    "actionTokenGeneratedByUserLifespan" : 300,
-    "oauth2DeviceCodeLifespan" : 600,
-    "oauth2DevicePollingInterval" : 5,
-    "enabled" : true,
-    "sslRequired" : "external",
-    "registrationAllowed" : false,
-    "registrationEmailAsUsername" : false,
-    "rememberMe" : false,
-    "verifyEmail" : false,
-    "loginWithEmailAllowed" : true,
-    "duplicateEmailsAllowed" : false,
-    "resetPasswordAllowed" : false,
-    "editUsernameAllowed" : false,
-    "bruteForceProtected" : false,
-    "permanentLockout" : false,
-    "maxFailureWaitSeconds" : 900,
-    "minimumQuickLoginWaitSeconds" : 60,
-    "waitIncrementSeconds" : 60,
-    "quickLoginCheckMilliSeconds" : 1000,
-    "maxDeltaTimeSeconds" : 43200,
-    "failureFactor" : 30,
-    "roles" : {
-        "realm" : [ {
-            "id" : "c5f4c2f3-0d0a-41cd-be51-58eeb1b38514",
-            "name" : "uma_authorization",
-            "description" : "${role_uma_authorization}",
-            "composite" : false,
-            "clientRole" : false,
-            "containerId" : "test",
-            "attributes" : { }
-        }, {
-            "id" : "07cf52bc-5dce-4b29-8a6c-03d4f49d95b4",
-            "name" : "offline_access",
-            "description" : "${role_offline-access}",
-            "composite" : false,
-            "clientRole" : false,
-            "containerId" : "test",
-            "attributes" : { }
-        }, {
-            "id" : "d84a5ad7-ef32-4c7f-bfed-63256266c721",
-            "name" : "default-roles-test",
-            "description" : "${role_default-roles}",
-            "composite" : true,
-            "composites" : {
-                "realm" : [ "offline_access", "uma_authorization" ],
-                "client" : {
-                    "account" : [ "view-profile", "manage-account" ]
-                }
-            },
-            "clientRole" : false,
-            "containerId" : "test",
-            "attributes" : { }
-        } ],
+  "id" : "test",
+  "realm" : "test",
+  "notBefore" : 1642523586,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "c5f4c2f3-0d0a-41cd-be51-58eeb1b38514",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "test",
+      "attributes" : { }
+    }, {
+      "id" : "07cf52bc-5dce-4b29-8a6c-03d4f49d95b4",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "test",
+      "attributes" : { }
+    }, {
+      "id" : "d84a5ad7-ef32-4c7f-bfed-63256266c721",
+      "name" : "default-roles-test",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
         "client" : {
-            "realm-management" : [ {
-                "id" : "90f9feb7-3f87-4afe-ac9c-d68601f2735c",
-                "name" : "query-groups",
-                "description" : "${role_query-groups}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "803566ff-911d-4a3c-abd5-e492f11bf019",
-                "name" : "view-events",
-                "description" : "${role_view-events}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "81629562-dd95-4e74-8e2a-91e99afdd739",
-                "name" : "view-authorization",
-                "description" : "${role_view-authorization}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "f13b65bc-3591-434d-a74f-ddc5fee3b23b",
-                "name" : "query-realms",
-                "description" : "${role_query-realms}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "224b0eb1-81c2-42ff-bd70-74c4da9d3f02",
-                "name" : "create-client",
-                "description" : "${role_create-client}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "635e39b4-0c9c-4421-8767-240d0f11bb16",
-                "name" : "manage-users",
-                "description" : "${role_manage-users}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "aaa49cca-cce6-4ad4-8eda-c8239c773502",
-                "name" : "view-users",
-                "description" : "${role_view-users}",
-                "composite" : true,
-                "composites" : {
-                    "client" : {
-                        "realm-management" : [ "query-users", "query-groups" ]
-                    }
-                },
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "826a472d-6694-4778-b581-36f51e9dddc8",
-                "name" : "view-identity-providers",
-                "description" : "${role_view-identity-providers}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "7922f15b-8b87-4742-b764-39f4ed816a74",
-                "name" : "manage-authorization",
-                "description" : "${role_manage-authorization}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "86c58c5c-6b3f-4b63-bb6b-6baf6af177e1",
-                "name" : "manage-clients",
-                "description" : "${role_manage-clients}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "806ea0bf-d63c-4e21-a63d-735910488fa5",
-                "name" : "impersonation",
-                "description" : "${role_impersonation}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "b9c2dc0d-d35e-4a04-91f0-5170fbef7b87",
-                "name" : "view-realm",
-                "description" : "${role_view-realm}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "60a907de-14b4-4004-9a7e-4300a9afb2c0",
-                "name" : "query-users",
-                "description" : "${role_query-users}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "d23cdc0a-795e-42c6-b6a8-07a7dfa0f151",
-                "name" : "manage-events",
-                "description" : "${role_manage-events}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "6b6b4b28-b594-4379-b0dc-2cde8fddeca0",
-                "name" : "realm-admin",
-                "description" : "${role_realm-admin}",
-                "composite" : true,
-                "composites" : {
-                    "client" : {
-                        "realm-management" : [ "query-groups", "view-events", "view-authorization", "query-realms", "create-client", "manage-users", "view-users", "view-identity-providers", "manage-authorization", "manage-clients", "impersonation", "view-realm", "query-users", "manage-events", "manage-identity-providers", "query-clients", "manage-realm", "view-clients" ]
-                    }
-                },
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "a2220563-986a-4ef8-ae38-0546f11a1e9c",
-                "name" : "manage-identity-providers",
-                "description" : "${role_manage-identity-providers}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "8afdbb17-4b6e-4b2f-8609-77a3c5a0179c",
-                "name" : "query-clients",
-                "description" : "${role_query-clients}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "b184e0ae-a474-4651-97e8-d28435700a73",
-                "name" : "manage-realm",
-                "description" : "${role_manage-realm}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            }, {
-                "id" : "9d6e1fc4-1949-4cf6-bb77-06633ad90077",
-                "name" : "view-clients",
-                "description" : "${role_view-clients}",
-                "composite" : true,
-                "composites" : {
-                    "client" : {
-                        "realm-management" : [ "query-clients" ]
-                    }
-                },
-                "clientRole" : true,
-                "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
-                "attributes" : { }
-            } ],
-            "security-admin-console" : [ ],
-            "admin-cli" : [ ],
-            "account-console" : [ ],
-            "broker" : [ {
-                "id" : "4ec62d80-1cd7-4502-8029-e93d920b69ae",
-                "name" : "read-token",
-                "description" : "${role_read-token}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "9cdbf3ec-85f6-4366-956b-d1556302eac1",
-                "attributes" : { }
-            } ],
-            "lrs" : [ ],
-            "account" : [ {
-                "id" : "e34fd9d6-b441-4415-a77d-857f456dd024",
-                "name" : "manage-consent",
-                "description" : "${role_manage-consent}",
-                "composite" : true,
-                "composites" : {
-                    "client" : {
-                        "account" : [ "view-consent" ]
-                    }
-                },
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            }, {
-                "id" : "8f99b9d9-abb3-42e3-828e-504068c5666c",
-                "name" : "manage-account-links",
-                "description" : "${role_manage-account-links}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            }, {
-                "id" : "e199034f-3da1-48d0-82ed-9cde5920528f",
-                "name" : "delete-account",
-                "description" : "${role_delete-account}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            }, {
-                "id" : "be80bb48-9ca7-4517-9f70-98acea96b8d6",
-                "name" : "view-consent",
-                "description" : "${role_view-consent}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            }, {
-                "id" : "5b050df5-1366-46fe-ab90-cd43a659724c",
-                "name" : "view-profile",
-                "description" : "${role_view-profile}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            }, {
-                "id" : "689b7ad1-019f-4449-b0f9-4caf6fac4ac8",
-                "name" : "manage-account",
-                "description" : "${role_manage-account}",
-                "composite" : true,
-                "composites" : {
-                    "client" : {
-                        "account" : [ "manage-account-links" ]
-                    }
-                },
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            }, {
-                "id" : "a1ab542d-c481-4dc2-9455-cbb78c8325e5",
-                "name" : "view-applications",
-                "description" : "${role_view-applications}",
-                "composite" : false,
-                "clientRole" : true,
-                "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-                "attributes" : { }
-            } ],
-            "lrs_admin_ui" : [ ]
+          "account" : [ "view-profile", "manage-account" ]
         }
-    },
-    "groups" : [ {
-        "id" : "617dd33a-0ec4-4ad3-b496-d792020e839c",
-        "name" : "developers",
-        "path" : "/developers",
-        "attributes" : { },
-        "realmRoles" : [ ],
-        "clientRoles" : { },
-        "subGroups" : [ ]
+      },
+      "clientRole" : false,
+      "containerId" : "test",
+      "attributes" : { }
     } ],
-    "defaultRole" : {
-        "id" : "d84a5ad7-ef32-4c7f-bfed-63256266c721",
-        "name" : "default-roles-test",
-        "description" : "${role_default-roles}",
+    "client" : {
+      "lrs_client" : [ ],
+      "realm-management" : [ {
+        "id" : "90f9feb7-3f87-4afe-ac9c-d68601f2735c",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "803566ff-911d-4a3c-abd5-e492f11bf019",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "81629562-dd95-4e74-8e2a-91e99afdd739",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "f13b65bc-3591-434d-a74f-ddc5fee3b23b",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "224b0eb1-81c2-42ff-bd70-74c4da9d3f02",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "635e39b4-0c9c-4421-8767-240d0f11bb16",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "aaa49cca-cce6-4ad4-8eda-c8239c773502",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
         "composite" : true,
-        "clientRole" : false,
-        "containerId" : "test"
-    },
-    "requiredCredentials" : [ "password" ],
-    "otpPolicyType" : "totp",
-    "otpPolicyAlgorithm" : "HmacSHA1",
-    "otpPolicyInitialCounter" : 0,
-    "otpPolicyDigits" : 6,
-    "otpPolicyLookAheadWindow" : 1,
-    "otpPolicyPeriod" : 30,
-    "otpSupportedApplications" : [ "FreeOTP", "Google Authenticator" ],
-    "webAuthnPolicyRpEntityName" : "keycloak",
-    "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
-    "webAuthnPolicyRpId" : "",
-    "webAuthnPolicyAttestationConveyancePreference" : "not specified",
-    "webAuthnPolicyAuthenticatorAttachment" : "not specified",
-    "webAuthnPolicyRequireResidentKey" : "not specified",
-    "webAuthnPolicyUserVerificationRequirement" : "not specified",
-    "webAuthnPolicyCreateTimeout" : 0,
-    "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
-    "webAuthnPolicyAcceptableAaguids" : [ ],
-    "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
-    "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
-    "webAuthnPolicyPasswordlessRpId" : "",
-    "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
-    "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
-    "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
-    "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
-    "webAuthnPolicyPasswordlessCreateTimeout" : 0,
-    "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
-    "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
-    "users" : [ {
-        "id" : "9c9708f0-c84a-49db-805a-1231b007a306",
-        "createdTimestamp" : 1643146437013,
-        "username" : "dev_user",
-        "enabled" : true,
-        "totp" : false,
-        "emailVerified" : true,
-        "firstName" : "Development",
-        "lastName" : "User",
-        "email" : "dev_user@example.com",
-        "attributes" : {
-            "foo" : [ "bar" ]
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-users", "query-groups" ]
+          }
         },
-        "credentials" : [ {
-            "id" : "9477829d-6f0b-4a2d-b1bd-40769cd79121",
-            "type" : "password",
-            "createdDate" : 1643146523059,
-            "secretData" : "{\"value\":\"kiGu0mANJBvsuKpf9AJGPfXXN7JLuH/nXmK3+1fd7pXXTtRc8ZIaQKFXt09szSJAfosrMWbNDtMAc6Of/BeLqA==\",\"salt\":\"xRmuQt7YJKfeCxlAvf/v9A==\",\"additionalParameters\":{}}",
-            "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
-        } ],
-        "disableableCredentialTypes" : [ ],
-        "requiredActions" : [ ],
-        "realmRoles" : [ "default-roles-test" ],
-        "notBefore" : 0,
-        "groups" : [ "/developers" ]
-    } ],
-    "scopeMappings" : [ {
-        "clientScope" : "offline_access",
-        "roles" : [ "offline_access" ]
-    } ],
-    "clientScopeMappings" : {
-        "account" : [ {
-            "client" : "account-console",
-            "roles" : [ "manage-account" ]
-        } ]
-    },
-    "clients" : [ {
-        "id" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
-        "clientId" : "account",
-        "name" : "${client_account}",
-        "rootUrl" : "${authBaseUrl}",
-        "baseUrl" : "/realms/test/account/",
-        "surrogateAuthRequired" : false,
-        "enabled" : true,
-        "alwaysDisplayInConsole" : false,
-        "clientAuthenticatorType" : "client-secret",
-        "redirectUris" : [ "/realms/test/account/*" ],
-        "webOrigins" : [ ],
-        "notBefore" : 0,
-        "bearerOnly" : false,
-        "consentRequired" : false,
-        "standardFlowEnabled" : true,
-        "implicitFlowEnabled" : false,
-        "directAccessGrantsEnabled" : false,
-        "serviceAccountsEnabled" : false,
-        "publicClient" : true,
-        "frontchannelLogout" : false,
-        "protocol" : "openid-connect",
-        "attributes" : { },
-        "authenticationFlowBindingOverrides" : { },
-        "fullScopeAllowed" : false,
-        "nodeReRegistrationTimeout" : 0,
-        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-    }, {
-        "id" : "c8f48dc1-c2fd-45d1-bcfb-1cc345cb269a",
-        "clientId" : "account-console",
-        "name" : "${client_account-console}",
-        "rootUrl" : "${authBaseUrl}",
-        "baseUrl" : "/realms/test/account/",
-        "surrogateAuthRequired" : false,
-        "enabled" : true,
-        "alwaysDisplayInConsole" : false,
-        "clientAuthenticatorType" : "client-secret",
-        "redirectUris" : [ "/realms/test/account/*" ],
-        "webOrigins" : [ ],
-        "notBefore" : 0,
-        "bearerOnly" : false,
-        "consentRequired" : false,
-        "standardFlowEnabled" : true,
-        "implicitFlowEnabled" : false,
-        "directAccessGrantsEnabled" : false,
-        "serviceAccountsEnabled" : false,
-        "publicClient" : true,
-        "frontchannelLogout" : false,
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "pkce.code.challenge.method" : "S256"
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "826a472d-6694-4778-b581-36f51e9dddc8",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "7922f15b-8b87-4742-b764-39f4ed816a74",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "86c58c5c-6b3f-4b63-bb6b-6baf6af177e1",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "806ea0bf-d63c-4e21-a63d-735910488fa5",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "b9c2dc0d-d35e-4a04-91f0-5170fbef7b87",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "60a907de-14b4-4004-9a7e-4300a9afb2c0",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "d23cdc0a-795e-42c6-b6a8-07a7dfa0f151",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "6b6b4b28-b594-4379-b0dc-2cde8fddeca0",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "view-events", "view-authorization", "query-realms", "create-client", "manage-users", "view-users", "view-identity-providers", "manage-authorization", "manage-clients", "impersonation", "view-realm", "query-users", "manage-events", "manage-identity-providers", "query-clients", "manage-realm", "view-clients" ]
+          }
         },
-        "authenticationFlowBindingOverrides" : { },
-        "fullScopeAllowed" : false,
-        "nodeReRegistrationTimeout" : 0,
-        "protocolMappers" : [ {
-            "id" : "8ad7c1f2-57d0-4989-bda9-8768dbc222b6",
-            "name" : "audience resolve",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-audience-resolve-mapper",
-            "consentRequired" : false,
-            "config" : { }
-        } ],
-        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-    }, {
-        "id" : "554b71bc-8f36-49f1-b39f-86fa65ebbe8f",
-        "clientId" : "admin-cli",
-        "name" : "${client_admin-cli}",
-        "surrogateAuthRequired" : false,
-        "enabled" : true,
-        "alwaysDisplayInConsole" : false,
-        "clientAuthenticatorType" : "client-secret",
-        "redirectUris" : [ ],
-        "webOrigins" : [ ],
-        "notBefore" : 0,
-        "bearerOnly" : false,
-        "consentRequired" : false,
-        "standardFlowEnabled" : false,
-        "implicitFlowEnabled" : false,
-        "directAccessGrantsEnabled" : true,
-        "serviceAccountsEnabled" : false,
-        "publicClient" : true,
-        "frontchannelLogout" : false,
-        "protocol" : "openid-connect",
-        "attributes" : { },
-        "authenticationFlowBindingOverrides" : { },
-        "fullScopeAllowed" : false,
-        "nodeReRegistrationTimeout" : 0,
-        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-    }, {
-        "id" : "9cdbf3ec-85f6-4366-956b-d1556302eac1",
-        "clientId" : "broker",
-        "name" : "${client_broker}",
-        "surrogateAuthRequired" : false,
-        "enabled" : true,
-        "alwaysDisplayInConsole" : false,
-        "clientAuthenticatorType" : "client-secret",
-        "redirectUris" : [ ],
-        "webOrigins" : [ ],
-        "notBefore" : 0,
-        "bearerOnly" : true,
-        "consentRequired" : false,
-        "standardFlowEnabled" : true,
-        "implicitFlowEnabled" : false,
-        "directAccessGrantsEnabled" : false,
-        "serviceAccountsEnabled" : false,
-        "publicClient" : false,
-        "frontchannelLogout" : false,
-        "protocol" : "openid-connect",
-        "attributes" : { },
-        "authenticationFlowBindingOverrides" : { },
-        "fullScopeAllowed" : false,
-        "nodeReRegistrationTimeout" : 0,
-        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-    }, {
-        "id" : "93f48f9d-bd78-44f2-97f7-7f3b65aaa8da",
-        "clientId" : "lrs",
-        "name" : "SQL LRS",
-        "rootUrl" : "http://0.0.0.0:8080/",
-        "adminUrl" : "http://0.0.0.0:8080/",
-        "surrogateAuthRequired" : false,
-        "enabled" : true,
-        "alwaysDisplayInConsole" : false,
-        "clientAuthenticatorType" : "client-secret",
-        "redirectUris" : [ "http://0.0.0.0:8080/*" ],
-        "webOrigins" : [ "http://0.0.0.0:8080" ],
-        "notBefore" : 0,
-        "bearerOnly" : true,
-        "consentRequired" : false,
-        "standardFlowEnabled" : true,
-        "implicitFlowEnabled" : false,
-        "directAccessGrantsEnabled" : true,
-        "serviceAccountsEnabled" : false,
-        "publicClient" : false,
-        "frontchannelLogout" : false,
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "id.token.as.detached.signature" : "false",
-            "saml.assertion.signature" : "false",
-            "saml.force.post.binding" : "false",
-            "saml.multivalued.roles" : "false",
-            "saml.encrypt" : "false",
-            "oauth2.device.authorization.grant.enabled" : "false",
-            "backchannel.logout.revoke.offline.tokens" : "false",
-            "saml.server.signature" : "false",
-            "saml.server.signature.keyinfo.ext" : "false",
-            "use.refresh.tokens" : "true",
-            "exclude.session.state.from.auth.response" : "false",
-            "oidc.ciba.grant.enabled" : "false",
-            "saml.artifact.binding" : "false",
-            "backchannel.logout.session.required" : "true",
-            "client_credentials.use_refresh_token" : "false",
-            "saml_force_name_id_format" : "false",
-            "require.pushed.authorization.requests" : "false",
-            "saml.client.signature" : "false",
-            "tls.client.certificate.bound.access.tokens" : "false",
-            "saml.authnstatement" : "false",
-            "display.on.consent.screen" : "false",
-            "saml.onetimeuse.condition" : "false"
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "a2220563-986a-4ef8-ae38-0546f11a1e9c",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "8afdbb17-4b6e-4b2f-8609-77a3c5a0179c",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "b184e0ae-a474-4651-97e8-d28435700a73",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      }, {
+        "id" : "9d6e1fc4-1949-4cf6-bb77-06633ad90077",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
         },
-        "authenticationFlowBindingOverrides" : { },
-        "fullScopeAllowed" : true,
-        "nodeReRegistrationTimeout" : -1,
-        "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-        "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-    }, {
-        "clientId": "lrs_client",
-        "name": "LRS Client",
-        "description": "An example LRS client suitable for the OAuth Client Credentials Grant",
-        "surrogateAuthRequired": false,
-        "enabled": true,
-        "alwaysDisplayInConsole": false,
-        "clientAuthenticatorType": "client-secret",
-        "redirectUris": [],
-        "webOrigins": [],
-        "notBefore": 0,
-        "bearerOnly": false,
-        "consentRequired": false,
-        "standardFlowEnabled": false,
-        "implicitFlowEnabled": false,
-        "directAccessGrantsEnabled": false,
-        "serviceAccountsEnabled": true,
-        "publicClient": false,
-        "frontchannelLogout": false,
-        "protocol": "openid-connect",
-        "attributes": {
-            "id.token.as.detached.signature": "false",
-            "saml.assertion.signature": "false",
-            "saml.force.post.binding": "false",
-            "saml.multivalued.roles": "false",
-            "saml.encrypt": "false",
-            "oauth2.device.authorization.grant.enabled": "false",
-            "backchannel.logout.revoke.offline.tokens": "false",
-            "saml.server.signature": "false",
-            "saml.server.signature.keyinfo.ext": "false",
-            "use.refresh.tokens": "true",
-            "exclude.session.state.from.auth.response": "false",
-            "oidc.ciba.grant.enabled": "false",
-            "saml.artifact.binding": "false",
-            "backchannel.logout.session.required": "true",
-            "client_credentials.use_refresh_token": "false",
-            "saml_force_name_id_format": "false",
-            "require.pushed.authorization.requests": "false",
-            "saml.client.signature": "false",
-            "tls.client.certificate.bound.access.tokens": "false",
-            "saml.authnstatement": "false",
-            "display.on.consent.screen": "false",
-            "saml.onetimeuse.condition": "false"
+        "clientRole" : true,
+        "containerId" : "07000d1e-39d0-4864-a39d-70566b870361",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "4ec62d80-1cd7-4502-8029-e93d920b69ae",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "9cdbf3ec-85f6-4366-956b-d1556302eac1",
+        "attributes" : { }
+      } ],
+      "lrs" : [ ],
+      "account" : [ {
+        "id" : "e34fd9d6-b441-4415-a77d-857f456dd024",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
         },
-        "authenticationFlowBindingOverrides": {},
-        "fullScopeAllowed": true,
-        "nodeReRegistrationTimeout": -1,
-        "protocolMappers": [
-            {
-                "name": "Client IP Address",
-                "protocol": "openid-connect",
-                "protocolMapper": "oidc-usersessionmodel-note-mapper",
-                "consentRequired": false,
-                "config": {
-                    "user.session.note": "clientAddress",
-                    "id.token.claim": "true",
-                    "access.token.claim": "true",
-                    "claim.name": "clientAddress",
-                    "jsonType.label": "String"
-                }
-            },
-            {
-                "name": "Client ID",
-                "protocol": "openid-connect",
-                "protocolMapper": "oidc-usersessionmodel-note-mapper",
-                "consentRequired": false,
-                "config": {
-                    "user.session.note": "clientId",
-                    "id.token.claim": "true",
-                    "access.token.claim": "true",
-                    "claim.name": "clientId",
-                    "jsonType.label": "String"
-                }
-            },
-            {
-                "name": "lrs_client_audience_mapper",
-                "protocol": "openid-connect",
-                "protocolMapper": "oidc-audience-mapper",
-                "consentRequired": false,
-                "config": {
-                    "id.token.claim": "false",
-                    "access.token.claim": "true",
-                    "included.custom.audience": "http://0.0.0.0:8080"
-                }
-            },
-            {
-                "name": "Client Host",
-                "protocol": "openid-connect",
-                "protocolMapper": "oidc-usersessionmodel-note-mapper",
-                "consentRequired": false,
-                "config": {
-                    "user.session.note": "clientHost",
-                    "id.token.claim": "true",
-                    "access.token.claim": "true",
-                    "claim.name": "clientHost",
-                    "jsonType.label": "String"
-                }
-            }
-        ],
-        "defaultClientScopes": [
-            "web-origins",
-            "profile",
-            "roles",
-            "lrs:all",
-            "email"
-        ],
-        "optionalClientScopes": [
-            "address",
-            "phone",
-            "offline_access",
-            "microprofile-jwt"
-        ],
-        "access": {
-            "view": true,
-            "configure": true,
-            "manage": true
-        }
-    },
-                  {
-                      "clientId": "lrs_admin_ui",
-                      "name": "LRS Admin UI/Figwheel Server",
-                      "rootUrl": "http://localhost:9500/",
-                      "adminUrl": "http://localhost:9500/",
-                      "surrogateAuthRequired": false,
-                      "enabled": true,
-                      "alwaysDisplayInConsole": false,
-                      "clientAuthenticatorType": "client-secret",
-                      "redirectUris": [
-                          "http://localhost:9500/",
-                          "http://0.0.0.0:8080/admin/index.html",
-                          "http://localhost:9500/*"
-                      ],
-                      "webOrigins": [
-                          "http://localhost:9500",
-                          "http://0.0.0.0:8080"
-                      ],
-                      "notBefore": 0,
-                      "bearerOnly": false,
-                      "consentRequired": false,
-                      "standardFlowEnabled": true,
-                      "implicitFlowEnabled": false,
-                      "directAccessGrantsEnabled": true,
-                      "serviceAccountsEnabled": false,
-                      "publicClient": true,
-                      "frontchannelLogout": false,
-                      "protocol": "openid-connect",
-                      "attributes": {
-                          "saml.force.post.binding": "false",
-                          "saml.multivalued.roles": "false",
-                          "oauth2.device.authorization.grant.enabled": "false",
-                          "use.jwks.url": "false",
-                          "backchannel.logout.revoke.offline.tokens": "false",
-                          "saml.server.signature.keyinfo.ext": "false",
-                          "use.refresh.tokens": "true",
-                          "jwt.credential.certificate": "MIICqzCCAZMCBgF+VSRiwDANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDDA50ZXN0YXBwX3B1YmxpYzAeFw0yMjAxMTMyMDMwNTVaFw0zMjAxMTMyMDMyMzVaMBkxFzAVBgNVBAMMDnRlc3RhcHBfcHVibGljMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAl18eQYywttSxpioT0plMAj0BENJQhHu/7LmkF7a4GwG3OyZNpiky3V1W4oFgfmTcTisXYBB1eRIw+bC8Iy808DX7PbHr4N/qn1pjgkohl9pPo3UnKAa2hEUsKtQDfn5Oltx/qliSvT0zFzHmPXH2CHKCqyjy9NFFG+rPNXXrmY/xM8HToqjchwvA4DHOnbcUgRzGSQl2vmO0GJvRqcFQjoQXaPEvQck8geVB2bjx0Lkt6m5zWkMZsVH8aBeBTuuZqpCGO5LecyMOHz0iEx8T0lMJorE5uR6ul8jnZzFdv9blLEiroy8Btes8WCImopKO1MCqdIbrSB54v+lQ+Jg7HwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAy9xUwUDTQjRiiHCljmJpjQEqTuXHzFaBr9oj3pQ698eM0vjaoBh0DAqUfNiPHTwqvyuOOLYoO2HJzcjnGYn0hHgTWWUGAzj0id+Nq1+nfdq9yqW2PGsEza7/LZja80RclRs3E6ZjFxPBUndyTV2ppvtL5/KFN/OYC7iXvSJd++dOIPRtk4hyOtu08HvQ0uFwh+H3bcb0ZKnTqsVhkBs9AmHF61K4IKDPJc8FahVeSVQDH46uqLjhSBx4lmjGFF7hax3RxvLB4zO88YZECo8+ce4B9kMxsYqsVL2xuJFf8kucfJRwA6LIkARsICiDI9pIda9QbHibaxyFaARQ6kdIT",
-                          "oidc.ciba.grant.enabled": "false",
-                          "use.jwks.string": "false",
-                          "backchannel.logout.session.required": "true",
-                          "client_credentials.use_refresh_token": "false",
-                          "require.pushed.authorization.requests": "false",
-                          "saml.client.signature": "false",
-                          "id.token.as.detached.signature": "false",
-                          "saml.assertion.signature": "false",
-                          "saml.encrypt": "false",
-                          "saml.server.signature": "false",
-                          "exclude.session.state.from.auth.response": "false",
-                          "saml.artifact.binding": "false",
-                          "saml_force_name_id_format": "false",
-                          "tls.client.certificate.bound.access.tokens": "false",
-                          "saml.authnstatement": "false",
-                          "display.on.consent.screen": "false",
-                          "saml.onetimeuse.condition": "false"
-                      },
-                      "authenticationFlowBindingOverrides": {},
-                      "fullScopeAllowed": true,
-                      "nodeReRegistrationTimeout": -1,
-                      "protocolMappers": [
-                          {
-                              "name": "LRS Audience Mapper",
-                              "protocol": "openid-connect",
-                              "protocolMapper": "oidc-audience-mapper",
-                              "consentRequired": false,
-                              "config": {
-                                  "id.token.claim": "false",
-                                  "access.token.claim": "true",
-                                  "included.custom.audience": "http://0.0.0.0:8080",
-                                  "userinfo.token.claim": "false"
-                              }
-                          }
-                      ],
-                      "defaultClientScopes": [
-                          "web-origins",
-                          "profile",
-                          "roles",
-                          "email"
-                      ],
-                      "optionalClientScopes": [
-                          "lrs:statements/read",
-                          "lrs:admin",
-                          "lrs:all/read",
-                          "address",
-                          "phone",
-                          "offline_access",
-                          "lrs:statements/write",
-                          "microprofile-jwt",
-                          "lrs:all"
-                      ],
-                      "access": {
-                          "view": true,
-                          "configure": true,
-                          "manage": true
-                      }
-                  }, {
-                      "id" : "07000d1e-39d0-4864-a39d-70566b870361",
-                      "clientId" : "realm-management",
-                      "name" : "${client_realm-management}",
-                      "surrogateAuthRequired" : false,
-                      "enabled" : true,
-                      "alwaysDisplayInConsole" : false,
-                      "clientAuthenticatorType" : "client-secret",
-                      "redirectUris" : [ ],
-                      "webOrigins" : [ ],
-                      "notBefore" : 0,
-                      "bearerOnly" : true,
-                      "consentRequired" : false,
-                      "standardFlowEnabled" : true,
-                      "implicitFlowEnabled" : false,
-                      "directAccessGrantsEnabled" : false,
-                      "serviceAccountsEnabled" : false,
-                      "publicClient" : false,
-                      "frontchannelLogout" : false,
-                      "protocol" : "openid-connect",
-                      "attributes" : { },
-                      "authenticationFlowBindingOverrides" : { },
-                      "fullScopeAllowed" : false,
-                      "nodeReRegistrationTimeout" : 0,
-                      "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-                      "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-                  }, {
-                      "id" : "fe5daf9c-81b7-4aa8-9d89-557dac44e9cd",
-                      "clientId" : "security-admin-console",
-                      "name" : "${client_security-admin-console}",
-                      "rootUrl" : "${authAdminUrl}",
-                      "baseUrl" : "/admin/test/console/",
-                      "surrogateAuthRequired" : false,
-                      "enabled" : true,
-                      "alwaysDisplayInConsole" : false,
-                      "clientAuthenticatorType" : "client-secret",
-                      "redirectUris" : [ "/admin/test/console/*" ],
-                      "webOrigins" : [ "+" ],
-                      "notBefore" : 0,
-                      "bearerOnly" : false,
-                      "consentRequired" : false,
-                      "standardFlowEnabled" : true,
-                      "implicitFlowEnabled" : false,
-                      "directAccessGrantsEnabled" : false,
-                      "serviceAccountsEnabled" : false,
-                      "publicClient" : true,
-                      "frontchannelLogout" : false,
-                      "protocol" : "openid-connect",
-                      "attributes" : {
-                          "pkce.code.challenge.method" : "S256"
-                      },
-                      "authenticationFlowBindingOverrides" : { },
-                      "fullScopeAllowed" : false,
-                      "nodeReRegistrationTimeout" : 0,
-                      "protocolMappers" : [ {
-                          "id" : "c368d119-cdfa-42d3-ac6f-25027c669774",
-                          "name" : "locale",
-                          "protocol" : "openid-connect",
-                          "protocolMapper" : "oidc-usermodel-attribute-mapper",
-                          "consentRequired" : false,
-                          "config" : {
-                              "userinfo.token.claim" : "true",
-                              "user.attribute" : "locale",
-                              "id.token.claim" : "true",
-                              "access.token.claim" : "true",
-                              "claim.name" : "locale",
-                              "jsonType.label" : "String"
-                          }
-                      } ],
-                      "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
-                      "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
-                  } ],
-    "clientScopes" : [ {
-        "id" : "8b2321db-a3f5-4d8e-ae28-39f48125c07a",
-        "name" : "lrs:statements/read",
-        "description" : "xAPI Statements Read Only",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "xAPI Statements Read Only"
-        }
-    }, {
-        "id" : "6a4a4a4d-03aa-473f-aa0d-75b489977d5c",
-        "name" : "profile",
-        "description" : "OpenID Connect built-in scope: profile",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "${profileScopeConsentText}"
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      }, {
+        "id" : "8f99b9d9-abb3-42e3-828e-504068c5666c",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      }, {
+        "id" : "e199034f-3da1-48d0-82ed-9cde5920528f",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      }, {
+        "id" : "be80bb48-9ca7-4517-9f70-98acea96b8d6",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      }, {
+        "id" : "5b050df5-1366-46fe-ab90-cd43a659724c",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      }, {
+        "id" : "689b7ad1-019f-4449-b0f9-4caf6fac4ac8",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
         },
-        "protocolMappers" : [ {
-            "id" : "f8993932-62d2-48e0-a304-3f136ea8edfe",
-            "name" : "given name",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-property-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "firstName",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "given_name",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "523c9af4-4711-43d7-85af-f3ac04ace666",
-            "name" : "updated at",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "updatedAt",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "updated_at",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "1858bdad-5c52-4aa1-b0fc-5581af798a08",
-            "name" : "nickname",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "nickname",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "nickname",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "b3db4dc4-231d-4674-a5b6-ea6d5e9016dc",
-            "name" : "username",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-property-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "username",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "preferred_username",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "e0e5805c-c044-480f-a3a7-2981d794df86",
-            "name" : "birthdate",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "birthdate",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "birthdate",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "c5ced14b-2b38-419b-9896-85cf88a3711b",
-            "name" : "family name",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-property-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "lastName",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "family_name",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "75c08d02-0833-4aa2-a098-98e4b4963cd7",
-            "name" : "middle name",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "middleName",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "middle_name",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "1cdfb88e-1e04-4d78-a68a-3e289b089a33",
-            "name" : "locale",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "locale",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "locale",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "236affeb-fffc-4848-b717-7c8f190d06fb",
-            "name" : "full name",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-full-name-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "userinfo.token.claim" : "true"
-            }
-        }, {
-            "id" : "e59085e5-6bf4-4916-a8c9-44102337b968",
-            "name" : "profile",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "profile",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "profile",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "f3bbe050-5486-4e1c-8557-070e89096f7d",
-            "name" : "picture",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "picture",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "picture",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "c7181162-eabd-4e46-9c4b-c8c4ff14ce67",
-            "name" : "gender",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "gender",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "gender",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "c3dac1cf-d61a-4f3d-8bea-74f7eb65d565",
-            "name" : "website",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "website",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "website",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "bc51e879-fd49-4456-8dab-ad9495ce1da0",
-            "name" : "zoneinfo",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "zoneinfo",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "zoneinfo",
-                "jsonType.label" : "String"
-            }
-        } ]
-    }, {
-        "id" : "db720beb-9e39-4a19-9372-3fe356561c3b",
-        "name" : "lrs:admin",
-        "description" : "All admin permissions on LRS",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "Administer LRS"
-        }
-    }, {
-        "id" : "c6283805-484f-4d1c-9e85-1955c13c9c7f",
-        "name" : "roles",
-        "description" : "OpenID Connect scope for add user roles to the access token",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "false",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "${rolesScopeConsentText}"
-        },
-        "protocolMappers" : [ {
-            "id" : "71ef7385-cc4d-41a7-aa03-d67f0586f87e",
-            "name" : "audience resolve",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-audience-resolve-mapper",
-            "consentRequired" : false,
-            "config" : { }
-        }, {
-            "id" : "f4784c65-9cd1-4b38-be19-a8c36efa0c84",
-            "name" : "client roles",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-client-role-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "user.attribute" : "foo",
-                "access.token.claim" : "true",
-                "claim.name" : "resource_access.${client_id}.roles",
-                "jsonType.label" : "String",
-                "multivalued" : "true"
-            }
-        }, {
-            "id" : "8c57c0a4-f8b9-4358-962b-49b0f3013eac",
-            "name" : "realm roles",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-realm-role-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "user.attribute" : "foo",
-                "access.token.claim" : "true",
-                "claim.name" : "realm_access.roles",
-                "jsonType.label" : "String",
-                "multivalued" : "true"
-            }
-        } ]
-    }, {
-        "id" : "817b903a-cb78-4caf-a338-affb280d364f",
-        "name" : "email",
-        "description" : "OpenID Connect built-in scope: email",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "${emailScopeConsentText}"
-        },
-        "protocolMappers" : [ {
-            "id" : "fa86e7f0-866d-412c-8191-9cc86c5a7d8b",
-            "name" : "email verified",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-property-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "emailVerified",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "email_verified",
-                "jsonType.label" : "boolean"
-            }
-        }, {
-            "id" : "8833ffce-a1a0-4558-a65e-ed5d107f1022",
-            "name" : "email",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-property-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "email",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "email",
-                "jsonType.label" : "String"
-            }
-        } ]
-    }, {
-        "id" : "7141d9b9-5746-4559-9151-8411bdb3afb5",
-        "name" : "lrs:all",
-        "description" : "All xAPI Permissions",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "All xAPI"
-        }
-    }, {
-        "id" : "1066033a-7d3e-46ba-97a1-7fc2e84c65ab",
-        "name" : "lrs:statements/write",
-        "description" : "xAPI Statements Write Only",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "xAPI Statements Write Only"
-        }
-    }, {
-        "id" : "dca4ed1d-460c-4807-b0d9-568592e6d088",
-        "name" : "web-origins",
-        "description" : "OpenID Connect scope for add allowed web origins to the access token",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "false",
-            "display.on.consent.screen" : "false",
-            "consent.screen.text" : ""
-        },
-        "protocolMappers" : [ {
-            "id" : "6374f381-4889-489e-aead-5fa18ef1b822",
-            "name" : "allowed web origins",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-allowed-origins-mapper",
-            "consentRequired" : false,
-            "config" : { }
-        } ]
-    }, {
-        "id" : "be667ccc-ba78-4afa-970e-13da6bc07427",
-        "name" : "role_list",
-        "description" : "SAML role list",
-        "protocol" : "saml",
-        "attributes" : {
-            "consent.screen.text" : "${samlRoleListScopeConsentText}",
-            "display.on.consent.screen" : "true"
-        },
-        "protocolMappers" : [ {
-            "id" : "6a7b16b0-1e49-43b8-ae44-e4e6fdc2b3fc",
-            "name" : "role list",
-            "protocol" : "saml",
-            "protocolMapper" : "saml-role-list-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "single" : "false",
-                "attribute.nameformat" : "Basic",
-                "attribute.name" : "Role"
-            }
-        } ]
-    }, {
-        "id" : "52f9ee66-42fa-4bd0-a5b3-26aa8f42e25a",
-        "name" : "phone",
-        "description" : "OpenID Connect built-in scope: phone",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "${phoneScopeConsentText}"
-        },
-        "protocolMappers" : [ {
-            "id" : "1629c27c-75cc-4407-89e6-971c900bb127",
-            "name" : "phone number verified",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "phoneNumberVerified",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "phone_number_verified",
-                "jsonType.label" : "boolean"
-            }
-        }, {
-            "id" : "2da9c5aa-679c-433a-b4dc-8ab76917b1da",
-            "name" : "phone number",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-attribute-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "phoneNumber",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "phone_number",
-                "jsonType.label" : "String"
-            }
-        } ]
-    }, {
-        "id" : "6467a85b-e3a6-4181-ab4b-ca879ce2c123",
-        "name" : "lrs:all/read",
-        "description" : "Read-only xAPI Permissions",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "xAPI Read Only"
-        }
-    }, {
-        "id" : "84261ec9-96d3-4f8c-b343-619828a3ad4b",
-        "name" : "address",
-        "description" : "OpenID Connect built-in scope: address",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "true",
-            "consent.screen.text" : "${addressScopeConsentText}"
-        },
-        "protocolMappers" : [ {
-            "id" : "aceb7515-642e-4403-afab-3c93aebfb056",
-            "name" : "address",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-address-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "user.attribute.formatted" : "formatted",
-                "user.attribute.country" : "country",
-                "user.attribute.postal_code" : "postal_code",
-                "userinfo.token.claim" : "true",
-                "user.attribute.street" : "street",
-                "id.token.claim" : "true",
-                "user.attribute.region" : "region",
-                "access.token.claim" : "true",
-                "user.attribute.locality" : "locality"
-            }
-        } ]
-    }, {
-        "id" : "1e5dfa94-fed1-4fb4-a591-9951704e4a84",
-        "name" : "offline_access",
-        "description" : "OpenID Connect built-in scope: offline_access",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "consent.screen.text" : "${offlineAccessScopeConsentText}",
-            "display.on.consent.screen" : "true"
-        }
-    }, {
-        "id" : "7c2908d3-28c4-42e6-bd96-c9e57cef7cf0",
-        "name" : "microprofile-jwt",
-        "description" : "Microprofile - JWT built-in scope",
-        "protocol" : "openid-connect",
-        "attributes" : {
-            "include.in.token.scope" : "true",
-            "display.on.consent.screen" : "false"
-        },
-        "protocolMappers" : [ {
-            "id" : "dc7578fc-d518-4312-99ea-bb4d93774562",
-            "name" : "upn",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-property-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "username",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "upn",
-                "jsonType.label" : "String"
-            }
-        }, {
-            "id" : "f6241122-16ec-4f71-b9e8-efd173318dea",
-            "name" : "groups",
-            "protocol" : "openid-connect",
-            "protocolMapper" : "oidc-usermodel-realm-role-mapper",
-            "consentRequired" : false,
-            "config" : {
-                "multivalued" : "true",
-                "userinfo.token.claim" : "true",
-                "user.attribute" : "foo",
-                "id.token.claim" : "true",
-                "access.token.claim" : "true",
-                "claim.name" : "groups",
-                "jsonType.label" : "String"
-            }
-        } ]
-    } ],
-    "defaultDefaultClientScopes" : [ "profile", "email", "role_list", "roles", "web-origins" ],
-    "defaultOptionalClientScopes" : [ "offline_access", "phone", "microprofile-jwt", "address" ],
-    "browserSecurityHeaders" : {
-        "contentSecurityPolicyReportOnly" : "",
-        "xContentTypeOptions" : "nosniff",
-        "xRobotsTag" : "none",
-        "xFrameOptions" : "SAMEORIGIN",
-        "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
-        "xXSSProtection" : "1; mode=block",
-        "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
-    },
-    "smtpServer" : { },
-    "eventsEnabled" : false,
-    "eventsListeners" : [ "jboss-logging" ],
-    "enabledEventTypes" : [ ],
-    "adminEventsEnabled" : false,
-    "adminEventsDetailsEnabled" : false,
-    "identityProviders" : [ ],
-    "identityProviderMappers" : [ ],
-    "components" : {
-        "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
-            "id" : "c0c16b10-415f-4d6e-88f6-c1050314e85d",
-            "name" : "Max Clients Limit",
-            "providerId" : "max-clients",
-            "subType" : "anonymous",
-            "subComponents" : { },
-            "config" : {
-                "max-clients" : [ "200" ]
-            }
-        }, {
-            "id" : "06bdbf20-05ff-4e6d-bbf0-3daa86fb0757",
-            "name" : "Consent Required",
-            "providerId" : "consent-required",
-            "subType" : "anonymous",
-            "subComponents" : { },
-            "config" : { }
-        }, {
-            "id" : "86f63e93-ef16-41ff-8a7b-9a0f99344497",
-            "name" : "Allowed Protocol Mapper Types",
-            "providerId" : "allowed-protocol-mappers",
-            "subType" : "anonymous",
-            "subComponents" : { },
-            "config" : {
-                "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "saml-user-property-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper" ]
-            }
-        }, {
-            "id" : "cb89ebbf-ff1c-432c-a43e-63df05848a62",
-            "name" : "Allowed Client Scopes",
-            "providerId" : "allowed-client-templates",
-            "subType" : "authenticated",
-            "subComponents" : { },
-            "config" : {
-                "allow-default-scopes" : [ "true" ]
-            }
-        }, {
-            "id" : "70c357f9-59c0-4758-b202-ba75ace53eda",
-            "name" : "Full Scope Disabled",
-            "providerId" : "scope",
-            "subType" : "anonymous",
-            "subComponents" : { },
-            "config" : { }
-        }, {
-            "id" : "9f3b5f54-efe8-4ebf-a6d7-1bcb3b3f192b",
-            "name" : "Allowed Client Scopes",
-            "providerId" : "allowed-client-templates",
-            "subType" : "anonymous",
-            "subComponents" : { },
-            "config" : {
-                "allow-default-scopes" : [ "true" ]
-            }
-        }, {
-            "id" : "e640c7f7-0c39-4b47-91c3-d1687c353769",
-            "name" : "Trusted Hosts",
-            "providerId" : "trusted-hosts",
-            "subType" : "anonymous",
-            "subComponents" : { },
-            "config" : {
-                "host-sending-registration-request-must-match" : [ "true" ],
-                "client-uris-must-match" : [ "true" ]
-            }
-        }, {
-            "id" : "ebc3625c-9fe2-4739-8d75-b07866794e28",
-            "name" : "Allowed Protocol Mapper Types",
-            "providerId" : "allowed-protocol-mappers",
-            "subType" : "authenticated",
-            "subComponents" : { },
-            "config" : {
-                "allowed-protocol-mapper-types" : [ "saml-user-attribute-mapper", "saml-role-list-mapper", "oidc-usermodel-property-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper" ]
-            }
-        } ],
-        "org.keycloak.keys.KeyProvider" : [ {
-            "id" : "2586006e-6e8e-479f-b6e3-dd2af4bd253d",
-            "name" : "rsa-generated",
-            "providerId" : "rsa-generated",
-            "subComponents" : { },
-            "config" : {
-                "privateKey" : [ "MIIEpAIBAAKCAQEAs49gQ2xcce8VslFoqBR3gj/oUmOc2g2J8SGlPaYAQ4pHWopfZqD6gBQ5hKmRKefuNBXn2bN2j2Zq7RMbPVYKH6F5U+RtJ1ja+tNOK8+uY5coqvwRrYR10BFtrYNq9MapWHXUFdzIJZ5IDT3/W/jS6qNPOL49Os/TO7tf8QpVV67d0zxblR8VSKagp1KmhjSvTx7lWJcRNYRIKFbIcZ0ZP4/2pzemTyDqJjkzgNrSW8K3cNLzohdjr1pR3UFVw+sGlG5NdDrVs0CporOJrArzqF8YkLMMpMCLpjYAiK7AEC7yN9cn7Og1NctqVN2lA+agqkcT+dpOE1wa2lr1oeTKAwIDAQABAoIBAGj34CaKKmDQi7Z6sNvRWyvhgEbpxMAUOheku5yWdoEFTUE4sxyj7s0BBb7wAdSlqTL5u1gg+aZLEScWjE4HBlQHaY4Jc2YVI66N6JzkA+Zkb3nFcfAmB1ljVuKgeN4vZMA54YoGT1rudOCI5cc2ZtaUMbPSQqkm5S1+FFAs4kcnD6t/m3dpHE0uG3cWutfzUHAkk0cZFtZFLlI+arB4Ml5fj/ZfDTC4cp8+LS4EeHK/+gmlBGOknEd8gtNLl4a9G2lOfvG8knjnWpIApkDhPpLqtn8x/KHYeu+dJ1u2V+Fn5ZNcILp66q3zbFevZVNNzsrQXx8f1huoO4dTnIytOIECgYEA4lh05yHfPohdoiW2DvowzV7Bg3V2e3Z5pXTB2kcfP65QITqYJpItmeLvfMUXbxbOUOP1ZaBJig7WbfngqFsOa9J77KBJw+c1N91FCtm7auovGsbo8sOAGRu7oQPS/DZO5aUBfGncfHAJpJ/yWWHlOk/S30fBU+QlVK168d1YK2sCgYEAyxXAnpR346U4ayW02Re1I7hPP0bYwQy9TseYlfimxzApIEa6vNbyHXtbl4ppl5uakBMZcDpM3JfZni7eLD6ndH5rWNyGSkNmPh+yb6E92Asnv+1VmGJd7FAM2VbLfY7ufS7qEBJWJrmwRuOB9DbpmRQqQ3PvdelOCGj3FOzX2ckCgYAh2Yq6GjWxu2ENY8hjWwU7YWVdTI7IjgJJPTnUc/h3ZJE1NvcUJZ5OOkMIjM0hXu7B6CWF6j+1NtzYm5r+coeollTUIXCGrKgnz56IreE6bwVWYtLpo1Uf7CbWQKUn9NM9wryDJ63Cqlq21PjAZ0SJwPBPVgLSkfcHP954F1sdOwKBgQCd9q18q78VMs5PiWTB987Nme8KKPEwN9iIDniBLoeLJ8rVcC6P9CEfDXSQyviXFFGE/1YqFS7z5qk+gPYPNCzMUAjvdZh+6y375GvGqISSJxskDlcl0F1+EkXsR7bAUwzuEi+9kIWyWXzjptLOQmgwyZ6WGPeJn48yu3J0tESxAQKBgQCHvUJOwdrXqN7mZzAWPUwbLr+evkJSQQyquR3HW/Yq8LYB1nFxzBVdNKvh5JMvpB1wOtjFdEQ0y6M+w+ZzMfsJEz0jap1z0m8R0DwrXCjtIT9YOtSkbp2cHxxMYodshqEKQErkFtNySit/BkYjpJrSNwk7AwfDNaCdcXcHmR962A==" ],
-                "keyUse" : [ "SIG" ],
-                "certificate" : [ "MIIClzCCAX8CBgF+ShW75DANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDAR0ZXN0MB4XDTIyMDExMTE2NTkwNVoXDTMyMDExMTE3MDA0NVowDzENMAsGA1UEAwwEdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALOPYENsXHHvFbJRaKgUd4I/6FJjnNoNifEhpT2mAEOKR1qKX2ag+oAUOYSpkSnn7jQV59mzdo9mau0TGz1WCh+heVPkbSdY2vrTTivPrmOXKKr8Ea2EddARba2DavTGqVh11BXcyCWeSA09/1v40uqjTzi+PTrP0zu7X/EKVVeu3dM8W5UfFUimoKdSpoY0r08e5ViXETWESChWyHGdGT+P9qc3pk8g6iY5M4Da0lvCt3DS86IXY69aUd1BVcPrBpRuTXQ61bNAqaKziawK86hfGJCzDKTAi6Y2AIiuwBAu8jfXJ+zoNTXLalTdpQPmoKpHE/naThNcGtpa9aHkygMCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAoj8kXR2fabdLtMGCj7BGy1xIJLUtNnmAIGnHaZ37cVadzHPxRXtOKJjBrAOrjQ7dvONelubZ3Uj9warCdsUV65t6NrG85KpJlW3qVtMuaIoY/sJ2bT9CYKemrOgTW3LgPmjO+YpZOR4uuo2LmVw0XL8KE6zlZwqRfwhjWy/QkRrgHsIXcbF4SnVDAQzpPlo3dTNS60pDtQtbYkIFI2ujdFpkA5u73DAPUCNakRvoutI8ZuHRqqPIIwKFzMXYZNG4GRfL51tRC14VSb+IIoknFwPpm2Y4ZCZkM7OfEDombHgU301NpMcc0ZZxw0zrI5ADEgLpxFitonbFf4MZyJXUbA==" ],
-                "priority" : [ "100" ]
-            }
-        }, {
-            "id" : "3c9c0ea4-c541-428d-ac49-44d955b4fbcc",
-            "name" : "rsa-enc-generated",
-            "providerId" : "rsa-enc-generated",
-            "subComponents" : { },
-            "config" : {
-                "privateKey" : [ "MIIEogIBAAKCAQEAh4/1V8qm/ZoenwUI15TispVHM24NvnhbPOlSg4Hj3FduSi9qJ/CbiOKaZ15cQ6n6J4Niiv5X6VgehrU00Ni/yzNfDVjiiz2esb4YEGHMoEzjtjh6B5sNaptYyYjOenHRdiEVsKX480DJDs81MrQS7dLaSkXP3nz8i1w6JK086vT6JLf5YX7w+aESFr4etzPluWokKtx9MvK36+oqoPqIzzzXOSDFQ1FaQmOMyYKxaVOL9TFJoCevR5BzDxz+p5OyjDvsDq6VhKavU5mggXgQNrpDuWvNJQ7aBnUY2iJ0+gOF4/KieHUWNgtDc5eyOuhWRqg6QsEM8jXiOa55tVm+7QIDAQABAoIBAEavLYJFTKVXQzgva9jc7QepBqMuc0QphYlRL5EanTE69WsBJh0FPFQ3s8LKVNmDO8h2nV9UF4q4Q9KBkbSEEB1n/9v5yMZJrwGG2Q1RsVy0Ote8wwRMOMapkbYj+2WlC07JGYIuSIyt7yglqttxQZ14IBIyLJ0aFqSjxj1xhx4LMlslOMzjgAqybqATj+3/dbhUxj82DoucVMkGvgJyax9VuJL7r0c7jvzn+/LRjP2oouECN9NjOusVM1CA4+l70IasR6dnuD93QMK/rBSTvls2knk9HPBX5bZZxa0cLK2en14Zv9T57zf7176Xuy7WC4eUSfVN7LiiO5RA5bK/QgECgYEA1pfZqp3ynhRp8VAO9qqSuOBdqxXYkKEnoQgNp9v/t8DM5DftOExyFPeAcFu1nSoKALM0J+MaV9ggsS8c1vVgc63jL96Yt9+/dhIXJuHFx0TlE/6TLYmrRgfOSvthiSsGxVutcGu0UfYcmhObNLike3Ulfb7Sww2z18Ic/NSEfs0CgYEAobhDLH8xfV7rPnvQB3bse2Pz4anqFIgfaTJYk9dYgjuHpy9v4qU5LqJ8UjJtVscceJObrQnkZADzaQNMkL1Ce7YBmzo/pB2M39J7cRyQ+H5d2VbSlX9dTL+jBzvIye73YXl9GQH7YPU0NwGY3qtmNUYUetFdLYaK0cCukfoeAKECgYBT/pPgSHqSjYL6RU/WFOXhH1EKij5+PdX5HeHadi4dioWoPovHoYR12HqZgAwSPEY2B+6+PhItmBcTw1ESgnECVmm6bvJv5lBWsrYFLhHv8XOI4/hPtrcnbh69ErAWtJSt4zh77GxkOGTxmgMCG9OlzzChi3OLjW17YiteewBxcQKBgFhO8Ud8ET8/tL/DBl79HrdmZkeE7FDX4Ccmmd3pSuiar0GpErS1ulrv2WldJf2r7q0dFXZRH4lIR6LBbW7gGkzJn2jvTs9EX6fdHREwIy2+e2ryET4XdZAyWUja6ZLzTdzJZXlhbq6MVz3uPlbhS4etxAMpDnOMs4NEb09BQF7hAoGAQ//vl9A328D5h5O5XyqylG1WPeXLcdwMQ3uP+erxS4kLrYlEv3Eo7BNpK6nRHQUndkrOGDMABc3TOOnYVE6486DWdrpy9MsQk3KoNM7KogswRQcDmXPLG3smOcfAtOraZGqlL8SX15N9CAedj0Nw4MeDI7biSZSt6jhaC5RlZlU=" ],
-                "keyUse" : [ "ENC" ],
-                "certificate" : [ "MIIClzCCAX8CBgF+ShW93DANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDAR0ZXN0MB4XDTIyMDExMTE2NTkwNVoXDTMyMDExMTE3MDA0NVowDzENMAsGA1UEAwwEdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIeP9VfKpv2aHp8FCNeU4rKVRzNuDb54WzzpUoOB49xXbkovaifwm4jimmdeXEOp+ieDYor+V+lYHoa1NNDYv8szXw1Y4os9nrG+GBBhzKBM47Y4egebDWqbWMmIznpx0XYhFbCl+PNAyQ7PNTK0Eu3S2kpFz958/ItcOiStPOr0+iS3+WF+8PmhEha+Hrcz5blqJCrcfTLyt+vqKqD6iM881zkgxUNRWkJjjMmCsWlTi/UxSaAnr0eQcw8c/qeTsow77A6ulYSmr1OZoIF4EDa6Q7lrzSUO2gZ1GNoidPoDhePyonh1FjYLQ3OXsjroVkaoOkLBDPI14jmuebVZvu0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEADSvRbqA28R+QU2ij01HcDNWmLvkxSMTFytHRs08n00Rd4ONYeXir1s2F4o0bSLCuYX1d7hOJiw2VVkQNqU2ZvfLZe9QBIetj+AaSsFEz3+3CqE22fHPrnM+1cI6SXpF/zK7Jx3sNdaKRuG3+WbTtjT1p45D/QwUd/YzjWf2YI824jAGamTupd1oyKX2klCnryS2sKrIqnH/1MDfgK93PLtSxNite/effRI2O6ySXX1wmila+nBo9hYcr5Y+yHCmPg+EtdVgGzvVDKrxFEQcLvbZD1HBDCymkWzix0hbsSKc4BDfBl8gOiAes4CATvhMyVJ4unsb/SMBkIDfclr/vdQ==" ],
-                "priority" : [ "100" ],
-                "algorithm" : [ "RSA-OAEP" ]
-            }
-        }, {
-            "id" : "ced222a6-758f-4bde-a993-c1f8882b99f3",
-            "name" : "hmac-generated",
-            "providerId" : "hmac-generated",
-            "subComponents" : { },
-            "config" : {
-                "kid" : [ "13938f82-4b06-4dfa-a9ae-9f113d84d602" ],
-                "secret" : [ "cROFgwh4hrwUtON8MHhFY2Izr-A70s5FbHetwhnr0HdWNqrCtiPznHbNcvCpC8RhA1Nlm5i_DuxfkNHxbmDyEQ" ],
-                "priority" : [ "100" ],
-                "algorithm" : [ "HS256" ]
-            }
-        }, {
-            "id" : "1346c112-4ab3-4609-8282-c13fdb429b51",
-            "name" : "aes-generated",
-            "providerId" : "aes-generated",
-            "subComponents" : { },
-            "config" : {
-                "kid" : [ "622051f7-e16a-45ea-ae3d-d0f3d7c6066f" ],
-                "secret" : [ "087wgqk1GaBeJqSwG0Va1A" ],
-                "priority" : [ "100" ]
-            }
-        } ]
-    },
-    "internationalizationEnabled" : false,
-    "supportedLocales" : [ ],
-    "authenticationFlows" : [ {
-        "id" : "42162a9e-46d8-4683-b4de-33f63f2acb3e",
-        "alias" : "Account verification options",
-        "description" : "Method with which to verity the existing account",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "idp-email-verification",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 20,
-            "flowAlias" : "Verify Existing Account by Re-authentication",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "377ebacb-348b-4a0c-89dc-8bc7c04f8ae9",
-        "alias" : "Authentication Options",
-        "description" : "Authentication options.",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "basic-auth",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "basic-auth-otp",
-            "authenticatorFlow" : false,
-            "requirement" : "DISABLED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "auth-spnego",
-            "authenticatorFlow" : false,
-            "requirement" : "DISABLED",
-            "priority" : 30,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "44561c83-653d-4e87-badf-0b60d90d1ac6",
-        "alias" : "Browser - Conditional OTP",
-        "description" : "Flow to determine if the OTP is required for the authentication",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "conditional-user-configured",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "auth-otp-form",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "224fa87f-aec9-479f-badc-a7de48a3b5e1",
-        "alias" : "Direct Grant - Conditional OTP",
-        "description" : "Flow to determine if the OTP is required for the authentication",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "conditional-user-configured",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "direct-grant-validate-otp",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "42e59c0b-41a7-458c-848b-3e28269151c6",
-        "alias" : "First broker login - Conditional OTP",
-        "description" : "Flow to determine if the OTP is required for the authentication",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "conditional-user-configured",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "auth-otp-form",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "b92df23b-0b5d-47ed-a0bb-1e7c59d3a7dd",
-        "alias" : "Handle Existing Account",
-        "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "idp-confirm-link",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "flowAlias" : "Account verification options",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "f124c209-55a1-494c-9b2f-5c940da6de4c",
-        "alias" : "Reset - Conditional OTP",
-        "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "conditional-user-configured",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "reset-otp",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "0e5718c0-8561-4da5-b466-223ab6668d07",
-        "alias" : "User creation or linking",
-        "description" : "Flow for the existing/non-existing user alternatives",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticatorConfig" : "create unique user config",
-            "authenticator" : "idp-create-user-if-unique",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 20,
-            "flowAlias" : "Handle Existing Account",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "e4dcb1d4-db3f-48af-991e-893364e81a18",
-        "alias" : "Verify Existing Account by Re-authentication",
-        "description" : "Reauthentication of existing account",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "idp-username-password-form",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "CONDITIONAL",
-            "priority" : 20,
-            "flowAlias" : "First broker login - Conditional OTP",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "9516356e-7d84-4bb8-916e-ac9b8ecc7762",
-        "alias" : "browser",
-        "description" : "browser based authentication",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "auth-cookie",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "auth-spnego",
-            "authenticatorFlow" : false,
-            "requirement" : "DISABLED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "identity-provider-redirector",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 25,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 30,
-            "flowAlias" : "forms",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "fd8729f9-54e0-4668-981d-ba07816bedc6",
-        "alias" : "clients",
-        "description" : "Base authentication for clients",
-        "providerId" : "client-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "client-secret",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "client-jwt",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "client-secret-jwt",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 30,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "client-x509",
-            "authenticatorFlow" : false,
-            "requirement" : "ALTERNATIVE",
-            "priority" : 40,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "1ee381cc-3d6e-4997-8e55-337a39d5c72d",
-        "alias" : "direct grant",
-        "description" : "OpenID Connect Resource Owner Grant",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "direct-grant-validate-username",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "direct-grant-validate-password",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "CONDITIONAL",
-            "priority" : 30,
-            "flowAlias" : "Direct Grant - Conditional OTP",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "238e5013-5aa6-4199-8364-272ecbddb6d9",
-        "alias" : "docker auth",
-        "description" : "Used by Docker clients to authenticate against the IDP",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "docker-http-basic-authenticator",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "ba482013-fbc2-42a1-bbfa-3166f9eb7506",
-        "alias" : "first broker login",
-        "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticatorConfig" : "review profile config",
-            "authenticator" : "idp-review-profile",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "flowAlias" : "User creation or linking",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "f1366e50-9bf5-4b76-a10b-cbc78dfbc513",
-        "alias" : "forms",
-        "description" : "Username, password, otp and other auth forms.",
-        "providerId" : "basic-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "auth-username-password-form",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "CONDITIONAL",
-            "priority" : 20,
-            "flowAlias" : "Browser - Conditional OTP",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "45807ee7-a310-4fb0-91c4-4510de12643a",
-        "alias" : "http challenge",
-        "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "no-cookie-redirect",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "flowAlias" : "Authentication Options",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "c7fd3e3c-5eeb-4b78-9651-313f60ec97ae",
-        "alias" : "registration",
-        "description" : "registration flow",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "registration-page-form",
-            "authenticatorFlow" : true,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "flowAlias" : "registration form",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "9e7b6c5e-0124-4e82-9266-ee24cd489b79",
-        "alias" : "registration form",
-        "description" : "registration form",
-        "providerId" : "form-flow",
-        "topLevel" : false,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "registration-user-creation",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "registration-profile-action",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 40,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "registration-password-action",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 50,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "registration-recaptcha-action",
-            "authenticatorFlow" : false,
-            "requirement" : "DISABLED",
-            "priority" : 60,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    }, {
-        "id" : "28c7878b-49cd-4ae3-895d-fe470601813d",
-        "alias" : "reset credentials",
-        "description" : "Reset credentials for a user if they forgot their password or something",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "reset-credentials-choose-user",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "reset-credential-email",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 20,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticator" : "reset-password",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 30,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        }, {
-            "authenticatorFlow" : true,
-            "requirement" : "CONDITIONAL",
-            "priority" : 40,
-            "flowAlias" : "Reset - Conditional OTP",
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : true
-        } ]
-    }, {
-        "id" : "1490e50b-c26d-423e-91c7-62801ddb1e19",
-        "alias" : "saml ecp",
-        "description" : "SAML ECP Profile Authentication Flow",
-        "providerId" : "basic-flow",
-        "topLevel" : true,
-        "builtIn" : true,
-        "authenticationExecutions" : [ {
-            "authenticator" : "http-basic-authenticator",
-            "authenticatorFlow" : false,
-            "requirement" : "REQUIRED",
-            "priority" : 10,
-            "userSetupAllowed" : false,
-            "autheticatorFlow" : false
-        } ]
-    } ],
-    "authenticatorConfig" : [ {
-        "id" : "8f937846-ec80-4e17-a50c-f7fdfd900d5d",
-        "alias" : "create unique user config",
-        "config" : {
-            "require.password.update.after.registration" : "false"
-        }
-    }, {
-        "id" : "3a8384cd-4ef4-4f0f-9c52-2f7ebe234bc0",
-        "alias" : "review profile config",
-        "config" : {
-            "update.profile.on.first.login" : "missing"
-        }
-    } ],
-    "requiredActions" : [ {
-        "alias" : "CONFIGURE_TOTP",
-        "name" : "Configure OTP",
-        "providerId" : "CONFIGURE_TOTP",
-        "enabled" : true,
-        "defaultAction" : false,
-        "priority" : 10,
-        "config" : { }
-    }, {
-        "alias" : "terms_and_conditions",
-        "name" : "Terms and Conditions",
-        "providerId" : "terms_and_conditions",
-        "enabled" : false,
-        "defaultAction" : false,
-        "priority" : 20,
-        "config" : { }
-    }, {
-        "alias" : "UPDATE_PASSWORD",
-        "name" : "Update Password",
-        "providerId" : "UPDATE_PASSWORD",
-        "enabled" : true,
-        "defaultAction" : false,
-        "priority" : 30,
-        "config" : { }
-    }, {
-        "alias" : "UPDATE_PROFILE",
-        "name" : "Update Profile",
-        "providerId" : "UPDATE_PROFILE",
-        "enabled" : true,
-        "defaultAction" : false,
-        "priority" : 40,
-        "config" : { }
-    }, {
-        "alias" : "VERIFY_EMAIL",
-        "name" : "Verify Email",
-        "providerId" : "VERIFY_EMAIL",
-        "enabled" : true,
-        "defaultAction" : false,
-        "priority" : 50,
-        "config" : { }
-    }, {
-        "alias" : "delete_account",
-        "name" : "Delete Account",
-        "providerId" : "delete_account",
-        "enabled" : false,
-        "defaultAction" : false,
-        "priority" : 60,
-        "config" : { }
-    }, {
-        "alias" : "update_user_locale",
-        "name" : "Update User Locale",
-        "providerId" : "update_user_locale",
-        "enabled" : true,
-        "defaultAction" : false,
-        "priority" : 1000,
-        "config" : { }
-    } ],
-    "browserFlow" : "browser",
-    "registrationFlow" : "registration",
-    "directGrantFlow" : "direct grant",
-    "resetCredentialsFlow" : "reset credentials",
-    "clientAuthenticationFlow" : "clients",
-    "dockerAuthenticationFlow" : "docker auth",
-    "attributes" : {
-        "cibaBackchannelTokenDeliveryMode" : "poll",
-        "cibaExpiresIn" : "120",
-        "cibaAuthRequestedUserHint" : "login_hint",
-        "oauth2DeviceCodeLifespan" : "600",
-        "clientOfflineSessionMaxLifespan" : "0",
-        "oauth2DevicePollingInterval" : "5",
-        "clientSessionIdleTimeout" : "0",
-        "parRequestUriLifespan" : "60",
-        "clientSessionMaxLifespan" : "0",
-        "clientOfflineSessionIdleTimeout" : "0",
-        "cibaInterval" : "5"
-    },
-    "keycloakVersion" : "16.1.0",
-    "userManagedAccessAllowed" : false,
-    "clientProfiles" : {
-        "profiles" : [ ]
-    },
-    "clientPolicies" : {
-        "policies" : [ ]
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      }, {
+        "id" : "a1ab542d-c481-4dc2-9455-cbb78c8325e5",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+        "attributes" : { }
+      } ],
+      "lrs_admin_ui" : [ ]
     }
+  },
+  "groups" : [ {
+    "id" : "617dd33a-0ec4-4ad3-b496-d792020e839c",
+    "name" : "developers",
+    "path" : "/developers",
+    "attributes" : { },
+    "realmRoles" : [ ],
+    "clientRoles" : { },
+    "subGroups" : [ ]
+  } ],
+  "defaultRole" : {
+    "id" : "d84a5ad7-ef32-4c7f-bfed-63256266c721",
+    "name" : "default-roles-test",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "test"
+  },
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpSupportedApplications" : [ "FreeOTP", "Google Authenticator" ],
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "users" : [ {
+    "id" : "9c9708f0-c84a-49db-805a-1231b007a306",
+    "createdTimestamp" : 1643146437013,
+    "username" : "dev_user",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : true,
+    "firstName" : "Development",
+    "lastName" : "User",
+    "email" : "dev_user@example.com",
+    "attributes" : {
+      "foo" : [ "bar" ]
+    },
+    "credentials" : [ {
+      "id" : "9477829d-6f0b-4a2d-b1bd-40769cd79121",
+      "type" : "password",
+      "createdDate" : 1643146523059,
+      "secretData" : "{\"value\":\"kiGu0mANJBvsuKpf9AJGPfXXN7JLuH/nXmK3+1fd7pXXTtRc8ZIaQKFXt09szSJAfosrMWbNDtMAc6Of/BeLqA==\",\"salt\":\"xRmuQt7YJKfeCxlAvf/v9A==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-test" ],
+    "notBefore" : 0,
+    "groups" : [ "/developers" ]
+  }, {
+    "id" : "992c8e02-6407-4f52-9c67-13821d62ac4e",
+    "createdTimestamp" : 1648052715358,
+    "username" : "service-account-lrs_client",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "serviceAccountClientId" : "lrs_client",
+    "credentials" : [ ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-test" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  } ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account" ]
+    } ]
+  },
+  "clients" : [ {
+    "id" : "f47cc13c-bd8e-4a1f-94bf-b6e886b6fe29",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/test/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/test/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "c8f48dc1-c2fd-45d1-bcfb-1cc345cb269a",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/test/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/test/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "8ad7c1f2-57d0-4989-bda9-8768dbc222b6",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "554b71bc-8f36-49f1-b39f-86fa65ebbe8f",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "9cdbf3ec-85f6-4366-956b-d1556302eac1",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "93f48f9d-bd78-44f2-97f7-7f3b65aaa8da",
+    "clientId" : "lrs",
+    "name" : "SQL LRS",
+    "rootUrl" : "http://0.0.0.0:8080/",
+    "adminUrl" : "http://0.0.0.0:8080/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "http://0.0.0.0:8080/*" ],
+    "webOrigins" : [ "http://0.0.0.0:8080" ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "id.token.as.detached.signature" : "false",
+      "saml.assertion.signature" : "false",
+      "saml.force.post.binding" : "false",
+      "saml.multivalued.roles" : "false",
+      "saml.encrypt" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false",
+      "saml.server.signature" : "false",
+      "saml.server.signature.keyinfo.ext" : "false",
+      "use.refresh.tokens" : "true",
+      "exclude.session.state.from.auth.response" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "saml.artifact.binding" : "false",
+      "backchannel.logout.session.required" : "true",
+      "client_credentials.use_refresh_token" : "false",
+      "saml_force_name_id_format" : "false",
+      "require.pushed.authorization.requests" : "false",
+      "saml.client.signature" : "false",
+      "tls.client.certificate.bound.access.tokens" : "false",
+      "saml.authnstatement" : "false",
+      "display.on.consent.screen" : "false",
+      "saml.onetimeuse.condition" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "5815065b-8104-4051-b4a8-59a97c2af242",
+    "clientId" : "lrs_admin_ui",
+    "name" : "LRS Admin UI/Figwheel Server",
+    "rootUrl" : "http://localhost:9500/",
+    "adminUrl" : "http://localhost:9500/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "http://localhost:9500/", "http://0.0.0.0:8080/admin/index.html", "http://localhost:9500/*" ],
+    "webOrigins" : [ "http://localhost:9500", "http://0.0.0.0:8080" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "saml.force.post.binding" : "false",
+      "saml.multivalued.roles" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "use.jwks.url" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false",
+      "saml.server.signature.keyinfo.ext" : "false",
+      "use.refresh.tokens" : "true",
+      "jwt.credential.certificate" : "MIICqzCCAZMCBgF+VSRiwDANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDDA50ZXN0YXBwX3B1YmxpYzAeFw0yMjAxMTMyMDMwNTVaFw0zMjAxMTMyMDMyMzVaMBkxFzAVBgNVBAMMDnRlc3RhcHBfcHVibGljMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAl18eQYywttSxpioT0plMAj0BENJQhHu/7LmkF7a4GwG3OyZNpiky3V1W4oFgfmTcTisXYBB1eRIw+bC8Iy808DX7PbHr4N/qn1pjgkohl9pPo3UnKAa2hEUsKtQDfn5Oltx/qliSvT0zFzHmPXH2CHKCqyjy9NFFG+rPNXXrmY/xM8HToqjchwvA4DHOnbcUgRzGSQl2vmO0GJvRqcFQjoQXaPEvQck8geVB2bjx0Lkt6m5zWkMZsVH8aBeBTuuZqpCGO5LecyMOHz0iEx8T0lMJorE5uR6ul8jnZzFdv9blLEiroy8Btes8WCImopKO1MCqdIbrSB54v+lQ+Jg7HwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQAy9xUwUDTQjRiiHCljmJpjQEqTuXHzFaBr9oj3pQ698eM0vjaoBh0DAqUfNiPHTwqvyuOOLYoO2HJzcjnGYn0hHgTWWUGAzj0id+Nq1+nfdq9yqW2PGsEza7/LZja80RclRs3E6ZjFxPBUndyTV2ppvtL5/KFN/OYC7iXvSJd++dOIPRtk4hyOtu08HvQ0uFwh+H3bcb0ZKnTqsVhkBs9AmHF61K4IKDPJc8FahVeSVQDH46uqLjhSBx4lmjGFF7hax3RxvLB4zO88YZECo8+ce4B9kMxsYqsVL2xuJFf8kucfJRwA6LIkARsICiDI9pIda9QbHibaxyFaARQ6kdIT",
+      "oidc.ciba.grant.enabled" : "false",
+      "use.jwks.string" : "false",
+      "backchannel.logout.session.required" : "true",
+      "client_credentials.use_refresh_token" : "false",
+      "require.pushed.authorization.requests" : "false",
+      "saml.client.signature" : "false",
+      "id.token.as.detached.signature" : "false",
+      "saml.assertion.signature" : "false",
+      "saml.encrypt" : "false",
+      "saml.server.signature" : "false",
+      "exclude.session.state.from.auth.response" : "false",
+      "saml.artifact.binding" : "false",
+      "saml_force_name_id_format" : "false",
+      "tls.client.certificate.bound.access.tokens" : "false",
+      "saml.authnstatement" : "false",
+      "display.on.consent.screen" : "false",
+      "saml.onetimeuse.condition" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "07ca9c45-03b8-4744-bedd-6dcd3cbfc6b1",
+      "name" : "LRS Audience Mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "false",
+        "access.token.claim" : "true",
+        "included.custom.audience" : "http://0.0.0.0:8080",
+        "userinfo.token.claim" : "false"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "lrs:statements/read", "lrs:admin", "lrs:all/read", "address", "phone", "offline_access", "lrs:statements/write", "microprofile-jwt", "lrs:all" ]
+  }, {
+    "id" : "c71245dc-e3ed-43b3-bfd9-49955d7d793a",
+    "clientId" : "lrs_client",
+    "name" : "LRS Client",
+    "description" : "An example LRS client suitable for the OAuth Client Credentials Grant",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "vGxvFpk9CLtfQwGCSJlb9SvUoDByuZjN",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : true,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "id.token.as.detached.signature" : "false",
+      "saml.assertion.signature" : "false",
+      "saml.force.post.binding" : "false",
+      "saml.multivalued.roles" : "false",
+      "saml.encrypt" : "false",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false",
+      "saml.server.signature" : "false",
+      "saml.server.signature.keyinfo.ext" : "false",
+      "use.refresh.tokens" : "true",
+      "exclude.session.state.from.auth.response" : "false",
+      "oidc.ciba.grant.enabled" : "false",
+      "saml.artifact.binding" : "false",
+      "backchannel.logout.session.required" : "true",
+      "client_credentials.use_refresh_token" : "false",
+      "saml_force_name_id_format" : "false",
+      "require.pushed.authorization.requests" : "false",
+      "saml.client.signature" : "false",
+      "tls.client.certificate.bound.access.tokens" : "false",
+      "saml.authnstatement" : "false",
+      "display.on.consent.screen" : "false",
+      "saml.onetimeuse.condition" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "d2df95b0-4f7e-48ba-82a6-ebacb2b9dbc3",
+      "name" : "Client IP Address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientAddress",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientAddress",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c175448a-9739-45a1-b2d0-1c0f830ba903",
+      "name" : "Client Host",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientHost",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientHost",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "6b8382a5-6372-4863-9012-05ebbd8c3239",
+      "name" : "lrs_client_audience_mapper",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "false",
+        "access.token.claim" : "true",
+        "included.custom.audience" : "http://0.0.0.0:8080",
+        "userinfo.token.claim" : "false"
+      }
+    }, {
+      "id" : "4a076dfe-db68-4792-b3bf-cc46e92605fb",
+      "name" : "Client ID",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.session.note" : "clientId",
+        "userinfo.token.claim" : "true",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "clientId",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "lrs:all", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "07000d1e-39d0-4864-a39d-70566b870361",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "fe5daf9c-81b7-4aa8-9d89-557dac44e9cd",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/test/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/test/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "pkce.code.challenge.method" : "S256"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "c368d119-cdfa-42d3-ac6f-25027c669774",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "8b2321db-a3f5-4d8e-ae28-39f48125c07a",
+    "name" : "lrs:statements/read",
+    "description" : "xAPI Statements Read Only",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "xAPI Statements Read Only"
+    }
+  }, {
+    "id" : "6a4a4a4d-03aa-473f-aa0d-75b489977d5c",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "f8993932-62d2-48e0-a304-3f136ea8edfe",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "523c9af4-4711-43d7-85af-f3ac04ace666",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "1858bdad-5c52-4aa1-b0fc-5581af798a08",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "b3db4dc4-231d-4674-a5b6-ea6d5e9016dc",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e0e5805c-c044-480f-a3a7-2981d794df86",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c5ced14b-2b38-419b-9896-85cf88a3711b",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "75c08d02-0833-4aa2-a098-98e4b4963cd7",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "1cdfb88e-1e04-4d78-a68a-3e289b089a33",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "236affeb-fffc-4848-b717-7c8f190d06fb",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "e59085e5-6bf4-4916-a8c9-44102337b968",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f3bbe050-5486-4e1c-8557-070e89096f7d",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c7181162-eabd-4e46-9c4b-c8c4ff14ce67",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c3dac1cf-d61a-4f3d-8bea-74f7eb65d565",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "bc51e879-fd49-4456-8dab-ad9495ce1da0",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "db720beb-9e39-4a19-9372-3fe356561c3b",
+    "name" : "lrs:admin",
+    "description" : "All admin permissions on LRS",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "Administer LRS"
+    }
+  }, {
+    "id" : "c6283805-484f-4d1c-9e85-1955c13c9c7f",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "71ef7385-cc4d-41a7-aa03-d67f0586f87e",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    }, {
+      "id" : "f4784c65-9cd1-4b38-be19-a8c36efa0c84",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "8c57c0a4-f8b9-4358-962b-49b0f3013eac",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    } ]
+  }, {
+    "id" : "817b903a-cb78-4caf-a338-affb280d364f",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "fa86e7f0-866d-412c-8191-9cc86c5a7d8b",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "8833ffce-a1a0-4558-a65e-ed5d107f1022",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "7141d9b9-5746-4559-9151-8411bdb3afb5",
+    "name" : "lrs:all",
+    "description" : "All xAPI Permissions",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "All xAPI"
+    }
+  }, {
+    "id" : "1066033a-7d3e-46ba-97a1-7fc2e84c65ab",
+    "name" : "lrs:statements/write",
+    "description" : "xAPI Statements Write Only",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "xAPI Statements Write Only"
+    }
+  }, {
+    "id" : "dca4ed1d-460c-4807-b0d9-568592e6d088",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "6374f381-4889-489e-aead-5fa18ef1b822",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "be667ccc-ba78-4afa-970e-13da6bc07427",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "6a7b16b0-1e49-43b8-ae44-e4e6fdc2b3fc",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "52f9ee66-42fa-4bd0-a5b3-26aa8f42e25a",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "1629c27c-75cc-4407-89e6-971c900bb127",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "2da9c5aa-679c-433a-b4dc-8ab76917b1da",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "6467a85b-e3a6-4181-ab4b-ca879ce2c123",
+    "name" : "lrs:all/read",
+    "description" : "Read-only xAPI Permissions",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "xAPI Read Only"
+    }
+  }, {
+    "id" : "84261ec9-96d3-4f8c-b343-619828a3ad4b",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "aceb7515-642e-4403-afab-3c93aebfb056",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "1e5dfa94-fed1-4fb4-a591-9951704e4a84",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "7c2908d3-28c4-42e6-bd96-c9e57cef7cf0",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "dc7578fc-d518-4312-99ea-bb4d93774562",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "f6241122-16ec-4f71-b9e8-efd173318dea",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "profile", "email", "role_list", "roles", "web-origins" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "phone", "microprofile-jwt", "address" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "c0c16b10-415f-4d6e-88f6-c1050314e85d",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "06bdbf20-05ff-4e6d-bbf0-3daa86fb0757",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "86f63e93-ef16-41ff-8a7b-9a0f99344497",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "oidc-address-mapper", "saml-role-list-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper" ]
+      }
+    }, {
+      "id" : "cb89ebbf-ff1c-432c-a43e-63df05848a62",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "70c357f9-59c0-4758-b202-ba75ace53eda",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "9f3b5f54-efe8-4ebf-a6d7-1bcb3b3f192b",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "e640c7f7-0c39-4b47-91c3-d1687c353769",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "ebc3625c-9fe2-4739-8d75-b07866794e28",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "saml-user-property-mapper", "oidc-address-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "2586006e-6e8e-479f-b6e3-dd2af4bd253d",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEpAIBAAKCAQEAs49gQ2xcce8VslFoqBR3gj/oUmOc2g2J8SGlPaYAQ4pHWopfZqD6gBQ5hKmRKefuNBXn2bN2j2Zq7RMbPVYKH6F5U+RtJ1ja+tNOK8+uY5coqvwRrYR10BFtrYNq9MapWHXUFdzIJZ5IDT3/W/jS6qNPOL49Os/TO7tf8QpVV67d0zxblR8VSKagp1KmhjSvTx7lWJcRNYRIKFbIcZ0ZP4/2pzemTyDqJjkzgNrSW8K3cNLzohdjr1pR3UFVw+sGlG5NdDrVs0CporOJrArzqF8YkLMMpMCLpjYAiK7AEC7yN9cn7Og1NctqVN2lA+agqkcT+dpOE1wa2lr1oeTKAwIDAQABAoIBAGj34CaKKmDQi7Z6sNvRWyvhgEbpxMAUOheku5yWdoEFTUE4sxyj7s0BBb7wAdSlqTL5u1gg+aZLEScWjE4HBlQHaY4Jc2YVI66N6JzkA+Zkb3nFcfAmB1ljVuKgeN4vZMA54YoGT1rudOCI5cc2ZtaUMbPSQqkm5S1+FFAs4kcnD6t/m3dpHE0uG3cWutfzUHAkk0cZFtZFLlI+arB4Ml5fj/ZfDTC4cp8+LS4EeHK/+gmlBGOknEd8gtNLl4a9G2lOfvG8knjnWpIApkDhPpLqtn8x/KHYeu+dJ1u2V+Fn5ZNcILp66q3zbFevZVNNzsrQXx8f1huoO4dTnIytOIECgYEA4lh05yHfPohdoiW2DvowzV7Bg3V2e3Z5pXTB2kcfP65QITqYJpItmeLvfMUXbxbOUOP1ZaBJig7WbfngqFsOa9J77KBJw+c1N91FCtm7auovGsbo8sOAGRu7oQPS/DZO5aUBfGncfHAJpJ/yWWHlOk/S30fBU+QlVK168d1YK2sCgYEAyxXAnpR346U4ayW02Re1I7hPP0bYwQy9TseYlfimxzApIEa6vNbyHXtbl4ppl5uakBMZcDpM3JfZni7eLD6ndH5rWNyGSkNmPh+yb6E92Asnv+1VmGJd7FAM2VbLfY7ufS7qEBJWJrmwRuOB9DbpmRQqQ3PvdelOCGj3FOzX2ckCgYAh2Yq6GjWxu2ENY8hjWwU7YWVdTI7IjgJJPTnUc/h3ZJE1NvcUJZ5OOkMIjM0hXu7B6CWF6j+1NtzYm5r+coeollTUIXCGrKgnz56IreE6bwVWYtLpo1Uf7CbWQKUn9NM9wryDJ63Cqlq21PjAZ0SJwPBPVgLSkfcHP954F1sdOwKBgQCd9q18q78VMs5PiWTB987Nme8KKPEwN9iIDniBLoeLJ8rVcC6P9CEfDXSQyviXFFGE/1YqFS7z5qk+gPYPNCzMUAjvdZh+6y375GvGqISSJxskDlcl0F1+EkXsR7bAUwzuEi+9kIWyWXzjptLOQmgwyZ6WGPeJn48yu3J0tESxAQKBgQCHvUJOwdrXqN7mZzAWPUwbLr+evkJSQQyquR3HW/Yq8LYB1nFxzBVdNKvh5JMvpB1wOtjFdEQ0y6M+w+ZzMfsJEz0jap1z0m8R0DwrXCjtIT9YOtSkbp2cHxxMYodshqEKQErkFtNySit/BkYjpJrSNwk7AwfDNaCdcXcHmR962A==" ],
+        "keyUse" : [ "SIG" ],
+        "certificate" : [ "MIIClzCCAX8CBgF+ShW75DANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDAR0ZXN0MB4XDTIyMDExMTE2NTkwNVoXDTMyMDExMTE3MDA0NVowDzENMAsGA1UEAwwEdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALOPYENsXHHvFbJRaKgUd4I/6FJjnNoNifEhpT2mAEOKR1qKX2ag+oAUOYSpkSnn7jQV59mzdo9mau0TGz1WCh+heVPkbSdY2vrTTivPrmOXKKr8Ea2EddARba2DavTGqVh11BXcyCWeSA09/1v40uqjTzi+PTrP0zu7X/EKVVeu3dM8W5UfFUimoKdSpoY0r08e5ViXETWESChWyHGdGT+P9qc3pk8g6iY5M4Da0lvCt3DS86IXY69aUd1BVcPrBpRuTXQ61bNAqaKziawK86hfGJCzDKTAi6Y2AIiuwBAu8jfXJ+zoNTXLalTdpQPmoKpHE/naThNcGtpa9aHkygMCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAoj8kXR2fabdLtMGCj7BGy1xIJLUtNnmAIGnHaZ37cVadzHPxRXtOKJjBrAOrjQ7dvONelubZ3Uj9warCdsUV65t6NrG85KpJlW3qVtMuaIoY/sJ2bT9CYKemrOgTW3LgPmjO+YpZOR4uuo2LmVw0XL8KE6zlZwqRfwhjWy/QkRrgHsIXcbF4SnVDAQzpPlo3dTNS60pDtQtbYkIFI2ujdFpkA5u73DAPUCNakRvoutI8ZuHRqqPIIwKFzMXYZNG4GRfL51tRC14VSb+IIoknFwPpm2Y4ZCZkM7OfEDombHgU301NpMcc0ZZxw0zrI5ADEgLpxFitonbFf4MZyJXUbA==" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "3c9c0ea4-c541-428d-ac49-44d955b4fbcc",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEogIBAAKCAQEAh4/1V8qm/ZoenwUI15TispVHM24NvnhbPOlSg4Hj3FduSi9qJ/CbiOKaZ15cQ6n6J4Niiv5X6VgehrU00Ni/yzNfDVjiiz2esb4YEGHMoEzjtjh6B5sNaptYyYjOenHRdiEVsKX480DJDs81MrQS7dLaSkXP3nz8i1w6JK086vT6JLf5YX7w+aESFr4etzPluWokKtx9MvK36+oqoPqIzzzXOSDFQ1FaQmOMyYKxaVOL9TFJoCevR5BzDxz+p5OyjDvsDq6VhKavU5mggXgQNrpDuWvNJQ7aBnUY2iJ0+gOF4/KieHUWNgtDc5eyOuhWRqg6QsEM8jXiOa55tVm+7QIDAQABAoIBAEavLYJFTKVXQzgva9jc7QepBqMuc0QphYlRL5EanTE69WsBJh0FPFQ3s8LKVNmDO8h2nV9UF4q4Q9KBkbSEEB1n/9v5yMZJrwGG2Q1RsVy0Ote8wwRMOMapkbYj+2WlC07JGYIuSIyt7yglqttxQZ14IBIyLJ0aFqSjxj1xhx4LMlslOMzjgAqybqATj+3/dbhUxj82DoucVMkGvgJyax9VuJL7r0c7jvzn+/LRjP2oouECN9NjOusVM1CA4+l70IasR6dnuD93QMK/rBSTvls2knk9HPBX5bZZxa0cLK2en14Zv9T57zf7176Xuy7WC4eUSfVN7LiiO5RA5bK/QgECgYEA1pfZqp3ynhRp8VAO9qqSuOBdqxXYkKEnoQgNp9v/t8DM5DftOExyFPeAcFu1nSoKALM0J+MaV9ggsS8c1vVgc63jL96Yt9+/dhIXJuHFx0TlE/6TLYmrRgfOSvthiSsGxVutcGu0UfYcmhObNLike3Ulfb7Sww2z18Ic/NSEfs0CgYEAobhDLH8xfV7rPnvQB3bse2Pz4anqFIgfaTJYk9dYgjuHpy9v4qU5LqJ8UjJtVscceJObrQnkZADzaQNMkL1Ce7YBmzo/pB2M39J7cRyQ+H5d2VbSlX9dTL+jBzvIye73YXl9GQH7YPU0NwGY3qtmNUYUetFdLYaK0cCukfoeAKECgYBT/pPgSHqSjYL6RU/WFOXhH1EKij5+PdX5HeHadi4dioWoPovHoYR12HqZgAwSPEY2B+6+PhItmBcTw1ESgnECVmm6bvJv5lBWsrYFLhHv8XOI4/hPtrcnbh69ErAWtJSt4zh77GxkOGTxmgMCG9OlzzChi3OLjW17YiteewBxcQKBgFhO8Ud8ET8/tL/DBl79HrdmZkeE7FDX4Ccmmd3pSuiar0GpErS1ulrv2WldJf2r7q0dFXZRH4lIR6LBbW7gGkzJn2jvTs9EX6fdHREwIy2+e2ryET4XdZAyWUja6ZLzTdzJZXlhbq6MVz3uPlbhS4etxAMpDnOMs4NEb09BQF7hAoGAQ//vl9A328D5h5O5XyqylG1WPeXLcdwMQ3uP+erxS4kLrYlEv3Eo7BNpK6nRHQUndkrOGDMABc3TOOnYVE6486DWdrpy9MsQk3KoNM7KogswRQcDmXPLG3smOcfAtOraZGqlL8SX15N9CAedj0Nw4MeDI7biSZSt6jhaC5RlZlU=" ],
+        "keyUse" : [ "ENC" ],
+        "certificate" : [ "MIIClzCCAX8CBgF+ShW93DANBgkqhkiG9w0BAQsFADAPMQ0wCwYDVQQDDAR0ZXN0MB4XDTIyMDExMTE2NTkwNVoXDTMyMDExMTE3MDA0NVowDzENMAsGA1UEAwwEdGVzdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAIeP9VfKpv2aHp8FCNeU4rKVRzNuDb54WzzpUoOB49xXbkovaifwm4jimmdeXEOp+ieDYor+V+lYHoa1NNDYv8szXw1Y4os9nrG+GBBhzKBM47Y4egebDWqbWMmIznpx0XYhFbCl+PNAyQ7PNTK0Eu3S2kpFz958/ItcOiStPOr0+iS3+WF+8PmhEha+Hrcz5blqJCrcfTLyt+vqKqD6iM881zkgxUNRWkJjjMmCsWlTi/UxSaAnr0eQcw8c/qeTsow77A6ulYSmr1OZoIF4EDa6Q7lrzSUO2gZ1GNoidPoDhePyonh1FjYLQ3OXsjroVkaoOkLBDPI14jmuebVZvu0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEADSvRbqA28R+QU2ij01HcDNWmLvkxSMTFytHRs08n00Rd4ONYeXir1s2F4o0bSLCuYX1d7hOJiw2VVkQNqU2ZvfLZe9QBIetj+AaSsFEz3+3CqE22fHPrnM+1cI6SXpF/zK7Jx3sNdaKRuG3+WbTtjT1p45D/QwUd/YzjWf2YI824jAGamTupd1oyKX2klCnryS2sKrIqnH/1MDfgK93PLtSxNite/effRI2O6ySXX1wmila+nBo9hYcr5Y+yHCmPg+EtdVgGzvVDKrxFEQcLvbZD1HBDCymkWzix0hbsSKc4BDfBl8gOiAes4CATvhMyVJ4unsb/SMBkIDfclr/vdQ==" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    }, {
+      "id" : "ced222a6-758f-4bde-a993-c1f8882b99f3",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "13938f82-4b06-4dfa-a9ae-9f113d84d602" ],
+        "secret" : [ "cROFgwh4hrwUtON8MHhFY2Izr-A70s5FbHetwhnr0HdWNqrCtiPznHbNcvCpC8RhA1Nlm5i_DuxfkNHxbmDyEQ" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS256" ]
+      }
+    }, {
+      "id" : "1346c112-4ab3-4609-8282-c13fdb429b51",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "622051f7-e16a-45ea-ae3d-d0f3d7c6066f" ],
+        "secret" : [ "087wgqk1GaBeJqSwG0Va1A" ],
+        "priority" : [ "100" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "c629abb1-27aa-4069-9eff-88696a6bf2dd",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "fb210296-cf90-40b3-a634-4ebf59015309",
+    "alias" : "Authentication Options",
+    "description" : "Authentication options.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "basic-auth",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "basic-auth-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "880de9f9-56c8-42cf-ae24-6d742117965c",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "7a7cf4ce-3efe-4532-a83c-68cf048d06ab",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "4e0b1784-7ec6-45c0-b31a-e67b37eb2ed3",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "93a17980-f94c-4ab1-ba70-9748be1efc5a",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "f57018a5-7750-4e48-8ad4-0f56bf6e9556",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "fdfd97d7-21e1-477a-a62c-1c13eb1981e1",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "e8dd210d-45cb-4184-9190-b0670fd194c1",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "2b7d37a1-e858-4b0a-b472-0e117e9dd867",
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "c48f10da-e463-401c-918b-23e8b0e50d38",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "3d911f1c-3035-4b93-b956-202c219f5b9e",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "7158f40c-97cd-4652-b36a-399db39eb4fc",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "2a2d8fa1-6591-4b6d-9bec-1e2c57b5ebc2",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "2a294bda-bb2a-46ab-8534-0f1f28e67b97",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "ea82fdd2-d742-4eb3-94b3-b871b8d70476",
+    "alias" : "http challenge",
+    "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "no-cookie-redirect",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "flowAlias" : "Authentication Options",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "de10e1c0-bca0-432e-ad60-87d9e6192dc2",
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "f84ec39b-22d5-40d9-94c7-7e98bff41fdd",
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-profile-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 40,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "c1226766-e5a4-4b0d-bb9d-6182bb7b6826",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "4bab12b2-3513-4e4d-a22e-b9dc12ff428b",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "7c882b45-0091-46de-89f9-2f1f8b5375eb",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "43cf4a3b-64a4-48a0-92ad-96b45c78f24c",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "terms_and_conditions",
+    "name" : "Terms and Conditions",
+    "providerId" : "terms_and_conditions",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaExpiresIn" : "120",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "oauth2DeviceCodeLifespan" : "600",
+    "clientOfflineSessionMaxLifespan" : "0",
+    "oauth2DevicePollingInterval" : "5",
+    "clientSessionIdleTimeout" : "0",
+    "parRequestUriLifespan" : "60",
+    "clientSessionMaxLifespan" : "0",
+    "clientOfflineSessionIdleTimeout" : "0",
+    "cibaInterval" : "5"
+  },
+  "keycloakVersion" : "16.1.0",
+  "userManagedAccessAllowed" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
+  },
+  "clientPolicies" : {
+    "policies" : [ ]
+  }
 }


### PR DESCRIPTION
[SQL-143] Add a client to the keycloak demo to enable OIDC auth with the Client Credentials Grant, which uses the id and secret of an Oauth client/consumer rather than identified user credentials.


[SQL-143]: https://yet.atlassian.net/browse/SQL-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ