### PR TITLE
Update jackson-core to 2.13.2 to address CVE-2020-36518

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -15,6 +15,10 @@
     com.fasterxml.jackson.dataformat/jackson-dataformat-smile
     com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]}
   com.fasterxml.jackson.core/jackson-core  {:mvn/version "2.13.2"}
+  com.fasterxml.jackson.dataformat/jackson-dataformat-smile
+  {:mvn/version "2.13.2"}
+  com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
+  {:mvn/version "2.13.2"}
   clojure.java-time/clojure.java-time      {:mvn/version "0.3.2"}
   danlentz/clj-uuid                        {:mvn/version "0.1.9"}
   aero/aero                                {:mvn/version "1.1.6"}

--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,13 @@
   ;; Util deps
   ;; - java-time: Updating to 0.3.3 causes dep clash with DATASIM
   camel-snake-kebab/camel-snake-kebab      {:mvn/version "0.4.2"}
-  cheshire/cheshire                        {:mvn/version "5.10.1"}
+  cheshire/cheshire
+  {:mvn/version "5.10.1"
+   :exclusions
+   [com.fasterxml.jackson.core/jackson-core
+    com.fasterxml.jackson.dataformat/jackson-dataformat-smile
+    com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]}
+  com.fasterxml.jackson.core/jackson-core  {:mvn/version "2.13.2"}
   clojure.java-time/clojure.java-time      {:mvn/version "0.3.2"}
   danlentz/clj-uuid                        {:mvn/version "0.1.9"}
   aero/aero                                {:mvn/version "1.1.6"}


### PR DESCRIPTION
For scan failure: https://github.com/yetanalytics/lrsql/runs/5640486174?check_suite_focus=true

https://nvd.nist.gov/vuln/detail/CVE-2020-36518

https://github.com/FasterXML/jackson-databind/issues/2816