### PR TITLE
SQL-144 OIDC local admin toggle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 
 # Version of LRS Admin UI to use
 
-LRS_ADMIN_UI_VERSION ?= v0.1.6-pre3
-
+LRS_ADMIN_UI_VERSION ?= v0.1.6-pre6
 LRS_ADMIN_UI_LOCATION ?= https://github.com/yetanalytics/lrs-admin-ui/releases/download/${LRS_ADMIN_UI_VERSION}/lrs-admin-ui.zip
 LRS_ADMIN_ZIPFILE ?= lrs-admin-ui-${LRS_ADMIN_UI_VERSION}.zip
 

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -117,5 +117,6 @@ You may have noted that some options are not available:
 | `LRSQL_OIDC_CLIENT_ID` | `oidcClientId` | An optional OIDC client ID for the SQL LRS Admin SPA. If provided, along with the `LRSQL_OIDC_ISSUER` and `LRSQL_OIDC_AUDIENCE` variables, will enable OIDC access to the Admin UI. | Not Set |
 | `LRSQL_OIDC_CLIENT_TEMPLATE` | `oidcClientTemplate` | An optional template to modify LRS Admin UI client OIDC configuration. | Not Set |
 | `LRSQL_OIDC_VERIFY_REMOTE_ISSUER` | `oidcVerifyRemoteIssuer` | Verify on startup that the issuer in remote configuration matches `LRSQL_OIDC_ISSUER`. No effect if `LRSQL_OIDC_ISSUER` is not set. | `true` |
+| `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` | `oidcEnableLocalAdmin` | Whether or not to enable local administrative account login when `LRSQL_OIDC_CLIENT_ID` is set. | `false` |
 
 [<- Back to Index](index.md)

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -117,6 +117,6 @@ You may have noted that some options are not available:
 | `LRSQL_OIDC_CLIENT_ID` | `oidcClientId` | An optional OIDC client ID for the SQL LRS Admin SPA. If provided, along with the `LRSQL_OIDC_ISSUER` and `LRSQL_OIDC_AUDIENCE` variables, will enable OIDC access to the Admin UI. | Not Set |
 | `LRSQL_OIDC_CLIENT_TEMPLATE` | `oidcClientTemplate` | An optional template to modify LRS Admin UI client OIDC configuration. | Not Set |
 | `LRSQL_OIDC_VERIFY_REMOTE_ISSUER` | `oidcVerifyRemoteIssuer` | Verify on startup that the issuer in remote configuration matches `LRSQL_OIDC_ISSUER`. No effect if `LRSQL_OIDC_ISSUER` is not set. | `true` |
-| `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` | `oidcEnableLocalAdmin` | Whether or not to enable local administrative account authentication and login when `LRSQL_OIDC_ISSUER` is set. | `false` |
+| `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` | `oidcEnableLocalAdmin` | Whether or not to enable local administrative account authentication, login and management when `LRSQL_OIDC_ISSUER` is set. | `false` |
 
 [<- Back to Index](index.md)

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -117,6 +117,6 @@ You may have noted that some options are not available:
 | `LRSQL_OIDC_CLIENT_ID` | `oidcClientId` | An optional OIDC client ID for the SQL LRS Admin SPA. If provided, along with the `LRSQL_OIDC_ISSUER` and `LRSQL_OIDC_AUDIENCE` variables, will enable OIDC access to the Admin UI. | Not Set |
 | `LRSQL_OIDC_CLIENT_TEMPLATE` | `oidcClientTemplate` | An optional template to modify LRS Admin UI client OIDC configuration. | Not Set |
 | `LRSQL_OIDC_VERIFY_REMOTE_ISSUER` | `oidcVerifyRemoteIssuer` | Verify on startup that the issuer in remote configuration matches `LRSQL_OIDC_ISSUER`. No effect if `LRSQL_OIDC_ISSUER` is not set. | `true` |
-| `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` | `oidcEnableLocalAdmin` | Whether or not to enable local administrative account login when `LRSQL_OIDC_CLIENT_ID` is set. | `false` |
+| `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` | `oidcEnableLocalAdmin` | Whether or not to enable local administrative account authentication and login when `LRSQL_OIDC_ISSUER` is set. | `false` |
 
 [<- Back to Index](index.md)

--- a/resources/lrsql/config/prod/default/webserver.edn
+++ b/resources/lrsql/config/prod/default/webserver.edn
@@ -18,5 +18,5 @@
  :oidc-audience             #env LRSQL_OIDC_AUDIENCE
  :oidc-client-id            #env LRSQL_OIDC_CLIENT_ID
  :oidc-client-template      #or [#env LRSQL_OIDC_CLIENT_TEMPLATE "config/oidc_client.json.template"]
- :oidc-verify-remote-issuer #or [#env LRSQL_OIDC_VERIFY_REMOTE_ISSUER true]
+ :oidc-verify-remote-issuer #boolean #or [#env LRSQL_OIDC_VERIFY_REMOTE_ISSUER true]
  :oidc-enable-local-admin   #boolean #or [#env LRSQL_OIDC_ENABLE_LOCAL_ADMIN false]}

--- a/resources/lrsql/config/prod/default/webserver.edn
+++ b/resources/lrsql/config/prod/default/webserver.edn
@@ -18,4 +18,5 @@
  :oidc-audience             #env LRSQL_OIDC_AUDIENCE
  :oidc-client-id            #env LRSQL_OIDC_CLIENT_ID
  :oidc-client-template      #or [#env LRSQL_OIDC_CLIENT_TEMPLATE "config/oidc_client.json.template"]
- :oidc-verify-remote-issuer #or [#env LRSQL_OIDC_VERIFY_REMOTE_ISSUER true]}
+ :oidc-verify-remote-issuer #or [#env LRSQL_OIDC_VERIFY_REMOTE_ISSUER true]
+ :oidc-enable-local-admin   #boolean #or [#env LRSQL_OIDC_ENABLE_LOCAL_ADMIN false]}

--- a/resources/lrsql/config/test/default/webserver.edn
+++ b/resources/lrsql/config/test/default/webserver.edn
@@ -13,4 +13,5 @@
  :enable-admin-ui           true
  :enable-stmt-html          true
  :oidc-verify-remote-issuer true
- :oidc-client-template      "config/oidc_client.json.template"}
+ :oidc-client-template      "config/oidc_client.json.template"
+ :oidc-enable-local-admin   false}

--- a/resources/lrsql/config/test/oidc/webserver.edn
+++ b/resources/lrsql/config/test/oidc/webserver.edn
@@ -1,6 +1,5 @@
 #merge
 [#include "test/default/webserver.edn"
- {:oidc-issuer               "http://0.0.0.0:8081/auth/realms/test"
-  :oidc-audience             "http://0.0.0.0:8080"
-  :oidc-client-id            "lrs_admin_ui"
-  :oidc-verify-remote-issuer true}]
+ {:oidc-issuer    "http://0.0.0.0:8081/auth/realms/test"
+  :oidc-audience  "http://0.0.0.0:8080"
+  :oidc-client-id "lrs_admin_ui"}]

--- a/src/main/lrsql/admin/interceptors/oidc.clj
+++ b/src/main/lrsql/admin/interceptors/oidc.clj
@@ -97,3 +97,17 @@
     :enter
     (fn inject-client-config [ctx]
       (assoc ctx ::client-config client-config))}))
+
+(def require-oidc-identity-interceptor
+  "Verify that there is an OIDC admin identity or return a 401.
+  Used to implement the oidc-enable-local-admin webserver config variable."
+  (interceptor
+   {:name ::require-oidc-identity
+    :enter
+    (fn require-oidc-identity [ctx]
+      (if (::admin-identity ctx)
+        ctx
+        (assoc (chain/terminate ctx)
+               :response
+               {:status 401
+                :body   {:error "Admin authentication requires OIDC!"}})))}))

--- a/src/main/lrsql/admin/interceptors/oidc.clj
+++ b/src/main/lrsql/admin/interceptors/oidc.clj
@@ -88,7 +88,7 @@
                  result))))
         ctx))}))
 
-(defn inject-client-config-interceptor
+(defn inject-client-config
   "Inject an OIDC client configuration to be picked up by the admin env
   interceptor."
   [client-config]
@@ -98,7 +98,7 @@
     (fn inject-client-config [ctx]
       (assoc ctx ::client-config client-config))}))
 
-(def require-oidc-identity-interceptor
+(def require-oidc-identity
   "Verify that there is an OIDC admin identity or return a 401.
   Used to implement the oidc-enable-local-admin webserver config variable."
   (interceptor

--- a/src/main/lrsql/admin/interceptors/oidc.clj
+++ b/src/main/lrsql/admin/interceptors/oidc.clj
@@ -88,15 +88,14 @@
                  result))))
         ctx))}))
 
-(defn inject-client-config
-  "Inject an OIDC client configuration to be picked up by the admin env
-  interceptor."
-  [client-config]
+(defn inject-admin-env
+  "Inject OIDC client configuration to merge with the admin env."
+  [admin-env]
   (interceptor
-   {:name ::inject-client-config
+   {:name ::inject-admin-env
     :enter
-    (fn inject-client-config [ctx]
-      (assoc ctx ::client-config client-config))}))
+    (fn inject-admin-env [ctx]
+      (assoc ctx ::admin-env admin-env))}))
 
 (def require-oidc-identity
   "Verify that there is an OIDC admin identity or return a 401.

--- a/src/main/lrsql/admin/interceptors/ui.clj
+++ b/src/main/lrsql/admin/interceptors/ui.clj
@@ -17,13 +17,12 @@
     (fn get-env [ctx]
       (let [{url-prefix          ::i/path-prefix
              enable-stmt-html    ::i/statement-html?
-             ?oidc-client-config ::oidc-i/client-config} ctx]
+             oidc-env            ::oidc-i/admin-env} ctx]
         (assoc ctx
                :response
                {:status 200
                 :body
-                (cond-> {:url-prefix       url-prefix
-                         :enable-stmt-html (some? enable-stmt-html)}
-                  ?oidc-client-config
-                  (assoc :oidc
-                         ?oidc-client-config))})))}))
+                (merge
+                 {:url-prefix       url-prefix
+                  :enable-stmt-html (some? enable-stmt-html)}
+                 oidc-env)})))}))

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -102,15 +102,19 @@
            leeway
            secret
            enable-admin-ui
+           enable-account-routes
            oidc-interceptors
            oidc-ui-interceptors]
-    :or {oidc-interceptors    []
-         oidc-ui-interceptors []}}
+    :or   {oidc-interceptors     []
+           oidc-ui-interceptors  []
+           enable-account-routes true}}
    routes]
-  (let [common-interceptors (make-common-interceptors lrs)
+  (let [common-interceptors      (make-common-interceptors lrs)
         common-interceptors-oidc (into common-interceptors oidc-interceptors)]
     (cset/union routes
-                (admin-account-routes common-interceptors-oidc secret exp leeway)
+                (when enable-account-routes
+                  (admin-account-routes
+                   common-interceptors-oidc secret exp leeway))
                 (admin-cred-routes common-interceptors-oidc secret leeway)
                 (when enable-admin-ui
                   (admin-ui-routes

--- a/src/main/lrsql/init/oidc.clj
+++ b/src/main/lrsql/init/oidc.clj
@@ -138,7 +138,7 @@
              admin-oidc/ensure-oidc-identity]
       ;; If local admin is disabled (default), prevent subsequent login
       (not oidc-enable-local-admin)
-      (conj admin-oidc/require-oidc-identity-interceptor))
+      (conj admin-oidc/require-oidc-identity))
     []))
 
 ;; Authority
@@ -261,7 +261,7 @@
    lrs-config]
   (if (and oidc-issuer
            oidc-client-id)
-    [(admin-oidc/inject-client-config-interceptor
+    [(admin-oidc/inject-client-config
       (render-client-config {:webserver webserver-config
                              :lrs       lrs-config}))]
     []))

--- a/src/main/lrsql/init/oidc.clj
+++ b/src/main/lrsql/init/oidc.clj
@@ -256,9 +256,10 @@
   "Given webserver and LRS configs, return a vector of interceptors to apply to
   Admin UI routes. If webserver oidc-client-id is not specified, returns an
   empty vector."
-  [{:keys                           [oidc-issuer
+  [{:keys [oidc-issuer
            oidc-client-id
-           oidc-enable-local-admin] :as webserver-config}
+           oidc-enable-local-admin]
+    :as   webserver-config}
    lrs-config]
   (if (and oidc-issuer
            oidc-client-id)

--- a/src/main/lrsql/init/oidc.clj
+++ b/src/main/lrsql/init/oidc.clj
@@ -256,14 +256,17 @@
   "Given webserver and LRS configs, return a vector of interceptors to apply to
   Admin UI routes. If webserver oidc-client-id is not specified, returns an
   empty vector."
-  [{:keys [oidc-issuer
-           oidc-client-id] :as webserver-config}
+  [{:keys                           [oidc-issuer
+           oidc-client-id
+           oidc-enable-local-admin] :as webserver-config}
    lrs-config]
   (if (and oidc-issuer
            oidc-client-id)
-    [(admin-oidc/inject-client-config
-      (render-client-config {:webserver webserver-config
-                             :lrs       lrs-config}))]
+    [(admin-oidc/inject-admin-env
+      {:oidc                    (render-client-config
+                                 {:webserver webserver-config
+                                  :lrs       lrs-config})
+       :oidc-enable-local-admin oidc-enable-local-admin})]
     []))
 
 (s/def ::resource-interceptors

--- a/src/main/lrsql/spec/config.clj
+++ b/src/main/lrsql/spec/config.clj
@@ -162,6 +162,7 @@
 (s/def ::oidc-client-id (s/nilable string?))
 (s/def ::oidc-client-template string?)
 (s/def ::oidc-verify-remote-issuer boolean?)
+(s/def ::oidc-enable-local-admin boolean?)
 
 (s/def ::webserver
   (s/keys :req-un [::http-host
@@ -178,7 +179,8 @@
                    ::enable-admin-ui
                    ::enable-stmt-html
                    ::oidc-verify-remote-issuer
-                   ::oidc-client-template]
+                   ::oidc-client-template
+                   ::oidc-enable-local-admin]
           :opt-un [::key-file
                    ::key-pkey-file
                    ::key-cert-chain

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -36,7 +36,7 @@
         {{oidc-resource-interceptors :resource-interceptors
           oidc-admin-interceptors    :admin-interceptors
           oidc-admin-ui-interceptors :admin-ui-interceptors} :interceptors
-         :keys [enable-local-admin]}
+         :keys                                               [enable-local-admin]}
         (oidc/init
          config
          (:config lrs))

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -32,11 +32,12 @@
         ;; The private key is used as the JWT symmetric secret
         {:keys [keystore
                 private-key]} (cu/init-keystore config)
-        ;; OIDC Interceptors
-        {oidc-resource-interceptors :resource-interceptors
-         oidc-admin-interceptors    :admin-interceptors
-         oidc-admin-ui-interceptors :admin-ui-interceptors}
-        (oidc/interceptors
+        ;; OIDC Interceptors & derived settings
+        {{oidc-resource-interceptors :resource-interceptors
+          oidc-admin-interceptors    :admin-interceptors
+          oidc-admin-ui-interceptors :admin-ui-interceptors} :interceptors
+         :keys [enable-local-admin]}
+        (oidc/init
          config
          (:config lrs))
 
@@ -49,13 +50,15 @@
                                          [i/error-interceptor
                                           (handle-json-parse-exn)]
                                          oidc-resource-interceptors)})
-             (add-admin-routes {:lrs                  lrs
-                                :exp                  jwt-exp
-                                :leeway               jwt-lwy
-                                :secret               private-key
-                                :enable-admin-ui      enable-admin-ui
-                                :oidc-interceptors    oidc-admin-interceptors
-                                :oidc-ui-interceptors oidc-admin-ui-interceptors}))]
+             (add-admin-routes
+              {:lrs                   lrs
+               :exp                   jwt-exp
+               :leeway                jwt-lwy
+               :secret                private-key
+               :enable-admin-ui       enable-admin-ui
+               :enable-account-routes enable-local-admin
+               :oidc-interceptors     oidc-admin-interceptors
+               :oidc-ui-interceptors  oidc-admin-ui-interceptors}))]
     {:env                      :prod
      ::http/routes             routes
      ;; only serve assets if the admin ui is enabled


### PR DESCRIPTION
[SQL-144] When started with settings to provide admin OIDC access, the `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` flag determines whether or not local admin accounts will still be allowed to do things.

[SQL-144]: https://yet.atlassian.net/browse/SQL-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ