### PR TITLE
[SQL-146] HugSql update

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -32,7 +32,7 @@
   ;; - HugSql: Use custom version instead of the released version (0.5.1)
   com.stuartsierra/component               {:mvn/version "1.0.0"}
   com.github.seancorfield/next.jdbc        {:mvn/version "1.2.709"}
-  com.yetanalytics/hugsql                  {:mvn/version "0.6.0-SNAPSHOT"}
+  com.yetanalytics/hugsql                  {:mvn/version "0.6.1-SNAPSHOT"}
   com.layerware/hugsql-adapter-next-jdbc   {:mvn/version "0.5.1"}
   com.zaxxer/HikariCP                      {:mvn/version "5.0.0"
                                             :exclusions  [org.slf4j/slf4j-api]}

--- a/deps.edn
+++ b/deps.edn
@@ -32,7 +32,7 @@
   ;; - HugSql: Use custom version instead of the released version (0.5.1)
   com.stuartsierra/component               {:mvn/version "1.0.0"}
   com.github.seancorfield/next.jdbc        {:mvn/version "1.2.709"}
-  com.yetanalytics/hugsql                  {:mvn/version "0.6.1-SNAPSHOT"}
+  com.yetanalytics/hugsql                  {:mvn/version "0.6.1-YetAnalytics"}
   com.layerware/hugsql-adapter-next-jdbc   {:mvn/version "0.5.1"}
   com.zaxxer/HikariCP                      {:mvn/version "5.0.0"
                                             :exclusions  [org.slf4j/slf4j-api]}

--- a/src/db/h2/lrsql/h2/record.clj
+++ b/src/db/h2/lrsql/h2/record.clj
@@ -1,19 +1,19 @@
 (ns lrsql.h2.record
   (:require [com.stuartsierra.component :as cmp]
+            [hugsql.core :as hug]
             [lrsql.backend.data :as bd]
             [lrsql.backend.protocol :as bp]
-            [lrsql.init :refer [init-hugsql-adapter!]]
-            [lrsql.util :as u]))
+            [lrsql.init :refer [init-hugsql-adapter!]]))
 
 ;; Init HugSql functions
 
 (init-hugsql-adapter!)
 
-(u/def-hugsql-db-fns "lrsql/h2/sql/ddl.sql")
-(u/def-hugsql-db-fns "lrsql/h2/sql/insert.sql")
-(u/def-hugsql-db-fns "lrsql/h2/sql/query.sql")
-(u/def-hugsql-db-fns "lrsql/h2/sql/update.sql")
-(u/def-hugsql-db-fns "lrsql/h2/sql/delete.sql")
+(hug/def-db-fns "lrsql/h2/sql/ddl.sql")
+(hug/def-db-fns "lrsql/h2/sql/insert.sql")
+(hug/def-db-fns "lrsql/h2/sql/query.sql")
+(hug/def-db-fns "lrsql/h2/sql/update.sql")
+(hug/def-db-fns "lrsql/h2/sql/delete.sql")
 
  ;; Define record
 

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -1,21 +1,21 @@
 (ns lrsql.postgres.record
   (:require [com.stuartsierra.component :as cmp]
+            [hugsql.core :as hug]
             [lrsql.backend.data :as bd]
             [lrsql.backend.protocol :as bp]
             [lrsql.init :refer [init-hugsql-adapter!]]
             [lrsql.postgres.data :as pd]
-            [clojure.string :refer [includes?]]
-            [lrsql.util :as u]))
+            [clojure.string :refer [includes?]]))
 
 ;; Init HugSql functions
 
 (init-hugsql-adapter!)
 
-(u/def-hugsql-db-fns "lrsql/postgres/sql/ddl.sql")
-(u/def-hugsql-db-fns "lrsql/postgres/sql/insert.sql")
-(u/def-hugsql-db-fns "lrsql/postgres/sql/query.sql")
-(u/def-hugsql-db-fns "lrsql/postgres/sql/update.sql")
-(u/def-hugsql-db-fns "lrsql/postgres/sql/delete.sql")
+(hug/def-db-fns "lrsql/postgres/sql/ddl.sql")
+(hug/def-db-fns "lrsql/postgres/sql/insert.sql")
+(hug/def-db-fns "lrsql/postgres/sql/query.sql")
+(hug/def-db-fns "lrsql/postgres/sql/update.sql")
+(hug/def-db-fns "lrsql/postgres/sql/delete.sql")
 
 ;; Define record
 #_{:clj-kondo/ignore [:unresolved-symbol]} ; Shut up VSCode warnings

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -1,20 +1,20 @@
 (ns lrsql.sqlite.record
   (:require [com.stuartsierra.component :as cmp]
+            [hugsql.core :as hug]
             [lrsql.backend.protocol :as bp]
             [lrsql.backend.data :as bd]
             [lrsql.init :refer [init-hugsql-adapter!]]
-            [lrsql.sqlite.data :as sd]
-            [lrsql.util :as u]))
+            [lrsql.sqlite.data :as sd]))
 
 ;; Init HugSql functions
 
 (init-hugsql-adapter!)
 
-(u/def-hugsql-db-fns "lrsql/sqlite/sql/ddl.sql")
-(u/def-hugsql-db-fns "lrsql/sqlite/sql/insert.sql")
-(u/def-hugsql-db-fns "lrsql/sqlite/sql/query.sql")
-(u/def-hugsql-db-fns "lrsql/sqlite/sql/update.sql")
-(u/def-hugsql-db-fns "lrsql/sqlite/sql/delete.sql")
+(hug/def-db-fns "lrsql/sqlite/sql/ddl.sql")
+(hug/def-db-fns "lrsql/sqlite/sql/insert.sql")
+(hug/def-db-fns "lrsql/sqlite/sql/query.sql")
+(hug/def-db-fns "lrsql/sqlite/sql/update.sql")
+(hug/def-db-fns "lrsql/sqlite/sql/delete.sql")
 
 ;; Define record
 

--- a/src/main/lrsql/system/util.clj
+++ b/src/main/lrsql/system/util.clj
@@ -74,11 +74,10 @@
     ;; If JDBC URL is given directly, this overrides all
     db-jdbc-url
     ;; Construct a new JDBC URL from config vars
-    (cond-> {:dbtype db-type
-             :dbname db-name
-             :host   db-host
-             :port   db-port}
-      db-properties
-      (merge (parse-db-props db-properties))
-      true
-      jdbc-conn/jdbc-url)))
+    (jdbc-conn/jdbc-url
+     (cond-> {:dbtype db-type
+              :dbname db-name
+              :host   db-host
+              :port   db-port}
+       db-properties
+       (merge (parse-db-props db-properties))))))

--- a/src/main/lrsql/util.clj
+++ b/src/main/lrsql/util.clj
@@ -2,7 +2,6 @@
   (:require [clj-uuid]
             [java-time]
             [java-time.properties :as jt-props]
-            [hugsql.core :as hug]
             [clojure.spec.alpha :as s]
             [clojure.java.io    :as io]
             [cheshire.core      :as cjson]
@@ -18,23 +17,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Macros
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defn def-hugsql-db-fns
-  "A custom version of `hugsql.core/def-db-fns` that reads .sql files
-   during compilation (instead of during runtime as in the original macro)."
-  [file]
-  (hug/def-db-fns file {})
-  #_(let [parsed-defs# (hug/parsed-defs-from-file file)]
-    ;; Validate defs at compile time
-    (doseq [pdef parsed-defs#]
-      (hug/validate-parsed-def! pdef))
-    ;; Runtime actions
-    `(doseq [~'exp-pdef (map hug/expand-compile-frags ~parsed-defs#)]
-       (hug/compile-exprs ~'exp-pdef)
-       (hug/dispatch-on-pdef ~'exp-pdef
-                             {} ; options - empty map is the hugsql default
-                             ~hug/intern-db-fn
-                             ~hug/intern-sqlvec-fn))))
 
 (defmacro wrap-parse-fn
   "Wrap `(parse-fn s)` in an exception such that on parse failure, the

--- a/src/main/lrsql/util.clj
+++ b/src/main/lrsql/util.clj
@@ -19,11 +19,12 @@
 ;; Macros
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defmacro def-hugsql-db-fns
+(defn def-hugsql-db-fns
   "A custom version of `hugsql.core/def-db-fns` that reads .sql files
    during compilation (instead of during runtime as in the original macro)."
   [file]
-  (let [parsed-defs# (hug/parsed-defs-from-file file)]
+  (hug/def-db-fns file {})
+  #_(let [parsed-defs# (hug/parsed-defs-from-file file)]
     ;; Validate defs at compile time
     (doseq [pdef parsed-defs#]
       (hug/validate-parsed-def! pdef))


### PR DESCRIPTION
Update HugSql to v0.5.3 to take advantage of SQL file reads and function definitions now being evaluated at compile-time.