### PR TITLE
Update Postgres to address CVE

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -69,7 +69,7 @@
    :extra-deps  {org.xerial/sqlite-jdbc {:mvn/version "3.36.0"}}}
   :db-postgres
   {:extra-paths ["src/db/postgres"]
-   :extra-deps  {org.postgresql/postgresql {:mvn/version "42.2.23"}}}
+   :extra-deps  {org.postgresql/postgresql {:mvn/version "42.3.3"}}}
   :bench
   {:extra-paths ["src/bench" "dev-resources"]
    :extra-deps  {org.clojure/tools.cli          {:mvn/version "1.0.194"}
@@ -90,8 +90,8 @@
    :extra-deps  {;; DB deps
                  com.h2database/h2             {:mvn/version "2.1.210"}
                  org.xerial/sqlite-jdbc        {:mvn/version "3.36.0"}
-                 org.postgresql/postgresql     {:mvn/version "42.2.23"}
-                 org.testcontainers/postgresql {:mvn/version "1.16.0"}
+                 org.postgresql/postgresql     {:mvn/version "42.3.3"}
+                 org.testcontainers/postgresql {:mvn/version "1.16.3"}
                  ;; Other test deps
                  org.clojure/test.check {:mvn/version "1.0.0"}
                  babashka/babashka.curl {:mvn/version "0.0.3"}


### PR DESCRIPTION
- Update Postgres to v42.3.3 to address [CVE-2022-21724](https://nvd.nist.gov/vuln/detail/CVE-2022-21724).
- Update Testcontainers to v1.16.3 to match PG version.