### PR TITLE
LRS-68 simplified attachment rendering

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -46,7 +46,9 @@
   less-awful-ssl/less-awful-ssl            {:mvn/version "1.0.6"}
   ;; Yet Analytics deps
   com.yetanalytics/lrs
-  {:mvn/version "1.2.6"
+  {:git/url "https://github.com/yetanalytics/lrs"
+   :git/sha "1cc99c0c9659a29aca6453b1ee1365c29202cb75"
+   #_#_:mvn/version "1.2.6"
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript
                 com.yetanalytics/xapi-schema]}


### PR DESCRIPTION
[LRS-68] Targets a branch of `lrs` with a simplified mechanism for forming multipart attachment responses in sync lrs mode (which `lrsql` uses).

See https://github.com/yetanalytics/lrs/pull/78

[LRS-68]: https://yet.atlassian.net/browse/LRS-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ