### PR TITLE
LRS-72 lrs 1.2.10

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -46,7 +46,7 @@
   less-awful-ssl/less-awful-ssl            {:mvn/version "1.0.6"}
   ;; Yet Analytics deps
   com.yetanalytics/lrs
-  {:mvn/version "1.2.10-SNAPSHOT"
+  {:mvn/version "1.2.10"
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript
                 com.yetanalytics/xapi-schema]}

--- a/deps.edn
+++ b/deps.edn
@@ -46,7 +46,7 @@
   less-awful-ssl/less-awful-ssl            {:mvn/version "1.0.6"}
   ;; Yet Analytics deps
   com.yetanalytics/lrs
-  {:mvn/version "1.2.6"
+  {:mvn/version "1.2.10-SNAPSHOT"
    :exclusions [org.clojure/clojure
                 org.clojure/clojurescript
                 com.yetanalytics/xapi-schema]}

--- a/src/test/lrsql/lrs_test.clj
+++ b/src/test/lrsql/lrs_test.clj
@@ -420,22 +420,26 @@
     (testing "returns normalized attachments"
       (testing "(multiple)"
         (is (= {:statement-result {:statements [stmt-5 stmt-4] :more ""}
-                :attachments      [(update stmt-5-attach :content #(String. %))
-                                   (update stmt-4-attach :content #(String. %))]}
+                ;; Compare attachments as a set, their order is different on the
+                ;; postgres backend
+                :attachments      #{(update stmt-5-attach :content #(String. %))
+                                    (update stmt-4-attach :content #(String. %))}}
                (-> (get-ss lrs
                            auth-ident
                            {:attachments true}
                            #{})
-                   string-result-attachment-content))))
+                   string-result-attachment-content
+                   (update :attachments set)))))
       (testing "(single)"
         (is (= {:statement   stmt-5
-                :attachments [(update stmt-5-attach :content #(String. %))
-                              (update stmt-4-attach :content #(String. %))]}
+                :attachments #{(update stmt-5-attach :content #(String. %))
+                               (update stmt-4-attach :content #(String. %))}}
                (-> (get-ss lrs
                            auth-ident
                            {:statementId id-5 :attachments true}
                            #{})
-                   string-result-attachment-content)))))
+                   string-result-attachment-content
+                   (update :attachments set))))))
     (component/stop sys')
     (support/unstrument-lrsql)))
 

--- a/src/test/lrsql/lrs_test.clj
+++ b/src/test/lrsql/lrs_test.clj
@@ -47,6 +47,16 @@
         (update-in [:statement-result :statements]
                    (partial map remove-props)))))
 
+(defn- string-result-attachment-content
+  [get-ss-result]
+  (update get-ss-result
+          :attachments
+          (fn [atts]
+            (mapv
+             (fn [att]
+               (update att :content #(String. %)))
+             atts))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Statement Tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -162,16 +172,6 @@
    :contentType "text/plain"
    :length      33
    :sha2        "7063d0a4cfa93373753ad2f5a6ffcf684559fb1df3c2f0473a14ece7d4edb06a"})
-
-(defn- string-result-attachment-content
-  [get-ss-result]
-  (update get-ss-result
-          :attachments
-          (fn [atts]
-            (mapv
-             (fn [att]
-               (update att :content #(String. %)))
-             atts))))
 
 (deftest test-statement-fns
   (let [sys   (support/test-system)

--- a/src/test/lrsql/lrs_test.clj
+++ b/src/test/lrsql/lrs_test.clj
@@ -420,7 +420,7 @@
                               id-6]}
              (lrsp/-store-statements
               ;; stmt-5 references stmt-4-attach
-              ;; stmt-6 references stmt-4-attach AND stmt-5-attach (twice)
+              ;; stmt-6 references stmt-4-attach AND stmt-6-attach (twice)
               lrs auth-ident [stmt-4 stmt-5 stmt-6] [stmt-4-attach stmt-6-attach]))))
 
     (testing "returns normalized attachments"

--- a/src/test/lrsql/lrs_test.clj
+++ b/src/test/lrsql/lrs_test.clj
@@ -414,7 +414,7 @@
       (is (= {:statement-ids [id-4
                               id-5]}
              (lrsp/-store-statements
-              ;; stmt-5 references stmt-4-attach AND stmt-5-attach
+              ;; stmt-5 references stmt-4-attach AND stmt-5-attach (twice)
               lrs auth-ident [stmt-4 stmt-5] [stmt-4-attach stmt-5-attach]))))
 
     (testing "returns normalized attachments"


### PR DESCRIPTION
[LRS-72] Handle deduplicated attachments introduced in https://github.com/yetanalytics/lrs/pull/81

Additionally, deduplicates outbound attachments per guidance in the `lrs` [README](https://github.com/yetanalytics/lrs#get-statements).

[LRS-72]: https://yet.atlassian.net/browse/LRS-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ