### PR TITLE
Fix NVD warnings and update deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Test.java
 .clj-kondo/.cache/
 .calva/
 .lsp/
+.vscode/
 # Admin SPA
 lrs-admin-ui-*.zip
 /resources/public/admin/

--- a/.nvd/suppression.xml
+++ b/.nvd/suppression.xml
@@ -7,5 +7,12 @@
       <packageUrl regex="true">^pkg:maven/org\.clojure/core\.async@.*$</packageUrl>
       <cpe>cpe:/a:async_project:async</cpe>
    </suppress>
-
+   <suppress base="true">
+      <notes><![CDATA[
+      FP per issue #4555
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/com\.h2database/h2@.*$</packageUrl>
+      <cpe>cpe:/a:h2database:h2</cpe>
+      <vulnerabilityName>CVE-2018-14335</vulnerabilityName>
+   </suppress>
 </suppressions>

--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
   ;; - java-time: Updating to 0.3.3 causes dep clash with DATASIM
   camel-snake-kebab/camel-snake-kebab      {:mvn/version "0.4.2"}
   cheshire/cheshire
-  {:mvn/version "5.10.1"
+  {:mvn/version "5.11.0"
    :exclusions
    [com.fasterxml.jackson.core/jackson-core
     com.fasterxml.jackson.dataformat/jackson-dataformat-smile
@@ -64,7 +64,7 @@
  :aliases
  {:db-h2
   {:extra-paths ["src/db/h2"]
-   :extra-deps  {com.h2database/h2 {:mvn/version "2.1.210"}}}
+   :extra-deps  {com.h2database/h2 {:mvn/version "2.1.212"}}}
   :db-sqlite
   {:extra-paths ["src/db/sqlite"]
    :extra-deps  {org.xerial/sqlite-jdbc {:mvn/version "3.36.0"}}}
@@ -89,7 +89,7 @@
                  "src/test"
                  "dev-resources"]
    :extra-deps  {;; DB deps
-                 com.h2database/h2             {:mvn/version "2.1.210"}
+                 com.h2database/h2             {:mvn/version "2.1.212"}
                  org.xerial/sqlite-jdbc        {:mvn/version "3.36.0"}
                  org.postgresql/postgresql     {:mvn/version "42.3.3"}
                  org.testcontainers/postgresql {:mvn/version "1.16.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -121,7 +121,7 @@
   {:extra-deps  {com.github.seancorfield/depstar {:mvn/version "2.1.267"}}
    :extra-paths ["src/build"]}
   :nvd
-  {:replace-deps {nvd-clojure/nvd-clojure {:mvn/version "2.5.0"}}
+  {:replace-deps {nvd-clojure/nvd-clojure {:mvn/version "2.6.0"}}
    :ns-default   nvd.task}
   :doc
   {:replace-deps {com.yetanalytics/markdoc {:git/url "https://github.com/yetanalytics/markdoc"

--- a/deps.edn
+++ b/deps.edn
@@ -8,20 +8,7 @@
   ;; Util deps
   ;; - java-time: Updating to 0.3.3 causes dep clash with DATASIM
   camel-snake-kebab/camel-snake-kebab      {:mvn/version "0.4.2"}
-  cheshire/cheshire
-  {:mvn/version "5.11.0"
-   :exclusions
-   [com.fasterxml.jackson.core/jackson-core
-    com.fasterxml.jackson.dataformat/jackson-dataformat-smile
-    com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
-    com.fasterxml.jackson.core/jackson-databind]}
-  com.fasterxml.jackson.core/jackson-core  {:mvn/version "2.13.2"}
-  com.fasterxml.jackson.dataformat/jackson-dataformat-smile
-  {:mvn/version "2.13.2"}
-  com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
-  {:mvn/version "2.13.2"}
-  com.fasterxml.jackson.core/jackson-databind
-  {:mvn/version "2.13.2.1"}
+  cheshire/cheshire                        {:mvn/version "5.11.0"}
   clojure.java-time/clojure.java-time      {:mvn/version "0.3.2"}
   danlentz/clj-uuid                        {:mvn/version "0.1.9"}
   aero/aero                                {:mvn/version "1.1.6"}


### PR DESCRIPTION
- Add suppression to H2 false positive CVE ([CVE issue](https://github.com/h2database/h2database/issues/3175), [FP report](https://github.com/jeremylong/DependencyCheck/issues/4555))
- Update cheshire lib to 5.11.0 and remove manual exclusions + transitive deps