### PR TITLE
SQL-150 Overwrite Statement Authority

### DIFF
--- a/doc/authority.md
+++ b/doc/authority.md
@@ -2,7 +2,7 @@
 
 # Authority Configuration
 
-The SQL LRS allows for configuration of the Authority included in xAPI Statements that are written to the LRS.
+The SQL LRS allows for configuration of the Authority included in xAPI statements that are written to the LRS. This authority will overwrite any authority present on incoming statements.
 
 ### Configuring a custom Authority template
 

--- a/src/main/lrsql/util/statement.clj
+++ b/src/main/lrsql/util/statement.clj
@@ -47,12 +47,12 @@
       (vary-meta assoc :primary-key squuid)
       true
       (assoc-to-stmt "stored" squuid-ts-str)
+      true
+      (assoc-to-stmt "authority" authority)
       (not ?id)
       (assoc-to-stmt "id" (u/uuid->str squuid-base))
       (not ?timestamp)
       (assoc-to-stmt "timestamp" squuid-ts-str)
-      (not ?authority)
-      (assoc-to-stmt "authority" authority)
       (not ?version)
       (assoc-to-stmt "version" xapi-version))))
 

--- a/src/main/lrsql/util/statement.clj
+++ b/src/main/lrsql/util/statement.clj
@@ -11,10 +11,9 @@
 ;; TODO: Change for version 2.0.0
 (def xapi-version "1.0.0")
 
-;; NOTE: It is recommended that we override any pre-existing authorities
-;; in a statement, unless there's a high degree of trust. We assume such
-;; a degree of trust (e.g. if the LRSs are part of the same system), but
-;; we may need to address this in the future (e.g. set using env vars).
+;; NOTE: SQL LRS overwrites any pre-existing authority object in a statement, as
+;; suggested by the spec:
+;; https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#requirements-14
 
 (defn prepare-statement
   "Prepare `statement` for LRS storage by coll-ifying context activities

--- a/src/main/lrsql/util/statement.clj
+++ b/src/main/lrsql/util/statement.clj
@@ -23,7 +23,6 @@
   [authority statement]
   (let [{?id        "id"
          ?timestamp "timestamp"
-         ?authority "authority"
          ?version   "version"}
         statement
         {squuid      :squuid

--- a/src/test/lrsql/util/statement_test.clj
+++ b/src/test/lrsql/util/statement_test.clj
@@ -42,6 +42,22 @@
   {"id"         "http://www.example.com/tincan/activities/multipart"
    "objectType" "Activity"})
 
+(deftest prepare-statement-test
+  (let [lrs-authority     {"mbox"       "mailto:a@example.com"
+                           "objectType" "Agent"}
+        foreign-authority {"mbox"       "mailto:b@example.com"
+                           "objectType" "Agent"}]
+    (testing "overwrites authority"
+      (is (= lrs-authority
+             (-> (su/prepare-statement
+                  lrs-authority
+                  {"id"        sample-id
+                   "actor"     sample-group
+                   "verb"      sample-verb
+                   "object"    sample-activity
+                   "authority" foreign-authority})
+                 (get "authority")))))))
+
 (deftest statements-equal-test
   (testing "statement equality"
     (is (su/statement-equal?


### PR DESCRIPTION
[SQL-150] SQL LRS currently does not overwrite authority with the operator-defined authority, a bug. This PR forces overwrite of all incoming statement authority objects.

[SQL-150]: https://yet.atlassian.net/browse/SQL-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ