### PR TITLE
Address Postgres CVE

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -57,7 +57,7 @@
    :extra-deps  {org.xerial/sqlite-jdbc {:mvn/version "3.36.0"}}}
   :db-postgres
   {:extra-paths ["src/db/postgres"]
-   :extra-deps  {org.postgresql/postgresql {:mvn/version "42.3.3"}}}
+   :extra-deps  {org.postgresql/postgresql {:mvn/version "42.4.1"}}}
   :bench
   {:extra-paths ["src/bench" "dev-resources"]
    :extra-deps  {org.clojure/tools.cli          {:mvn/version "1.0.194"}
@@ -78,8 +78,8 @@
    :extra-deps  {;; DB deps
                  com.h2database/h2             {:mvn/version "2.1.212"}
                  org.xerial/sqlite-jdbc        {:mvn/version "3.36.0"}
-                 org.postgresql/postgresql     {:mvn/version "42.3.3"}
-                 org.testcontainers/postgresql {:mvn/version "1.16.3"}
+                 org.postgresql/postgresql     {:mvn/version "42.4.1"}
+                 org.testcontainers/postgresql {:mvn/version "1.17.3"}
                  ;; Other test deps
                  org.clojure/test.check {:mvn/version "1.0.0"}
                  babashka/babashka.curl {:mvn/version "0.0.3"}

--- a/src/test/lrsql/https_test.clj
+++ b/src/test/lrsql/https_test.clj
@@ -28,7 +28,7 @@
       (testing "is not over the HTTP port"
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"curl: \(35\).*wrong version number"
+             #"curl: \(35\).+"
              (curl/get "https://0.0.0.0:8080/health"
                        {:raw-args ["--insecure"]}))))
       (component/stop sys'))))


### PR DESCRIPTION
Update Postgres JDBC driver to 42.4.1 in order to address CVE-2022-31197. Also update Testcontainers to 1.17.3 and fix an unrelated failing test on HTTPS.