### PR TITLE
OIDC and Authority Template security and validation

### DIFF
--- a/src/main/lrsql/admin/interceptors/oidc.clj
+++ b/src/main/lrsql/admin/interceptors/oidc.clj
@@ -36,7 +36,7 @@
     (fn authorize-oidc-request [{admin-identity ::admin-identity
                                  :as            ctx}]
       (if admin-identity
-        (if (oidc/authorize-admin-action ctx admin-identity)
+        (if (oidc/authorize-admin-action? ctx admin-identity)
           ctx
           (assoc (chain/terminate ctx)
                  :response

--- a/src/main/lrsql/admin/interceptors/oidc.clj
+++ b/src/main/lrsql/admin/interceptors/oidc.clj
@@ -35,14 +35,13 @@
     :enter
     (fn authorize-oidc-request [{admin-identity ::admin-identity
                                  :as            ctx}]
-      (if admin-identity
-        (if (oidc/authorize-admin-action? ctx admin-identity)
-          ctx
-          (assoc (chain/terminate ctx)
-                 :response
-                 {:status 401
-                  :body   {:error "Unauthorized Admin Action!"}}))
-        ctx))}))
+      (if (or (nil? admin-identity)
+              (oidc/authorize-admin-action? ctx admin-identity))
+        ctx
+        (assoc (chain/terminate ctx)
+               :response
+               {:status 401
+                :body   {:error "Unauthorized Admin Action!"}})))}))
 
 (defn- disable-jwt-interceptors
   [{queue ::chain/queue :as ctx}]

--- a/src/main/lrsql/init/oidc.clj
+++ b/src/main/lrsql/init/oidc.clj
@@ -15,8 +15,12 @@
             [lrsql.spec.oidc :as oidc]
             [selmer.parser :as selm-parser]
             [selmer.util :as selm-u]
-            xapi-schema.spec)
+            [xapi-schema.spec :as xs])
   (:import [java.io File]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Configuration
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- select-config
   [config]
@@ -69,6 +73,10 @@
                 {:type        ::invalid-config
                  :oidc-config (select-config config)}
                 ex)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Interceptors
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (s/fdef resource-interceptors
   :args (s/cat :config (s/merge partial-config-spec
@@ -145,7 +153,9 @@
       (conj admin-oidc/require-oidc-identity))
     []))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Authority
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (s/fdef resolve-authority-claims
   :args (s/cat :claims ::oidc/claims)
@@ -167,6 +177,30 @@
                aud
                (first aud)))))
 
+(def default-authority-path
+  "lrsql/config/oidc_authority.json.template")
+
+(def sample-authority-fn-input
+  {:scope "openid all"
+   :iss   "http://example.com/realm"
+   :sub   "1234"
+   :lrsql/resolved-client-id "someapp"})
+
+(defn- valid-authority-fn?
+  [authority-fn]
+  (s/valid? ::xs/tlo-group ; 3-legged OAuth group
+            (authority-fn sample-authority-fn-input)))
+
+(defn- validate-authority-fn
+  ([authority-fn]
+   (validate-authority-fn authority-fn default-authority-path))
+  ([authority-fn template-path]
+   (if (valid-authority-fn? authority-fn)
+     authority-fn
+     (throw (ex-info "Authority template does not produce a valid xAPI Group for 3-legged OAuth"
+                     {:type          ::invalid-json
+                      :template-path template-path})))))
+
 (s/fdef make-authority-fn
   :args (s/cat :template-path (s/nilable string?)
                :threshold (s/? pos-int?))
@@ -176,27 +210,37 @@
 
 (def default-authority-fn
   "The default precompiled function to render authority"
-  (-> "lrsql/config/oidc_authority.json.template"
+  (-> default-authority-path
       io/resource
       selm-parser/parse*
-      authority/make-authority-fn*))
+      authority/make-authority-fn*
+      ;; Should always be valid but we sanity check anyways (e.g. if we change
+      ;; the template during dev).
+      validate-authority-fn))
 
 (defn make-authority-fn
   "Like authority/make-authority-fn but produces a function expecting OIDC
   claims."
-  [template-path & [threshold]]
-  (let [^File f
-        (io/file template-path)
-        authority-fn
-        (if (and f (.exists f))
-          ;; Override template supplied - use that
-          (let [template (selm-parser/parse* f)]
-            (authority/make-authority-fn* template))
-          ;; Override template not supplied - fall back to default
-          default-authority-fn)]
-    (mem/lru (comp authority-fn
-                   resolve-authority-claims)
-             :lru/threshold (or threshold 512))))
+  ([template-path]
+   (make-authority-fn template-path 512))
+  ([template-path threshold]
+   (let [^File f
+         (io/file template-path)
+         authority-fn
+         (if (and f (.exists f))
+           ;; Override template supplied - use that
+           (-> f
+               selm-parser/parse*
+               authority/make-authority-fn*
+               validate-authority-fn)
+           ;; Override template not supplied - fall back to default
+           default-authority-fn)]
+     (mem/lru (comp authority-fn resolve-authority-claims)
+              :lru/threshold threshold))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Client
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def default-client-template
   (-> "lrsql/config/oidc_client.json.template"
@@ -251,6 +295,8 @@
       (get-client-template oidc-client-template)
       config))))
 
+;; Client-side Interceptors
+
 (s/fdef admin-ui-interceptors
   :args (s/cat :webserver-config ::config/webserver
                :lrs-config       ::config/lrs)
@@ -273,6 +319,10 @@
                                   :lrs       lrs-config})
        :oidc-enable-local-admin oidc-enable-local-admin})]
     []))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Putting it all together
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (s/def ::resource-interceptors
   (s/every i/interceptor?))

--- a/src/main/lrsql/util/oidc.clj
+++ b/src/main/lrsql/util/oidc.clj
@@ -159,18 +159,18 @@
         ;; no valid scopes, can't do anything
         ::unauthorized))))
 
-(s/fdef authorize-admin-action
+(s/fdef authorize-admin-action?
   :args (s/cat :ctx           (s/keys :req-un [::auth/request])
                :auth-identity (s/keys :req-un [::scopes]))
-  :ret (s/keys :req-un [::auth/result]))
+  :ret boolean?)
 
-(defn authorize-admin-action
-  "Given a pedestal context and an OIDC admin auth identity, authorize or deny."
+(defn authorize-admin-action?
+  "Given a pedestal context and an OIDC admin auth identity, return `true`
+   if the action is authorized (i.e. the auth scopes include `:scope/admin`),
+   `false` if it's denied."
   [{{:keys [path-info]} :request
     :as _ctx}
    {:keys [scopes]
     :as _auth-identity}]
-  {:result
-   (boolean
-    (and (cs/starts-with? path-info "/admin")
-         (contains? scopes :scope/admin)))})
+  (boolean (and (cs/starts-with? path-info "/admin")
+                (contains? scopes :scope/admin))))

--- a/src/test/lrsql/util/oidc_test.clj
+++ b/src/test/lrsql/util/oidc_test.clj
@@ -3,7 +3,7 @@
             [lrsql.util.oidc :as oidc :refer [parse-scope-claim
                                               token-auth-identity
                                               token-auth-admin-identity
-                                              authorize-admin-action]]
+                                              authorize-admin-action?]]
             [lrsql.init.oidc :refer [make-authority-fn]]
             [lrsql.test-support :refer [check-validate instrument-lrsql]]))
 
@@ -112,10 +112,10 @@
     (are [expected input]
          (= expected
             (let [{:keys [request-method path-info scopes]} input]
-              (:result (authorize-admin-action
-                        {:request {:request-method request-method
-                                   :path-info path-info}}
-                        {:scopes scopes}))))
+              (authorize-admin-action?
+               {:request {:request-method request-method
+                          :path-info path-info}}
+               {:scopes scopes})))
       ;; Admin Scope
       ;; Currently one for all admin requests
       true {:request-method :get
@@ -125,4 +125,4 @@
              :path-info      "/admin/account"
              :scopes         #{}}))
   (testing "authorize-admin-action gentest"
-    (is (nil? (check-validate `authorize-admin-action)))))
+    (is (nil? (check-validate `authorize-admin-action?)))))


### PR DESCRIPTION
- Add validation to default non-OIDC authority template and all OIDC authority templates
  - OIDC templates must conform to 3-legged OAuth xAPI Groups
- Fix bug/security hole in `authorize-oidc-request` interceptor where `authorize-admin-action`'s result is always interpreted as `true`.