### PR TITLE
OIDC security fix

### DIFF
--- a/src/main/lrsql/admin/interceptors/oidc.clj
+++ b/src/main/lrsql/admin/interceptors/oidc.clj
@@ -36,7 +36,7 @@
     (fn authorize-oidc-request [{admin-identity ::admin-identity
                                  :as            ctx}]
       (if admin-identity
-        (if (oidc/authorize-admin-action ctx admin-identity)
+        (if (oidc/authorize-admin-action? ctx admin-identity)
           ctx
           (assoc (chain/terminate ctx)
                  :response

--- a/src/main/lrsql/admin/interceptors/oidc.clj
+++ b/src/main/lrsql/admin/interceptors/oidc.clj
@@ -35,14 +35,13 @@
     :enter
     (fn authorize-oidc-request [{admin-identity ::admin-identity
                                  :as            ctx}]
-      (if admin-identity
-        (if (oidc/authorize-admin-action? ctx admin-identity)
-          ctx
-          (assoc (chain/terminate ctx)
-                 :response
-                 {:status 401
-                  :body   {:error "Unauthorized Admin Action!"}}))
-        ctx))}))
+      (if (or (nil? admin-identity)
+              (oidc/authorize-admin-action? ctx admin-identity))
+        ctx
+        (assoc (chain/terminate ctx)
+               :response
+               {:status 401
+                :body   {:error "Unauthorized Admin Action!"}})))}))
 
 (defn- disable-jwt-interceptors
   [{queue ::chain/queue :as ctx}]

--- a/src/main/lrsql/util/oidc.clj
+++ b/src/main/lrsql/util/oidc.clj
@@ -159,18 +159,18 @@
         ;; no valid scopes, can't do anything
         ::unauthorized))))
 
-(s/fdef authorize-admin-action
+(s/fdef authorize-admin-action?
   :args (s/cat :ctx           (s/keys :req-un [::auth/request])
                :auth-identity (s/keys :req-un [::scopes]))
-  :ret (s/keys :req-un [::auth/result]))
+  :ret boolean?)
 
-(defn authorize-admin-action
-  "Given a pedestal context and an OIDC admin auth identity, authorize or deny."
+(defn authorize-admin-action?
+  "Given a pedestal context and an OIDC admin auth identity, return `true`
+   if the action is authorized (i.e. the auth scopes include `:scope/admin`),
+   `false` if it's denied."
   [{{:keys [path-info]} :request
     :as _ctx}
    {:keys [scopes]
     :as _auth-identity}]
-  {:result
-   (boolean
-    (and (cs/starts-with? path-info "/admin")
-         (contains? scopes :scope/admin)))})
+  (boolean (and (cs/starts-with? path-info "/admin")
+                (contains? scopes :scope/admin))))

--- a/src/test/lrsql/util/oidc_test.clj
+++ b/src/test/lrsql/util/oidc_test.clj
@@ -3,7 +3,7 @@
             [lrsql.util.oidc :as oidc :refer [parse-scope-claim
                                               token-auth-identity
                                               token-auth-admin-identity
-                                              authorize-admin-action]]
+                                              authorize-admin-action?]]
             [lrsql.init.oidc :refer [make-authority-fn]]
             [lrsql.test-support :refer [check-validate instrument-lrsql]]))
 
@@ -112,10 +112,10 @@
     (are [expected input]
          (= expected
             (let [{:keys [request-method path-info scopes]} input]
-              (:result (authorize-admin-action
-                        {:request {:request-method request-method
-                                   :path-info path-info}}
-                        {:scopes scopes}))))
+              (authorize-admin-action?
+               {:request {:request-method request-method
+                          :path-info path-info}}
+               {:scopes scopes})))
       ;; Admin Scope
       ;; Currently one for all admin requests
       true {:request-method :get
@@ -125,4 +125,4 @@
              :path-info      "/admin/account"
              :scopes         #{}}))
   (testing "authorize-admin-action gentest"
-    (is (nil? (check-validate `authorize-admin-action)))))
+    (is (nil? (check-validate `authorize-admin-action?)))))


### PR DESCRIPTION
Fix bug/security hole in `authorize-oidc-request` interceptor where `authorize-admin-action`'s result is always interpreted as true.