### PR TITLE
latest lrs lib to clear CVE-2022-41719

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -48,7 +48,7 @@
   less-awful-ssl/less-awful-ssl            {:mvn/version "1.0.6"}
   ;; Yet Analytics deps
   com.yetanalytics/lrs
-  {:mvn/version "1.2.12"
+  {:mvn/version "1.2.14"
    :exclusions  [org.clojure/clojure
                  org.clojure/clojurescript
                  com.yetanalytics/xapi-schema]}


### PR DESCRIPTION
yetanalytics/lrs `1.2.14`