### PR TITLE
CVE-2022-41946 Redux

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -72,7 +72,7 @@
    :extra-deps  {org.xerial/sqlite-jdbc {:mvn/version "3.36.0"}}}
   :db-postgres
   {:extra-paths ["src/db/postgres"]
-   :extra-deps  {org.postgresql/postgresql {:mvn/version "42.4.3"}}}
+   :extra-deps  {org.postgresql/postgresql {:mvn/version "42.5.1"}}}
   :bench
   {:extra-paths ["src/bench" "dev-resources"]
    :extra-deps  {org.clojure/tools.cli          {:mvn/version "1.0.194"}
@@ -93,7 +93,7 @@
    :extra-deps  {;; DB deps
                  com.h2database/h2             {:mvn/version "2.1.212"}
                  org.xerial/sqlite-jdbc        {:mvn/version "3.36.0"}
-                 org.postgresql/postgresql     {:mvn/version "42.4.3"}
+                 org.postgresql/postgresql     {:mvn/version "42.5.1"}
                  org.testcontainers/postgresql {:mvn/version "1.17.3"}
                  ;; Other test deps
                  org.clojure/test.check        {:mvn/version "1.0.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -72,7 +72,7 @@
    :extra-deps  {org.xerial/sqlite-jdbc {:mvn/version "3.36.0"}}}
   :db-postgres
   {:extra-paths ["src/db/postgres"]
-   :extra-deps  {org.postgresql/postgresql {:mvn/version "42.4.1"}}}
+   :extra-deps  {org.postgresql/postgresql {:mvn/version "42.4.3"}}}
   :bench
   {:extra-paths ["src/bench" "dev-resources"]
    :extra-deps  {org.clojure/tools.cli          {:mvn/version "1.0.194"}
@@ -93,7 +93,7 @@
    :extra-deps  {;; DB deps
                  com.h2database/h2             {:mvn/version "2.1.212"}
                  org.xerial/sqlite-jdbc        {:mvn/version "3.36.0"}
-                 org.postgresql/postgresql     {:mvn/version "42.4.1"}
+                 org.postgresql/postgresql     {:mvn/version "42.4.3"}
                  org.testcontainers/postgresql {:mvn/version "1.17.3"}
                  ;; Other test deps
                  org.clojure/test.check        {:mvn/version "1.0.0"}


### PR DESCRIPTION
CVE-2022-41946 is back, baybee! Looks like `org.postgresql/postgresql@42.4.3` has been added to the vuln range, see [this change](https://nvd.nist.gov/vuln/detail/CVE-2022-41946/change-record?changeRecordedOn=11/28/2022T14:43:46.820-0500)