### PR TITLE
Force Locale on `lrsql.service`

### DIFF
--- a/dev-resources/template/2_lrs.yml
+++ b/dev-resources/template/2_lrs.yml
@@ -408,6 +408,8 @@ Resources:
                 Description=SQL LRS Service
                 [Service]
                 User=root
+                # Required to prevent arbitrary encoding settings
+                Environment="LC_ALL=en_US.UTF-8"
                 # The configuration file application.properties should be here:
                 WorkingDirectory=/opt/lrsql
                 ExecStart=/opt/lrsql/bin/run_postgres.sh


### PR DESCRIPTION
Prevent untold ruin by forcing locale to `en_US.UTF-8` for the service. This prevents the application from choosing an incorrect encoding for PG json, which may suggest other code changes to SQL LRS to remove this unpredictable behavior.