### PR TITLE
SQL-160 correct run script java arg syntax

### DIFF
--- a/bin/run_h2.sh
+++ b/bin/run_h2.sh
@@ -2,4 +2,4 @@
 
 MACHINE=`bin/machine.sh`
 
-runtimes/$MACHINE/bin/java -J-Dfile.encoding=UTF-8 -server -cp lrsql.jar lrsql.h2.main $@
+runtimes/$MACHINE/bin/java -Dfile.encoding=UTF-8 -server -cp lrsql.jar lrsql.h2.main $@

--- a/bin/run_h2_persistent.sh
+++ b/bin/run_h2_persistent.sh
@@ -2,4 +2,4 @@
 
 MACHINE=`bin/machine.sh`
 
-runtimes/$MACHINE/bin/java -J-Dfile.encoding=UTF-8 -server -cp lrsql.jar lrsql.h2.main --persistent true $@
+runtimes/$MACHINE/bin/java -Dfile.encoding=UTF-8 -server -cp lrsql.jar lrsql.h2.main --persistent true $@

--- a/bin/run_postgres.sh
+++ b/bin/run_postgres.sh
@@ -2,4 +2,4 @@
 
 MACHINE=`bin/machine.sh`
 
-runtimes/$MACHINE/bin/java -J-Dfile.encoding=UTF-8 -server -cp lrsql.jar lrsql.postgres.main $@
+runtimes/$MACHINE/bin/java -Dfile.encoding=UTF-8 -server -cp lrsql.jar lrsql.postgres.main $@

--- a/bin/run_sqlite.sh
+++ b/bin/run_sqlite.sh
@@ -2,4 +2,4 @@
 
 MACHINE=`bin/machine.sh`
 
-runtimes/$MACHINE/bin/java -J-Dfile.encoding=UTF-8 -server -cp lrsql.jar lrsql.sqlite.main $@
+runtimes/$MACHINE/bin/java -Dfile.encoding=UTF-8 -server -cp lrsql.jar lrsql.sqlite.main $@


### PR DESCRIPTION
Run script java args incorrectly carry the `-J` wrapping from the Clojure CLI. Correct this so run scripts (and thus docker) work.
See https://github.com/yetanalytics/lrsql/issues/263