### PR TITLE
CORS Configuration Support

### DIFF
--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -115,6 +115,8 @@ You may have noted that some options are not available:
 | `LRSQL_HTTP_HOST` | `httpHost` | The host that the webserver will run on. | `0.0.0.0` |
 | `LRSQL_HTTP_PORT` | `httpPort` | The HTTP port that the webserver will be open on. | `8080` |
 | `LRSQL_SSL_PORT` | `sslPort` | The HTTPS port that the webserver will be open on. | `8443` |
+| `LRSQL_ALLOW_ALL_ORIGINS` | `allowAllOrigins` | Determines whether to enable CORS. When false, it will not allow all origins, it will only allow either `LRSQL_HTTP_HOST` (for both HTTPS and HTTP ports) or if `LRSQL_ALLOWED_ORIGINS` is set that will override. | `false` |
+| `LRSQL_ALLOWED_ORIGINS` | `allowedOrigins` | This is a list of allowed origins which overrides the defaults. As an ENV it should be written as a comma separated list with no spaces. In JSON config it can be written directly as an array, e.g. `["http://myhost:myport", "https://anotherhost"]` | Not Set |
 | `LRSQL_URL_PREFIX` | `urlPrefix` | The prefix of the webserver URL path, e.g. the prefix in `http://0.0.0.0:8080/xapi` is `/xapi`. Used when constructing the `more` value for multi-statement queries. | `/xapi` |
 | `LRSQL_ENABLE_ADMIN_UI` | `enableAdminUi` | Whether or not to serve the administrative UI at `/admin` | `true` |
 | `LRSQL_ENABLE_STMT_HTML` | `enableStmtHtml` | Whether or not HTML data is returned in the LRS HTTP response. If `false` disables HTML rendering even if `LRSQL_ENABLE_ADMIN_UI` is `true`. In that case the UI will not display the Statement Browser feature. | `true` |

--- a/resources/lrsql/config/prod/default/webserver.edn
+++ b/resources/lrsql/config/prod/default/webserver.edn
@@ -10,6 +10,8 @@
  :enable-http2              #boolean #or [#env LRSQL_ENABLE_HTTP2 true]
  :http-host                 #or [#env LRSQL_HTTP_HOST "0.0.0.0"]
  :http-port                 #long #or [#env LRSQL_HTTP_PORT 8080]
+ :allow-all-origins         #boolean #or [#env LRSQL_ALLOW_ALL_ORIGINS false]
+ :allowed-origins           #array #or [#env LRSQL_ALLOWED_ORIGINS nil]
  :ssl-port                  #long #or [#env LRSQL_SSL_PORT 8443]
  :url-prefix                #or [#env LRSQL_URL_PREFIX "/xapi"]
  :enable-admin-ui           #boolean #or [#env LRSQL_ENABLE_ADMIN_UI true]

--- a/resources/lrsql/config/test/default/webserver.edn
+++ b/resources/lrsql/config/test/default/webserver.edn
@@ -9,6 +9,8 @@
  :ssl-port                  8443
  :http-host                 "0.0.0.0"
  :http-port                 8080
+ :allow-all-origins         false
+ :allowed-origins           nil
  :url-prefix                "/xapi"
  :enable-admin-ui           true
  :enable-stmt-html          true

--- a/src/main/lrsql/init/config.clj
+++ b/src/main/lrsql/init/config.clj
@@ -38,7 +38,7 @@
   (io/resource (str config-path-prefix include)))
 
 (defmethod aero/reader 'array
-  [{:keys [profile] :as opts} tag value]
+  [_ _ value]
   (if (empty? value)
     nil
     (split value #",")))

--- a/src/main/lrsql/init/config.clj
+++ b/src/main/lrsql/init/config.clj
@@ -2,6 +2,7 @@
   (:require [cheshire.core :as json]
             [clojure.java.io :as io]
             [aero.core :as aero]
+            [clojure.string :refer [split]]
             [camel-snake-kebab.core :as csk])
   (:import [java.io File]))
 
@@ -35,6 +36,12 @@
 (defn- resolver
   [_ include]
   (io/resource (str config-path-prefix include)))
+
+(defmethod aero/reader 'array
+  [{:keys [profile] :as opts} tag value]
+  (if (empty? value)
+    nil
+    (split value #",")))
 
 (defn read-config*
   "Read `config.edn` with the given value of `profile`. Valid

--- a/src/main/lrsql/spec/config.clj
+++ b/src/main/lrsql/spec/config.clj
@@ -143,6 +143,9 @@
 (s/def ::http-port nat-int?)
 (s/def ::ssl-port nat-int?)
 
+(s/def ::allow-all-origins boolean?)
+(s/def ::allowed-origins (s/nilable (s/coll-of string?)))
+
 (s/def ::jwt-exp-time pos-int?)
 (s/def ::jwt-exp-leeway nat-int?)
 
@@ -170,6 +173,8 @@
                    ::ssl-port
                    ::enable-http
                    ::enable-http2
+                   ::allow-all-origins
+                   ::allowed-origins
                    ::url-prefix
                    ::key-alias
                    ::key-password

--- a/src/main/lrsql/system.clj
+++ b/src/main/lrsql/system.clj
@@ -9,9 +9,13 @@
 (defn system
   "Return a lrsql system with configuration specified by the `profile`
    keyword."
-  [backend profile]
-  (let [config
+  [backend profile & {:keys [conf-overrides]}]
+  (let [profile-config
         (read-config profile)
+        config (reduce (fn [agg [key val]]
+                         (assoc-in agg key val))
+                       profile-config
+                       (seq conf-overrides))
         initial-sys ; init without configuration
         (component/system-map
          ;; Logger is required by backend so it happens first

--- a/src/main/lrsql/system.clj
+++ b/src/main/lrsql/system.clj
@@ -8,7 +8,8 @@
 
 (defn system
   "Return a lrsql system with configuration specified by the `profile`
-   keyword."
+   keyword. Optional kwarg ``conf-overrides`` takes a map where the key is a vec
+   of a key location in config map, and the value is an override."
   [backend profile & {:keys [conf-overrides]}]
   (let [profile-config
         (read-config profile)

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -76,11 +76,10 @@
      {:creds           true
       :allowed-origins (fn [origin]
                          (or allow-all-origins
-                             (let [allowed-list
+                             (some #(= origin %)
                                    (or allowed-origins
                                        [(format "http://%s:%s" http-host http-port)
-                                        (format "https://%s:%s" http-host ssl-port)])]
-                               (some #(= origin %) allowed-list))))}
+                                        (format "https://%s:%s" http-host ssl-port)]))))}
      ::http/container-options
      {:h2c?         (and enable-http enable-http2)
       :h2?          enable-http2

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -61,15 +61,14 @@
                :enable-account-routes enable-local-admin
                :oidc-interceptors     oidc-admin-interceptors
                :oidc-ui-interceptors  oidc-admin-ui-interceptors}))
-        ;; Build allowed-origins list
+        ;; Build allowed-origins list. Add without ports as well for
+        ;; default ports
         allowed-list
         (or allowed-origins
-            [(if (= http-port 80)
-               (format "http://%s" http-host)
-               (format "http://%s:%s" http-host http-port))
-             (if (= ssl-port 443)
-               (format "https://%s" http-host)
-               (format "https://%s:%s" http-host ssl-port))])]
+            (cond-> [(format "http://%s:%s" http-host http-port)
+                     (format "https://%s:%s" http-host ssl-port)]
+              (= http-port 80) (conj (format "http://%s" http-host))
+              (= ssl-port 443) (conj (format "https://%s" http-host))))]
     {:env                      :prod
      ::http/routes             routes
      ;; only serve assets if the admin ui is enabled

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -5,6 +5,7 @@
             [io.pedestal.http :as http]
             [com.yetanalytics.lrs.pedestal.routes :refer [build]]
             [com.yetanalytics.lrs.pedestal.interceptor :as i]
+            [clojure.core :refer [format]]
             [lrsql.admin.routes :refer [add-admin-routes]]
             [lrsql.init.oidc :as oidc]
             [lrsql.spec.config :as cs]
@@ -24,7 +25,9 @@
                 url-prefix
                 key-password
                 enable-admin-ui
-                enable-stmt-html]
+                enable-stmt-html
+                allow-all-origins
+                allowed-origins]
          jwt-exp :jwt-exp-time
          jwt-lwy :jwt-exp-leeway}
         config
@@ -71,7 +74,13 @@
      ::i/enable-statement-html enable-stmt-html
      ::http/allowed-origins
      {:creds           true
-      :allowed-origins (constantly true)}
+      :allowed-origins (fn [origin]
+                         (or allow-all-origins
+                             (let [allowed-list
+                                   (or allowed-origins
+                                       [(format "http://%s:%s" http-host http-port)
+                                        (format "https://%s:%s" http-host ssl-port)])]
+                               (some #(= origin %) allowed-list))))}
      ::http/container-options
      {:h2c?         (and enable-http enable-http2)
       :h2?          enable-http2

--- a/src/test/lrsql/admin/cors_test.clj
+++ b/src/test/lrsql/admin/cors_test.clj
@@ -1,0 +1,120 @@
+(ns lrsql.admin.cors-test
+  "Test for admin-related interceptors + routes
+   (as opposed to just the protocol)."
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [babashka.curl :as curl]
+            [com.stuartsierra.component :as component]
+            [lrsql.test-support :as support]
+            [lrsql.util :as u]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Init
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(support/instrument-lrsql)
+
+(use-fixtures :each support/fresh-db-fixture)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test content
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def content-type {"Content-Type" "application/json"})
+
+(defn- login-account
+  [headers body]
+  (curl/post "http://0.0.0.0:8080/admin/account/login"
+             {:headers headers
+              :body    body}))
+
+(defn- create-account
+  [headers body]
+  (curl/post "http://0.0.0.0:8080/admin/account/create"
+             {:headers headers
+              :body    body}))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmacro is-err-code
+  "Test that `expr` throws an exception with the correct HTTP error `code`."
+  [expr code]
+  `(try
+     (do ~expr (is false))
+     (catch clojure.lang.ExceptionInfo e#
+       (is (= ~code (-> e# ex-data :status))))))
+
+(deftest cors-default-test
+  (let [sys  (support/test-system)
+        sys' (component/start sys)
+        ;; Seed information
+        {:keys [api-key-default
+                api-secret-default]} (get-in sys' [:lrs :config])
+        seed-body (u/write-json-str
+                   {"username" api-key-default
+                    "password" api-secret-default})
+        seed-jwt  (-> (login-account content-type seed-body)
+                      :body
+                      u/parse-json
+                      (get "json-web-token"))
+        seed-auth {"Authorization" (str "Bearer " seed-jwt)}
+        ;; New data information
+        headers  (merge content-type seed-auth)
+        req-body (u/write-json-str {"username" "newUsername"
+                                    "password" "newPass"})]
+    (testing "seed jwt retrieved"
+      ;; Sanity check that the test credentials are in place
+      (is (some? seed-jwt)))
+    (testing "create account with default CORS check failure"
+      (let [bad-cors-headers
+            (merge headers {"Origin" "http://www.yetanalytics.com"})]
+        (is-err-code (create-account bad-cors-headers req-body) 403)))
+    (testing "create account with default CORS check success"
+      (let [good-cors-headers
+            (merge headers {"Origin" "http://0.0.0.0:8080"})
+            {:keys [status body] :as response}
+            (create-account good-cors-headers req-body)
+            edn-body       (u/parse-json body)]
+        (is (= 200 status))
+        (is (try (u/str->uuid (get edn-body "account-id"))
+                 (catch Exception _ false)))))
+    (component/stop sys')))
+
+(deftest cors-custom-test
+  (let [sys  (support/test-system :conf-overrides
+                                  {[:webserver :allowed-origins]
+                                   ["http://www.yetanalytics.com"]})
+        sys' (component/start sys)
+        ;; Seed information
+        {:keys [api-key-default
+                api-secret-default]} (get-in sys' [:lrs :config])
+        seed-body (u/write-json-str
+                   {"username" api-key-default
+                    "password" api-secret-default})
+        seed-jwt  (-> (login-account content-type seed-body)
+                      :body
+                      u/parse-json
+                      (get "json-web-token"))
+        seed-auth {"Authorization" (str "Bearer " seed-jwt)}
+        ;; New data information
+        headers  (merge content-type seed-auth)
+        req-body (u/write-json-str {"username" "newUsername"
+                                    "password" "newPass"})]
+    (testing "seed jwt retrieved"
+      ;; Sanity check that the test credentials are in place
+      (is (some? seed-jwt)))
+    (testing "create account with custom CORS check failure"
+      (let [bad-cors-headers
+            (merge headers {"Origin" "http://0.0.0.0:8080"})]
+        (is-err-code (create-account bad-cors-headers req-body) 403)))
+    (testing "create account with custom CORS check success"
+      (let [good-cors-headers
+            (merge headers {"Origin" "http://www.yetanalytics.com"})
+            {:keys [status body] :as response}
+            (create-account good-cors-headers req-body)
+            edn-body       (u/parse-json body)]
+        (is (= 200 status))
+        (is (try (u/str->uuid (get edn-body "account-id"))
+                 (catch Exception _ false)))))
+    (component/stop sys')))

--- a/src/test/lrsql/admin/cors_test.clj
+++ b/src/test/lrsql/admin/cors_test.clj
@@ -73,7 +73,7 @@
     (testing "create account with default CORS check success"
       (let [good-cors-headers
             (merge headers {"Origin" "http://0.0.0.0:8080"})
-            {:keys [status body] :as response}
+            {:keys [status body]}
             (create-account good-cors-headers req-body)
             edn-body       (u/parse-json body)]
         (is (= 200 status))
@@ -111,7 +111,7 @@
     (testing "create account with custom CORS check success"
       (let [good-cors-headers
             (merge headers {"Origin" "http://www.yetanalytics.com"})
-            {:keys [status body] :as response}
+            {:keys [status body]}
             (create-account good-cors-headers req-body)
             edn-body       (u/parse-json body)]
         (is (= 200 status))

--- a/src/test/lrsql/test_support.clj
+++ b/src/test/lrsql/test_support.clj
@@ -58,8 +58,10 @@
 
 ;; Returns `{}` as default - need to be used in a fixture
 (defn test-system
-  "Create a lrsql system specifically for tests"
-  []
+  "Create a lrsql system specifically for tests. Optional kwarg `conf-overrides`
+   takes a map where the key is a vec of a key location in config map, and the
+   value is an override."
+  [& {:keys [_]}]
   {})
 
 (defn fresh-h2-fixture

--- a/src/test/lrsql/test_support.clj
+++ b/src/test/lrsql/test_support.clj
@@ -69,8 +69,9 @@
                    (assoc-in [:connection :database :db-name] id-str))]
     (with-redefs
      [read-config (constantly h2-cfg)
-      test-system (fn []
-                    (system/system (hr/map->H2Backend {}) :test-h2-mem))]
+      test-system (fn [& {:keys [conf-overrides]}]
+                    (system/system (hr/map->H2Backend {}) :test-h2-mem
+                                   :conf-overrides conf-overrides))]
       (f))))
 
 ;; `:memory:` is a special db-name value that creates an in-memory SQLite DB.
@@ -81,8 +82,9 @@
                    (assoc-in [:connection :database :db-name] ":memory:"))]
     (with-redefs
      [read-config (constantly sl-cfg)
-      test-system (fn []
-                    (system/system (sr/map->SQLiteBackend {}) :test-sqlite))]
+      test-system (fn [& {:keys [conf-overrides]}]
+                    (system/system (sr/map->SQLiteBackend {}) :test-sqlite
+                                   :conf-overrides conf-overrides))]
       (f))))
 
 ;; Need to manually override db-type because next.jdbc does not support
@@ -108,9 +110,10 @@
                                             test-db-version)))))]
     (with-redefs
      [read-config (constantly pg-cfg)
-      test-system (fn []
+      test-system (fn [& {:keys [conf-overrides]}]
                     (system/system (pr/map->PostgresBackend {})
-                                   :test-postgres))]
+                                   :test-postgres
+                                   :conf-overrides conf-overrides))]
       (f))))
 
 (def fresh-db-fixture fresh-h2-fixture)


### PR DESCRIPTION
This enables CORS Support to be configurable. There are three possible running modes, defined by 2 variables:

- By default, with no additional settings, the allowed origins will be restricted to the `LRSQL_HTTP_HOST` setting, which is by default `0.0.0.0:[8080/8443]`
- If you set `LRSQL_ALLOW_ALL_ORIGINS` to `true`, it will ignore and just approve everything (legacy mode)
- If you explicitly set origins using `LRSQL_ALLOWED_ORIGINS` it will restrict to those. in ENV thats a comma-separated list, in JSON its an array.