### PR TITLE
SQL-163 localhost-friendly CORS defaults

### DIFF
--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -65,7 +65,9 @@
         ;; default ports
         allowed-list
         (or allowed-origins
-            (cond-> [(format "http://%s:%s" http-host http-port)
+            (cond-> [(format "http://localhost:%s" http-port)
+                     (format "https://localhost:%s" ssl-port)
+                     (format "http://%s:%s" http-host http-port)
                      (format "https://%s:%s" http-host ssl-port)]
               (= http-port 80) (conj (format "http://%s" http-host))
               (= ssl-port 443) (conj (format "https://%s" http-host))))]

--- a/src/test/lrsql/admin/cors_test.clj
+++ b/src/test/lrsql/admin/cors_test.clj
@@ -23,13 +23,13 @@
 
 (defn- login-account
   [headers body]
-  (curl/post "http://0.0.0.0:8080/admin/account/login"
+  (curl/post "http://localhost:8080/admin/account/login"
              {:headers headers
               :body    body}))
 
 (defn- create-account
   [headers body]
-  (curl/post "http://0.0.0.0:8080/admin/account/create"
+  (curl/post "http://localhost:8080/admin/account/create"
              {:headers headers
               :body    body}))
 
@@ -72,7 +72,7 @@
         (is-err-code (create-account bad-cors-headers req-body) 403)))
     (testing "create account with default CORS check success"
       (let [good-cors-headers
-            (merge headers {"Origin" "http://0.0.0.0:8080"})
+            (merge headers {"Origin" "http://localhost:8080"})
             {:keys [status body]}
             (create-account good-cors-headers req-body)
             edn-body       (u/parse-json body)]
@@ -106,7 +106,7 @@
       (is (some? seed-jwt)))
     (testing "create account with custom CORS check failure"
       (let [bad-cors-headers
-            (merge headers {"Origin" "http://0.0.0.0:8080"})]
+            (merge headers {"Origin" "http://localhost:8080"})]
         (is-err-code (create-account bad-cors-headers req-body) 403)))
     (testing "create account with custom CORS check success"
       (let [good-cors-headers


### PR DESCRIPTION
[SQL-163] With no CORS allowed origins specified, `localhost` should be a valid origin. This PR adds it to the default list with the given HTTP/S ports.

[SQL-163]: https://yet.atlassian.net/browse/SQL-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ