### PR TITLE
SQL-165 Add CORS for CF template

### DIFF
--- a/dev-resources/template/2_lrs.yml
+++ b/dev-resources/template/2_lrs.yml
@@ -93,7 +93,7 @@ Parameters:
   LrsVersion:
     Description: Version of SQL LRS to download and install (public release versions on GitHub)
     Type: String
-    Default: v0.3.9
+    Default: v0.5.1
 
   ASGMinSize:
     Type: Number

--- a/dev-resources/template/2_lrs.yml
+++ b/dev-resources/template/2_lrs.yml
@@ -132,8 +132,14 @@ Parameters:
     Description: Route53 Hosted Zone in which to set a DNS record. If unset no record will be updated
     Default: ""
 
+  # CORS Settings
+  CORSAllowedOrigins:
+    Type: CommaDelimitedList
+    Description: A comma-separated list of origins to allow. If not provided ALBHostName will be used if present, otherwise no origins will be allowed.
+
 Conditions:
   SetDNS: !Not [!Equals [!Ref ALBHostedZone, ""]]
+  SetCORS: !Not [!Equals [!Join ["", !Ref CORSAllowedOrigins], ""]]
   ASGCPUPolicyTargetValueProvided:
     !Not [!Equals [!Ref ASGCPUPolicyTargetValue, ""]]
   ASGALBRequestCountTargetValueProvided:
@@ -376,25 +382,36 @@ Resources:
         02_configureLrs:
           files:
             "/opt/lrsql/config/lrsql.json":
-              content: !Sub |
-                {
-                  "database": {
-                    "dbHost": "${DBHost}",
-                    "dbPort": ${DBPort},
-                    "dbName": "${DBName}",
-                    "dbUser": "${DBAppUserName}",
-                    "dbPassword": "${InitDBCustomResource.dbAppPass}"
-                  },
-                  "lrs" : {
-                    "adminUserDefault": "${DefaultAdminUser}",
-                    "adminPassDefault": "${DefaultAdminPass}",
-                    "authorityUrl": "http://mydomain.com"
-                  },
-                  "webserver": {
-                    "httpHost": "0.0.0.0",
-                    "httpPort": ${InstanceHttpPort}
+              content: !Sub
+                - |
+                  {
+                    "database": {
+                      "dbHost": "${DBHost}",
+                      "dbPort": ${DBPort},
+                      "dbName": "${DBName}",
+                      "dbUser": "${DBAppUserName}",
+                      "dbPassword": "${InitDBCustomResource.dbAppPass}"
+                    },
+                    "lrs" : {
+                      "adminUserDefault": "${DefaultAdminUser}",
+                      "adminPassDefault": "${DefaultAdminPass}",
+                      "authorityUrl": "http://mydomain.com"
+                    },
+                    "webserver": {
+                      "httpHost": "0.0.0.0",
+                      "httpPort": ${InstanceHttpPort},
+                      "allowedOrigins": ${AllowedOrigins}
+                    }
                   }
-                }
+                - AllowedOrigins: !If
+                    - SetCORS
+                    - !Sub
+                      - '["${JoinedAllowedOrigins}"]'
+                      - JoinedAllowedOrigins: !Join ['","', !Ref CORSAllowedOrigins]
+                    - !If
+                      - SetDNS
+                      - !Sub '["https://${ALBHostName}"]'
+                      - "[]"
               mode: "000755"
               owner: root
               group: root

--- a/doc/aws.md
+++ b/doc/aws.md
@@ -20,6 +20,8 @@ In this step we will not be deploying any templates but will instead be preparin
 
 Configuring a domain or subdomain will allow you to access the SQL LRS at that URL. If you have (or can acquire) the domain through AWS Route53, these templates provide automated DNS updates that will route the domain to the LRS upon deployment or update. If you already have the domain you will be using through another registrar, you will need to update a DNS record in your own registrar at the end of deployment in order to use the domain.
 
+Note that if you do not use Route53 DNS you MUST provide one or more allowed CORS origins with the CORSAllowedOrigins LRS template parameter (see Step 4 below).
+
 #### TLS Certificate
 
 In these templates the Load Balancer expects to provide access to the LRS via HTTPS/443. You will need to either acquire a free Amazon Certificate Manager cert (highly recommended) or import your own cert from another CA into ACM for use in the deployment.
@@ -88,6 +90,7 @@ This template deploys the application servers, the load balancer, and also a sma
   - ALBHostName: (Optional) Set the desired (sub)domain name from Step 1
   - ALBHostedZone: (Optional) Set the Hosted Zone ID if the domain registrar is Route53 to enable automatic DNS management
   - ALBSubnets: Choose the two Public Subnets from Step 2
+  - CORSAllowedOrigins: If you are using your own DNS and do not provide ALBHostName and ALBHostedZone above, put the HTTPS address of your LRS here, ie. `https://mydomain.com` to allow CORS requests.
   - DBAppUserName: Choose a desired database username for the application
   - DBAppUserPasswordPath: Use the name selected in Systems Manager for the App Password in Step 1
   - DBHost: Copy and paste the DBEndpoint Output from Step 3


### PR DESCRIPTION
[SQL-165] The CF template needs some love, specifically in the form of CORS settings.

The logic is now as follows: If the template is given the CORSAllowedOrigins param, these are used. If not, the ALBHostname is used, if it is not present no web origins are allowed.

[SQL-165]: https://yet.atlassian.net/browse/SQL-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ