### PR TITLE
SQL-172 add by-db support macro to dispatch on backend

### DIFF
--- a/src/test/lrsql/test_runner.clj
+++ b/src/test/lrsql/test_runner.clj
@@ -5,7 +5,8 @@
 (defn -main
   [& args]
   (let [{db "--database" :or {db "h2"}} args]
-    (with-redefs [support/fresh-db-fixture
+    (with-redefs [support/current-db (keyword db)
+                  support/fresh-db-fixture
                   (case db
                     "h2"       support/fresh-h2-fixture
                     "sqlite"   support/fresh-sqlite-fixture

--- a/src/test/lrsql/test_support.clj
+++ b/src/test/lrsql/test_support.clj
@@ -120,6 +120,17 @@
 
 (def fresh-db-fixture fresh-h2-fixture)
 
+(def current-db nil)
+
+(defmacro by-db
+  "Accepts an expression for each keyword given that will only be run if the
+  current-db matches that keyword. Use this to conditionally test different
+  things on different database backends.
+  Takes an optional :default expression that will run if no others are matched."
+  [& {:keys [default]
+      :as exp-map}]
+  (get exp-map current-db default))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Conformance test helpers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/test/lrsql/test_support_test.clj
+++ b/src/test/lrsql/test_support_test.clj
@@ -1,7 +1,10 @@
 (ns lrsql.test-support-test
   (:require [clojure.test :refer [deftest testing is]]
             [lrsql.init.config :refer [read-config]]
-            [lrsql.test-support :refer [test-system fresh-h2-fixture]]
+            [lrsql.test-support :refer [test-system
+                                        fresh-h2-fixture
+                                        current-db
+                                        by-db]]
             [lrsql.util :as u]))
 
 (defn- get-db-name
@@ -32,3 +35,23 @@
             (fresh-h2-fixture
              #(test-system))
             [:connection :database :db-name])))))
+
+(deftest by-db-test
+  (testing "db backend dispatch"
+    (by-db
+     :h2       (testing "h2 detection"
+                 (is (= current-db :h2)))
+     :sqlite   (testing "sqlite detection"
+                 (is (= current-db :sqlite)))
+     :postgres (testing "postgres detection"
+                 (is (= current-db :postgres)))
+     nil       (testing "unset current-db detection"
+                 (is (= current-db nil)))
+     :foo      (testing "this never runs"
+                 (is false))))
+  (testing ":default arg"
+    (by-db
+     :foo      (testing "this also never runs"
+                 (is false))
+     :default  (testing "this always runs"
+                 (is true)))))


### PR DESCRIPTION
[SQL-172] Add a var and macro that allows conditionally including test code based on which db backend is in use.

[SQL-172]: https://yet.atlassian.net/browse/SQL-172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ