### PR TITLE
SQL-176 add AS to postgresql timeline query so it doesn't error on 12+

### DIFF
--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -327,7 +327,7 @@ GROUP BY platform;
 -- :command :query
 -- :result :many
 -- :doc Return counts of statements by time unit for a given range.
-SELECT SUBSTRING(payload->>'stored' FOR :unit-for) stored,
+SELECT SUBSTRING(payload->>'stored' FOR :unit-for) AS stored,
 COUNT(id) scount
 FROM xapi_statement
 WHERE id > :since-id


### PR DESCRIPTION
[SQL-176] We're getting an error when the timeline query runs on PG 12+
When we add `AS` it works. This is a hotfix to get PG 12 working pending matrix testing of PG versions.

[SQL-176]: https://yet.atlassian.net/browse/SQL-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ