### PR TITLE
SQL-177 Test against all supported versions of PostgreSQL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,17 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-  
+
     strategy:
       matrix:
-        target: [test-h2, test-sqlite, test-postgres]
+        target:
+          - test-h2
+          - test-sqlite
+          - test-postgres-11
+          - test-postgres-12
+          - test-postgres-13
+          - test-postgres-14
+          - test-postgres-15
 
     steps:
     - name: Checkout repository

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ resources/public/admin:
 # All other phony targets run lrsql instances that can be used and tested
 # during development. All start up with fixed DB properties and seed creds.
 
-.phony: clean-dev, ci, ephemeral, ephemeral-prod, persistent, sqlite, postgres, bench, bench-async, check-vuln, keycloak-demo, ephemeral-oidc, superset-demo
+.phony: clean-dev, ci, ephemeral, ephemeral-prod, persistent, sqlite, postgres, bench, bench-async, check-vuln, keycloak-demo, ephemeral-oidc, superset-demo, test-h2, test-sqlite, test-postgres, test-postgres-11, test-postgres-12, test-postgres-13, test-postgres-14, test-postgres-15
 
 clean-dev:
 	rm -rf *.db *.log resources/public tmp target/nvd
@@ -37,8 +37,24 @@ test-h2:
 test-sqlite:
 	clojure -M:test -m lrsql.test-runner --database sqlite
 
-test-postgres:
-	clojure -M:test -m lrsql.test-runner --database postgres
+TEST_PG_COMMAND ?= clojure -M:test -m lrsql.test-runner --database postgres
+
+test-postgres: test-postgres-11
+
+test-postgres-11:
+	LRSQL_TEST_DB_VERSION=11 $(TEST_PG_COMMAND)
+
+test-postgres-12:
+	LRSQL_TEST_DB_VERSION=12 $(TEST_PG_COMMAND)
+
+test-postgres-13:
+	LRSQL_TEST_DB_VERSION=13 $(TEST_PG_COMMAND)
+
+test-postgres-14:
+	LRSQL_TEST_DB_VERSION=14 $(TEST_PG_COMMAND)
+
+test-postgres-15:
+	LRSQL_TEST_DB_VERSION=15 $(TEST_PG_COMMAND)
 
 ci: test-h2 test-sqlite test-postgres
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ test-sqlite:
 
 TEST_PG_COMMAND ?= clojure -M:test -m lrsql.test-runner --database postgres
 
-test-postgres: test-postgres-11
+# Without LRSQL_TEST_DB_VERSION, defaults to version 11
+test-postgres:
+	$(TEST_PG_COMMAND)
 
 test-postgres-11:
 	LRSQL_TEST_DB_VERSION=11 $(TEST_PG_COMMAND)

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -15,7 +15,12 @@ The SQL LRS can be built or run with the following Makefile targets. They can be
 | `ci` | Called when running continuous integration; runs all test cases in all SQL flavors. |
 | `test-h2` | Run all tests with H2 database. |
 | `test-sqlite` | Run all tests with SQLite database. |
-| `test-postgres` | Run all tests with Postgres database. |
+| `test-postgres` | Run all tests with Postgres database version 11. Set the `LRSQL_TEST_DB_VERSION` env var to a valid Postgres docker tag to use another version. |
+| `test-postgres-11` | Run all tests with Postgres database version 11. |
+| `test-postgres-12` | Run all tests with Postgres database version 12. |
+| `test-postgres-13` | Run all tests with Postgres database version 13. |
+| `test-postgres-14` | Run all tests with Postgres database version 14. |
+| `test-postgres-15` | Run all tests with Postgres database version 15. |
 | `bundle` | Build a complete distribution of the SQL LRS including the user interface and native runtimes for multiple operating systems. |
 | `bench` | Run a load test and benchmark performance, returning performance metrics on predefined test data. Requires a running SQL LRS instance to test against. This test sends requests synchronously on one thread. |
 | `bench-async` | Same as `bench` but it runs with concurrent requests on multiple threads. |

--- a/doc/postgres.md
+++ b/doc/postgres.md
@@ -92,6 +92,10 @@ Here is an example database config map in `config/lrsql.json`. The user is `lrsq
 
 The `connection`, `lrs`, and `webserver` sections of the config can then be set with whatever properties you see fit, like the example on the [Getting Started](startup.md) page.
 
+### Supported Versions
+
+SQL LRS supports PostgreSQL versions 11 through 15. It is tested against the [current minor point release](https://www.postgresql.org/support/versioning/) of each version.
+
 ### Unix Socket Support
 
 SQL LRS includes [junixsocket](https://github.com/kohlschutter/junixsocket) which allows unix socket connections to Postgres.

--- a/resources/lrsql/config/config.edn
+++ b/resources/lrsql/config/config.edn
@@ -22,7 +22,7 @@
                    ;; :db-properties "currentSchema=lrsql"
 
                    ;; Testing Only! Specify the version used with testcontainers
-                   :test-db-version "11.9"}
+                   :test-db-version #or [#env LRSQL_TEST_DB_VERSION "11"]}
    :test-oidc     {:db-type "h2:mem"
                    :db-name "ephemeral"}
 


### PR DESCRIPTION
[SQL-177] We support all current maintained versions of PG but do not test them in CI. This PR adds targets to the makefile to explicitly test each version. Note that the existing `test-postgres` target will run the earliest version, 11.

Note that the _current minor_ version of each major version will run.

The `LRSQL_TEST_DB_VERSION` env var determines which version will be run in TestContainers. Any Postgres docker tag (ex. `latest`) is valid. The default is `11`.

[SQL-177]: https://yet.atlassian.net/browse/SQL-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ