### PR TITLE
SQL-181 RDS template updates

### DIFF
--- a/dev-resources/template/1_db.yml
+++ b/dev-resources/template/1_db.yml
@@ -32,6 +32,20 @@ Parameters:
     Description: For provisioned aurora, the instance class to use
     Type: String
     Default: "db.r5.large"
+  DBInstanceReplica:
+    Description: Whether or not to create a second DB instance for use as a read-replica
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Default: false
+  DBInstancePublic:
+    Description: Whether or not to allow public access to DB instances
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Default: false
   DBName:
     Description: PG Database name. Ignored if DBSnapshotIdentifier is provided
     Type: String
@@ -70,6 +84,8 @@ Mappings:
 Conditions:
   DBProvisioned:
     !Equals [!Ref DBEngineMode, "provisioned"]
+  DBCreateReadReplica:
+    !And [Condition: DBProvisioned, !Equals [!Ref DBInstanceReplica, "true"]]
   DBSnapshotIdentifierProvided:
     !Not [!Equals [!Ref DBSnapshotIdentifier, ""]]
 
@@ -131,7 +147,17 @@ Resources:
       Engine: aurora-postgresql
       EngineVersion: !Ref DBEngineVersion
       DBClusterIdentifier: !Ref DBCluster
-      PubliclyAccessible: false
+      PubliclyAccessible: !Ref DBInstancePublic
+      DBInstanceClass: !Ref DBInstanceClass
+
+  DBInstance1:
+    Condition: DBCreateReadReplica
+    Type: AWS::RDS::DBInstance
+    Properties:
+      Engine: aurora-postgresql
+      EngineVersion: !Ref DBEngineVersion
+      DBClusterIdentifier: !Ref DBCluster
+      PubliclyAccessible: !Ref DBInstancePublic
       DBInstanceClass: !Ref DBInstanceClass
 
 Outputs:

--- a/dev-resources/template/1_db.yml
+++ b/dev-resources/template/1_db.yml
@@ -24,14 +24,14 @@ Parameters:
   DBEngineVersion:
     Description: PostgreSQL engine version on RDS
     Type: String
-    Default: "12.9"
+    Default: "14.3"
     AllowedValues:
       - "12.9"
       - "14.3"
   DBInstanceClass:
     Description: For provisioned aurora, the instance class to use
     Type: String
-    Default: "db.r4.large"
+    Default: "db.r5.large"
   DBName:
     Description: PG Database name. Ignored if DBSnapshotIdentifier is provided
     Type: String


### PR DESCRIPTION
* Add `DBInstancePublic` boolean parameter, if `true` will make DB instances publicly accessible
* Add `DBInstanceReplica` boolean parameter, if `true` will add a 2nd DB instance

Also sets the default engine to `14.3` and makes the default instance `db.r5.large` which is a working combo.