### PR TITLE
SQL-186 Prevent deletion of sole admin account

### DIFF
--- a/doc/oidc.md
+++ b/doc/oidc.md
@@ -43,7 +43,7 @@ Administrative functions like credential provisioning require a local admin acco
 
 ##### Local Admins
 
-By default SQL LRS will disable local administrator account usage and management when `LRSQL_OIDC_ISSUER` is provided. To enable local admin accounts when using OIDC, set the `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` (`lrs.oidcEnableLocalAdmin`) variable to `true`.
+By default SQL LRS will disable local administrator account usage and management when `LRSQL_OIDC_ISSUER` is provided. To enable local admin accounts when using OIDC, set the `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` (`lrs.oidcEnableLocalAdmin`) variable to `true`. Note that when OIDC and local accounts are enabled SQL LRS will allow the deletion of all local accounts from the aministrative interface and API.
 
 ### Admin UI Authentication
 

--- a/doc/oidc.md
+++ b/doc/oidc.md
@@ -43,7 +43,7 @@ Administrative functions like credential provisioning require a local admin acco
 
 ##### Local Admins
 
-By default SQL LRS will disable local administrator account usage and management when `LRSQL_OIDC_ISSUER` is provided. To enable local admin accounts when using OIDC, set the `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` (`lrs.oidcEnableLocalAdmin`) variable to `true`. Note that when OIDC and local accounts are enabled SQL LRS will allow the deletion of all local accounts from the aministrative interface and API.
+By default SQL LRS will disable local administrator account usage and management when `LRSQL_OIDC_ISSUER` is provided. To enable local admin accounts when using OIDC, set the `LRSQL_OIDC_ENABLE_LOCAL_ADMIN` (`lrs.oidcEnableLocalAdmin`) variable to `true`. Note that when OIDC and local accounts are enabled, SQL LRS will allow the deletion of all local accounts from the administrative interface and API.
 
 ### Admin UI Authentication
 

--- a/doc/startup.md
+++ b/doc/startup.md
@@ -111,6 +111,8 @@ For security purposes, it is important to delete the seed account (as the userna
 
 Additionally you should remove the `adminUserDefault` and `adminPassDefault` lines from `config/lrsql.json`. This will prevent the system from re-creating the seed accounts on future restarts.
 
+Note that SQL LRS will not delete an admin account if it is the only one present.
+
 ### Your first Statement
 
 xAPI Statements can be inserted into and queried from the SQL LRS using HTTP commands. Let us insert the following Statement:

--- a/src/db/h2/lrsql/h2/record.clj
+++ b/src/db/h2/lrsql/h2/record.clj
@@ -155,6 +155,8 @@
     (query-account tx input))
   (-query-account-oidc [_ tx input]
     (query-account-oidc tx input))
+  (-query-account-by-id [_ tx input]
+    (query-account-by-id tx input))
   (-query-account-exists [_ tx input]
     (query-account-exists tx input))
   (-query-account-count-local [_ tx]

--- a/src/db/h2/lrsql/h2/record.clj
+++ b/src/db/h2/lrsql/h2/record.clj
@@ -157,6 +157,8 @@
     (query-account-oidc tx input))
   (-query-account-exists [_ tx input]
     (query-account-exists tx input))
+  (-query-account-count-local [_ tx]
+    (query-account-count-local tx))
 
   bp/CredentialBackend
   (-insert-credential! [_ tx input]

--- a/src/db/h2/lrsql/h2/sql/query.sql
+++ b/src/db/h2/lrsql/h2/sql/query.sql
@@ -268,6 +268,14 @@ SELECT 1 FROM admin_account
 --~ (when (:username params)   "WHERE username = :username")
 --~ (when (:account-id params) "WHERE id = :account-id")
 
+-- :name query-account-count-local
+-- :command :query
+-- :result :one
+-- :doc Count the local admin accounts present.
+SELECT COUNT(id) local_account_count
+FROM admin_account
+WHERE oidc_issuer IS NULL
+
 /* Credentials */
 
 -- :name query-credentials

--- a/src/db/h2/lrsql/h2/sql/query.sql
+++ b/src/db/h2/lrsql/h2/sql/query.sql
@@ -278,7 +278,7 @@ SELECT 1 FROM admin_account
 -- :name query-account-count-local
 -- :command :query
 -- :result :one
--- :doc Count the local admin accounts present.
+-- :doc Count the local (non-OIDC) admin accounts present.
 SELECT COUNT(id) local_account_count
 FROM admin_account
 WHERE oidc_issuer IS NULL

--- a/src/db/h2/lrsql/h2/sql/query.sql
+++ b/src/db/h2/lrsql/h2/sql/query.sql
@@ -254,6 +254,13 @@ WHERE username = :username
 SELECT id, oidc_issuer FROM admin_account
 WHERE username = :username
 
+-- :name query-account-by-id
+-- :command :query
+-- :result :one
+-- :doc Given an account `account-id`, return the ID and OIDC issuer, if any.
+SELECT id, oidc_issuer FROM admin_account
+WHERE id = :account-id
+
 -- :name query-all-accounts
 -- :command :query
 -- :result :many

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -163,6 +163,8 @@
     (query-account tx input))
   (-query-account-oidc [_ tx input]
     (query-account-oidc tx input))
+  (-query-account-by-id [_ tx input]
+    (query-account-by-id tx input))
   (-query-account-exists [_ tx input]
     (query-account-exists tx input))
   (-query-account-count-local [_ tx]

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -165,6 +165,8 @@
     (query-account-oidc tx input))
   (-query-account-exists [_ tx input]
     (query-account-exists tx input))
+  (-query-account-count-local [_ tx]
+    (query-account-count-local tx))
 
   bp/CredentialBackend
   (-insert-credential! [_ tx input]

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -248,6 +248,13 @@ WHERE username = :username;
 SELECT id, oidc_issuer FROM admin_account
 WHERE username = :username;
 
+-- :name query-account-by-id
+-- :command :query
+-- :result :one
+-- :doc Given an account `account-id`, return the ID and OIDC issuer, if any.
+SELECT id, oidc_issuer FROM admin_account
+WHERE id = :account-id;
+
 -- :name query-all-accounts
 -- :command :query
 -- :result :many

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -273,7 +273,7 @@ SELECT 1 FROM admin_account
 -- :name query-account-count-local
 -- :command :query
 -- :result :one
--- :doc Count the local admin accounts present.
+-- :doc Count the local (non-OIDC) admin accounts present.
 SELECT COUNT(id) local_account_count
 FROM admin_account
 WHERE oidc_issuer IS NULL;

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -263,6 +263,14 @@ SELECT 1 FROM admin_account
 --~ (when (:account-id params) "WHERE id = :account-id")
 ;
 
+-- :name query-account-count-local
+-- :command :query
+-- :result :one
+-- :doc Count the local admin accounts present.
+SELECT COUNT(id) local_account_count
+FROM admin_account
+WHERE oidc_issuer IS NULL;
+
 /* Credentials */
 
 -- :name query-credentials

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -193,6 +193,8 @@
     (query-account-oidc tx input))
   (-query-account-exists [_ tx input]
     (query-account-exists tx input))
+  (-query-account-count-local [_ tx]
+    (query-account-count-local tx))
 
   bp/CredentialBackend
   (-insert-credential! [_ tx input]

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -191,6 +191,8 @@
     (query-account tx input))
   (-query-account-oidc [_ tx input]
     (query-account-oidc tx input))
+  (-query-account-by-id [_ tx input]
+    (query-account-by-id tx input))
   (-query-account-exists [_ tx input]
     (query-account-exists tx input))
   (-query-account-count-local [_ tx]

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -240,6 +240,14 @@ SELECT 1 FROM admin_account
 --~ (when (:username params)   "WHERE username = :username")
 --~ (when (:account-id params) "WHERE id = :account-id")
 
+-- :name query-account-count-local
+-- :command :query
+-- :result :one
+-- :doc Count the local admin accounts present.
+SELECT COUNT(id) local_account_count
+FROM admin_account
+WHERE oidc_issuer IS NULL
+
 /* Credentials */
 
 -- :name query-credentials

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -226,6 +226,13 @@ WHERE username = :username
 SELECT id, oidc_issuer FROM admin_account
 WHERE username = :username
 
+-- :name query-account-by-id
+-- :command :query
+-- :result :one
+-- :doc Given an account `account-id`, return the ID and OIDC issuer, if any.
+SELECT id, oidc_issuer FROM admin_account
+WHERE id = :account-id
+
 -- :name query-all-accounts
 -- :command :query
 -- :result :many

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -250,7 +250,7 @@ SELECT 1 FROM admin_account
 -- :name query-account-count-local
 -- :command :query
 -- :result :one
--- :doc Count the local admin accounts present.
+-- :doc Count the local (non-OIDC) admin accounts present.
 SELECT COUNT(id) local_account_count
 FROM admin_account
 WHERE oidc_issuer IS NULL

--- a/src/main/lrsql/admin/interceptors/account.clj
+++ b/src/main/lrsql/admin/interceptors/account.clj
@@ -130,10 +130,10 @@
       (let [{lrs :com.yetanalytics/lrs
              {:keys [account-id]} ::data}
             ctx
+            oidc-enabled?
+            (some? (:lrsql.admin.interceptors.oidc/admin-env ctx))
             {:keys [result]}
-            (adp/-delete-account
-             lrs account-id
-             (some? (:lrsql.admin.interceptors.oidc/admin-env ctx)))]
+            (adp/-delete-account lrs account-id oidc-enabled?)]
         (cond
           ;; The result is the account ID - success!
           (uuid? result)

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -9,7 +9,7 @@
     "Authenticate by looking up if the account exists in the account table.")
   (-existing-account? [this account-id]
     "Check that the account with the given ID exists in the account table. Returns a boolean.")
-  (-delete-account [this account-id]
+  (-delete-account [this account-id oidc-enabled?]
     "Delete the account and all associated creds. Assumes the account has already been authenticated.")
   (-ensure-account-oidc [this username oidc-issuer]
     "Create or verify an existing admin account with the given username and oidc-issuer."))

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -10,7 +10,7 @@
   (-existing-account? [this account-id]
     "Check that the account with the given ID exists in the account table. Returns a boolean.")
   (-delete-account [this account-id oidc-enabled?]
-    "Delete the account and all associated creds. Assumes the account has already been authenticated.")
+    "Delete the account and all associated creds. Assumes the account has already been authenticated. Requires OIDC status to prevent sole account deletion.")
   (-ensure-account-oidc [this username oidc-issuer]
     "Create or verify an existing admin account with the given username and oidc-issuer."))
 

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -95,7 +95,8 @@
   (-query-account [this tx input])
   (-query-account-oidc [this tx input])
   (-query-account-exists [this tx input])
-  (-query-all-admin-accounts [this tx]))
+  (-query-all-admin-accounts [this tx])
+  (-query-account-count-local [this tx]))
 
 (defprotocol CredentialBackend
   ;; Commands

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -94,6 +94,7 @@
   ;; Queries
   (-query-account [this tx input])
   (-query-account-oidc [this tx input])
+  (-query-account-by-id [this tx input])
   (-query-account-exists [this tx input])
   (-query-all-admin-accounts [this tx])
   (-query-account-count-local [this tx]))

--- a/src/main/lrsql/input/admin.clj
+++ b/src/main/lrsql/input/admin.clj
@@ -39,13 +39,15 @@
   (u/add-primary-key ensure-input))
 
 (s/fdef delete-admin-input
-  :args (s/cat :account-id ::ads/account-id)
+  :args (s/cat :account-id ::ads/account-id
+               :oidc-enabled? :lrsql.spec.admin.input/oidc-enabled?)
   :ret ads/admin-id-input-spec)
 
 (defn delete-admin-input
   "Given `account-id`, construct the input param map for `delete-admin!`."
-  [account-id]
-  {:account-id account-id})
+  [account-id oidc-enabled?]
+  {:account-id    account-id
+   :oidc-enabled? oidc-enabled?})
 
 (s/fdef query-admin-exists-input
   :args (s/cat :account-id ::ads/account-id)

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -47,11 +47,12 @@
           :as   input}]
   {:result
    (if-let [{:keys [oidc_issuer]} (bp/-query-account-by-id bk tx input)]
-     (if (or oidc_issuer ;; OIDC accounts can always be deleted
-             (< 1
-                (:local_account_count
-                 (bp/-query-account-count-local bk tx))) ;; more than one
-             oidc-enabled?) ;; Allow if OIDC is turned on
+     (if (or
+          oidc-enabled? ;; Allow if OIDC is turned on
+          oidc_issuer ;; OIDC accounts can always be deleted
+          (< 1
+             (:local_account_count
+              (bp/-query-account-count-local bk tx)))) ;; more than one
        (do
          (bp/-delete-admin-account! bk tx input)
          account-id)

--- a/src/main/lrsql/spec/admin.clj
+++ b/src/main/lrsql/spec/admin.clj
@@ -29,6 +29,8 @@
 (s/def :lrsql.spec.admin.input/oidc-issuer string?)
 ;; But is for ret
 (s/def :lrsql.spec.admin.ret/oidc-issuer (s/nilable string?))
+;; boolean to indicate whether OIDC is enabled
+(s/def :lrsql.spec.admin.input/oidc-enabled? boolean?)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Inputs
@@ -62,6 +64,10 @@
 (def admin-id-input-spec
   (s/keys :req-un [::account-id]))
 
+(def delete-admin-input-spec
+  (s/merge admin-id-input-spec
+           (s/keys :req-un [:lrsql.spec.admin.input/oidc-enabled?])))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Results
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -85,7 +91,8 @@
 (s/def :lrsql.spec.admin.delete/result
   (s/nonconforming
    (s/or :success uuid?
-         :failure #{:lrsql.admin/missing-account-error})))
+         :failure #{:lrsql.admin/missing-account-error
+                    :lrsql.admin/sole-admin-delete-error})))
 
 (def delete-admin-ret-spec
   (s/keys :req-un [:lrsql.spec.admin.delete/result]))

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -261,9 +261,9 @@
       (jdbc/with-transaction [tx conn]
         (admin-q/query-admin-exists backend tx input))))
   (-delete-account
-    [this account-id]
+    [this account-id oidc-enabled?]
     (let [conn  (lrs-conn this)
-          input (admin-input/delete-admin-input account-id)]
+          input (admin-input/delete-admin-input account-id oidc-enabled?)]
       (jdbc/with-transaction [tx conn]
         (admin-cmd/delete-admin! backend tx input))))
   (-ensure-account-oidc


### PR DESCRIPTION
[SQL-186] Prevent deletion of an admin account if it is the only one on the system. Allow deletion if the LRS is hooked up to OIDC.

[SQL-186]: https://yet.atlassian.net/browse/SQL-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ