### PR TITLE
SQL-187 Feature: Update Local Admin Password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Version of LRS Admin UI to use
 
-LRS_ADMIN_UI_VERSION ?= v0.1.8
+LRS_ADMIN_UI_VERSION ?= v0.1.9
 LRS_ADMIN_UI_LOCATION ?= https://github.com/yetanalytics/lrs-admin-ui/releases/download/${LRS_ADMIN_UI_VERSION}/lrs-admin-ui.zip
 LRS_ADMIN_ZIPFILE ?= lrs-admin-ui-${LRS_ADMIN_UI_VERSION}.zip
 

--- a/src/db/h2/lrsql/h2/record.clj
+++ b/src/db/h2/lrsql/h2/record.clj
@@ -151,6 +151,8 @@
     (query-all-accounts tx))
   (-delete-admin-account! [_ tx input]
     (delete-admin-account! tx input))
+  (-update-admin-password! [_ tx input]
+    (update-admin-password! tx input))
   (-query-account [_ tx input]
     (query-account tx input))
   (-query-account-oidc [_ tx input]

--- a/src/db/h2/lrsql/h2/sql/query.sql
+++ b/src/db/h2/lrsql/h2/sql/query.sql
@@ -243,9 +243,10 @@ WHERE activity_iri = :activity-iri
 -- :name query-account
 -- :command :query
 -- :result :one
--- :doc Given an account `username`, return the ID and the hashed password, which can be used to verify the account.
+-- :doc Given an account `username` or `account-id`, return the ID and the hashed password, which can be used to verify the account.
 SELECT id, passhash FROM admin_account
-WHERE username = :username
+--~ (when (:username params)   "WHERE username = :username")
+--~ (when (:account-id params) "WHERE id = :account-id")
 
 -- :name query-account-oidc
 -- :command :query

--- a/src/db/h2/lrsql/h2/sql/update.sql
+++ b/src/db/h2/lrsql/h2/sql/update.sql
@@ -62,3 +62,12 @@ SET
   last_modified = :last-modified
 WHERE profile_id = :profile-id
 AND activity_iri = :activity-iri
+
+-- :name update-admin-password!
+-- :command :execute
+-- :result :affected
+-- :doc Update the `passhash` of an admin account.
+UPDATE admin_account
+SET
+  passhash = :new-passhash
+WHERE username = :username

--- a/src/db/h2/lrsql/h2/sql/update.sql
+++ b/src/db/h2/lrsql/h2/sql/update.sql
@@ -70,4 +70,4 @@ AND activity_iri = :activity-iri
 UPDATE admin_account
 SET
   passhash = :new-passhash
-WHERE username = :username
+WHERE id = :account-id

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -159,6 +159,8 @@
     (query-all-accounts tx))
   (-delete-admin-account! [_ tx input]
     (delete-admin-account! tx input))
+  (-update-admin-password! [_ tx input]
+    (update-admin-password! tx input))
   (-query-account [_ tx input]
     (query-account tx input))
   (-query-account-oidc [_ tx input]

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -237,9 +237,11 @@ WHERE activity_iri = :activity-iri
 -- :name query-account
 -- :command :query
 -- :result :one
--- :doc Given an account `username`, return the ID and the hashed password, which can be used to verify the account.
+-- :doc Given an account `username` or `account-id`, return the ID and the hashed password, which can be used to verify the account.
 SELECT id, passhash FROM admin_account
-WHERE username = :username;
+--~ (when (:username params)   "WHERE username = :username")
+--~ (when (:account-id params) "WHERE id = :account-id")
+;
 
 -- :name query-account-oidc
 -- :command :query

--- a/src/db/postgres/lrsql/postgres/sql/update.sql
+++ b/src/db/postgres/lrsql/postgres/sql/update.sql
@@ -67,3 +67,12 @@ SET
   last_modified = :last-modified
 WHERE profile_id = :profile-id
 AND activity_iri = :activity-iri;
+
+-- :name update-admin-password!
+-- :command :execute
+-- :result :affected
+-- :doc Update the `passhash` of an admin account.
+UPDATE admin_account
+SET
+  passhash = :new-passhash
+WHERE username = :username;

--- a/src/db/postgres/lrsql/postgres/sql/update.sql
+++ b/src/db/postgres/lrsql/postgres/sql/update.sql
@@ -75,4 +75,4 @@ AND activity_iri = :activity-iri;
 UPDATE admin_account
 SET
   passhash = :new-passhash
-WHERE username = :username;
+WHERE id = :account-id;

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -187,6 +187,8 @@
     (query-all-accounts tx))
   (-delete-admin-account! [_ tx input]
     (delete-admin-account! tx input))
+  (-update-admin-password! [_ tx input]
+    (update-admin-password! tx input))
   (-query-account [_ tx input]
     (query-account tx input))
   (-query-account-oidc [_ tx input]

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -215,9 +215,10 @@ WHERE activity_iri = :activity-iri
 -- :name query-account
 -- :command :query
 -- :result :one
--- :doc Given an account `username`, return the ID and the hashed password, which can be used to verify the account.
+-- :doc Given an account `username` or `account-id`, return the ID and the hashed password, which can be used to verify the account.
 SELECT id, passhash FROM admin_account
-WHERE username = :username
+--~ (when (:username params)   "WHERE username = :username")
+--~ (when (:account-id params) "WHERE id = :account-id")
 
 -- :name query-account-oidc
 -- :command :query

--- a/src/db/sqlite/lrsql/sqlite/sql/update.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/update.sql
@@ -62,3 +62,12 @@ SET
   last_modified = :last-modified
 WHERE profile_id = :profile-id
 AND activity_iri = :activity-iri
+
+-- :name update-admin-password!
+-- :command :execute
+-- :result :affected
+-- :doc Update the `passhash` of an admin account.
+UPDATE admin_account
+SET
+  passhash = :new-passhash
+WHERE username = :username

--- a/src/db/sqlite/lrsql/sqlite/sql/update.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/update.sql
@@ -70,4 +70,4 @@ AND activity_iri = :activity-iri
 UPDATE admin_account
 SET
   passhash = :new-passhash
-WHERE username = :username
+WHERE id = :account-id

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -13,7 +13,7 @@
     "Delete the account and all associated creds. Assumes the account has already been authenticated. Requires OIDC status to prevent sole account deletion.")
   (-ensure-account-oidc [this username oidc-issuer]
     "Create or verify an existing admin account with the given username and oidc-issuer.")
-  (-update-admin-password [this username old-password new-password]
+  (-update-admin-password [this account-id old-password new-password]
     "Update the password for an admin account given old and new passwords."))
 
 (defprotocol APIKeyManager

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -12,7 +12,9 @@
   (-delete-account [this account-id oidc-enabled?]
     "Delete the account and all associated creds. Assumes the account has already been authenticated. Requires OIDC status to prevent sole account deletion.")
   (-ensure-account-oidc [this username oidc-issuer]
-    "Create or verify an existing admin account with the given username and oidc-issuer."))
+    "Create or verify an existing admin account with the given username and oidc-issuer.")
+  (-update-admin-password [this username old-password new-password]
+    "Update the password for an admin account given old and new passwords."))
 
 (defprotocol APIKeyManager
   (-create-api-keys [this account-id scopes]

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -34,6 +34,13 @@
                                          ji/validate-jwt-account
                                          ai/create-admin)
      :route-name :lrsql.admin.account/create]
+    ;; Update account password
+    ["/admin/account/password"
+     :put (conj common-interceptors
+                ai/validate-update-password-params
+                (ji/validate-jwt jwt-secret jwt-leeway)
+                ji/validate-jwt-account
+                ai/update-admin-password)]
     ;; Get all accounts
     ["/admin/account" :get (conj common-interceptors
                                  (ji/validate-jwt jwt-secret jwt-leeway)

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -91,6 +91,7 @@
   (-insert-admin-account! [this tx input])
   (-insert-admin-account-oidc! [this tx input])
   (-delete-admin-account! [this tx input])
+  (-update-admin-password! [this tx input])
   ;; Queries
   (-query-account [this tx input])
   (-query-account-oidc [this tx input])

--- a/src/main/lrsql/input/admin.clj
+++ b/src/main/lrsql/input/admin.clj
@@ -68,3 +68,14 @@
   [username password]
   {:username username
    :password password})
+
+(s/fdef update-admin-password-input
+  :args (s/cat :username ::ads/username :new-password ::ads/new-password)
+  :ret ads/update-admin-password-input-spec)
+
+(defn update-admin-password-input
+  "Given `username` and `new-password`, construct the input
+   param map for `update-admin-password`."
+  [username new-password]
+  {:username     username
+   :new-passhash (adu/hash-password new-password)})

--- a/src/main/lrsql/input/admin.clj
+++ b/src/main/lrsql/input/admin.clj
@@ -69,13 +69,24 @@
   {:username username
    :password password})
 
+(s/fdef query-validate-admin-by-id-input
+  :args (s/cat :account-id ::ads/account-id :password ::ads/password)
+  :ret ads/query-validate-admin-by-id-input-spec)
+
+(defn query-validate-admin-by-id-input
+  "Given `account-id` and `password`, construct the input param map for
+   `query-validate-admin-by-id`."
+  [account-id password]
+  {:account-id account-id
+   :password   password})
+
 (s/fdef update-admin-password-input
-  :args (s/cat :username ::ads/username :new-password ::ads/new-password)
+  :args (s/cat :account-id ::ads/account-id :new-password ::ads/new-password)
   :ret ads/update-admin-password-input-spec)
 
 (defn update-admin-password-input
-  "Given `username` and `new-password`, construct the input
+  "Given `account-id` and `new-password`, construct the input
    param map for `update-admin-password`."
-  [username new-password]
-  {:username     username
+  [account-id new-password]
+  {:account-id   account-id
    :new-passhash (adu/hash-password new-password)})

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -60,6 +60,25 @@
      :lrsql.admin/missing-account-error)})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Admin Account Update Password
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(s/fdef update-admin-password!
+  :args (s/cat :bk ads/admin-backend?
+               :tx transaction?
+               :input ads/update-admin-password-input-spec)
+  :ret ads/update-admin-password-ret-spec)
+
+(defn update-admin-password!
+  "Update the password of an admin account. Returns a map where `:result` is the
+   account ID."
+  [bk tx input]
+  {:result
+   (let [{:keys [id]} (bp/-query-account bk tx input)]
+     (do (bp/-update-admin-password! bk tx input)
+         id))})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Ensure Admin Account from OIDC
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -75,8 +75,8 @@
   [bk tx input]
   {:result
    (let [{:keys [id]} (bp/-query-account bk tx input)]
-     (do (bp/-update-admin-password! bk tx input)
-         id))})
+     (bp/-update-admin-password! bk tx input)
+     id)})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Ensure Admin Account from OIDC

--- a/src/main/lrsql/ops/query/admin.clj
+++ b/src/main/lrsql/ops/query/admin.clj
@@ -10,12 +10,14 @@
 (s/fdef query-validate-admin
   :args (s/cat :bk ads/admin-backend?
                :tx transaction?
-               :input ads/query-validate-admin-input-spec)
+               :input (s/or
+                       :by-username ads/query-admin-input-spec
+                       :by-id ads/query-admin-by-id-input-spec))
   :ret ads/query-admin-ret-spec)
 
 (defn query-admin
-  "Query an admin account with the given username and password. Returns
-   a map containing `:account-id` and `:passhash` on success, or nil on
+  "Query an admin account with the given username (or account-id) and password.
+   Returns a map containing `:account-id` and `:passhash` on success, or nil on
    failure."
   [bk tx input]
   (when-some [{account-id :id
@@ -33,7 +35,9 @@
 (s/fdef query-validate-admin
   :args (s/cat :bk ads/admin-backend?
                :tx transaction?
-               :input ads/query-validate-admin-input-spec)
+               :input (s/or
+                       :by-username ads/query-validate-admin-input-spec
+                       :by-id ads/query-validate-admin-by-id-input-spec))
   :ret ads/query-validate-admin-ret-spec)
 
 (defn query-validate-admin

--- a/src/main/lrsql/spec/admin.clj
+++ b/src/main/lrsql/spec/admin.clj
@@ -48,6 +48,15 @@
 (def admin-delete-params-spec
   (s/keys :req-un [::account-id]))
 
+(def update-admin-password-params-spec
+  (s/and
+   (s/keys :req-un [::old-password
+                    ::new-password])
+   (fn new-pass-noteq-old-pass
+     [{:keys [old-password
+              new-password]}]
+     (not= old-password new-password))))
+
 (def insert-admin-input-spec
   (s/keys :req-un [::c/primary-key
                    ::username
@@ -84,15 +93,6 @@
 (def delete-admin-input-spec
   (s/merge admin-id-input-spec
            (s/keys :req-un [:lrsql.spec.admin.input/oidc-enabled?])))
-
-(def update-admin-password-params-spec
-  (s/and
-   (s/keys :req-un [::old-password
-                    ::new-password])
-   (fn new-pass-noteq-old-pass
-     [{:keys [old-password
-              new-password]}]
-     (not= old-password new-password))))
 
 (def update-admin-password-input-spec
   (s/keys :req-un [::account-id

--- a/src/main/lrsql/spec/admin.clj
+++ b/src/main/lrsql/spec/admin.clj
@@ -62,8 +62,20 @@
                    ::username
                    :lrsql.spec.admin.input/oidc-issuer]))
 
+(def query-admin-input-spec
+  (s/keys :req-un [::username
+                   ::password]))
+
+(def query-admin-by-id-input-spec
+  (s/keys :req-un [::account-id
+                   ::password]))
+
 (def query-validate-admin-input-spec
   (s/keys :req-un [::username
+                   ::password]))
+
+(def query-validate-admin-by-id-input-spec
+  (s/keys :req-un [::account-id
                    ::password]))
 
 (def admin-id-input-spec
@@ -75,8 +87,7 @@
 
 (def update-admin-password-params-spec
   (s/and
-   (s/keys :req-un [::username
-                    ::old-password
+   (s/keys :req-un [::old-password
                     ::new-password])
    (fn new-pass-noteq-old-pass
      [{:keys [old-password
@@ -84,7 +95,7 @@
      (not= old-password new-password))))
 
 (def update-admin-password-input-spec
-  (s/keys :req-un [::username
+  (s/keys :req-un [::account-id
                    :lrsql.spec.admin.input/new-passhash]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/main/lrsql/spec/admin.clj
+++ b/src/main/lrsql/spec/admin.clj
@@ -31,6 +31,11 @@
 (s/def :lrsql.spec.admin.ret/oidc-issuer (s/nilable string?))
 ;; boolean to indicate whether OIDC is enabled
 (s/def :lrsql.spec.admin.input/oidc-enabled? boolean?)
+;; Update password params
+(s/def ::old-password ::password)
+(s/def ::new-password ::password)
+;; Update password input
+(s/def :lrsql.spec.admin.input/new-passhash :lrsql.spec.admin.input/passhash)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Inputs
@@ -67,6 +72,20 @@
 (def delete-admin-input-spec
   (s/merge admin-id-input-spec
            (s/keys :req-un [:lrsql.spec.admin.input/oidc-enabled?])))
+
+(def update-admin-password-params-spec
+  (s/and
+   (s/keys :req-un [::username
+                    ::old-password
+                    ::new-password])
+   (fn new-pass-noteq-old-pass
+     [{:keys [old-password
+              new-password]}]
+     (not= old-password new-password))))
+
+(def update-admin-password-input-spec
+  (s/keys :req-un [::username
+                   :lrsql.spec.admin.input/new-passhash]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Results
@@ -113,3 +132,8 @@
 
 (def query-validate-admin-ret-spec
   (s/keys :req-un [:lrsql.spec.admin.query/result]))
+
+(s/def :lrsql.spec.admin.update-password/result uuid?)
+
+(def update-admin-password-ret-spec
+  (s/keys :req-un [:lrsql.spec.admin.update-password/result]))

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -272,6 +272,19 @@
           input (admin-input/ensure-admin-oidc-input username oidc-issuer)]
       (jdbc/with-transaction [tx conn]
         (admin-cmd/ensure-admin-oidc! backend tx input))))
+  (-update-admin-password
+    [this username old-password new-password]
+    (let [conn       (lrs-conn this)
+          auth-input (admin-input/query-validate-admin-input
+                      username old-password)]
+      (jdbc/with-transaction [tx conn]
+        (let [{:keys [result]} (admin-q/query-validate-admin
+                                backend tx auth-input)]
+          (if (uuid? result)
+            (let [input (admin-input/update-admin-password-input
+                         username new-password)]
+              (admin-cmd/update-admin-password! backend tx input))
+            {:result result})))))
 
   adp/APIKeyManager
   (-create-api-keys

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -273,16 +273,16 @@
       (jdbc/with-transaction [tx conn]
         (admin-cmd/ensure-admin-oidc! backend tx input))))
   (-update-admin-password
-    [this username old-password new-password]
+    [this account-id old-password new-password]
     (let [conn       (lrs-conn this)
-          auth-input (admin-input/query-validate-admin-input
-                      username old-password)]
+          auth-input (admin-input/query-validate-admin-by-id-input
+                      account-id old-password)]
       (jdbc/with-transaction [tx conn]
         (let [{:keys [result]} (admin-q/query-validate-admin
                                 backend tx auth-input)]
           (if (uuid? result)
             (let [input (admin-input/update-admin-password-input
-                         username new-password)]
+                         account-id new-password)]
               (admin-cmd/update-admin-password! backend tx input))
             {:result result})))))
 

--- a/src/test/lrsql/admin/protocol_test.clj
+++ b/src/test/lrsql/admin/protocol_test.clj
@@ -96,7 +96,7 @@
                              :result)
             new-password "iLoveNoSql"]
         (testing "Valid update"
-          (adp/-update-admin-password lrs test-username test-password new-password)
+          (adp/-update-admin-password lrs account-id test-password new-password)
           (is (-> (adp/-authenticate-account lrs
                                              test-username
                                              new-password)
@@ -104,12 +104,12 @@
                   (= account-id))))
         (testing "Invalid update"
           (is (-> (adp/-update-admin-password
-                   lrs test-username "iLoveMongoDB" test-password)
+                   lrs account-id "iLoveMongoDB" test-password)
                   :result
                   (= :lrsql.admin/invalid-password-error))))
         ;; Change it back for subsequent tests
         (adp/-update-admin-password
-         lrs test-username new-password test-password)))
+         lrs account-id new-password test-password)))
     (testing "Admin account deletion"
       (let [account-id (-> (adp/-authenticate-account lrs
                                                       test-username

--- a/src/test/lrsql/admin/protocol_test.clj
+++ b/src/test/lrsql/admin/protocol_test.clj
@@ -89,6 +89,27 @@
         (is (adp/-existing-account? lrs account-id)))
       (let [bad-account-id #uuid "00000000-0000-4000-8000-000000000000"]
         (is (not (adp/-existing-account? lrs bad-account-id)))))
+    (testing "Admin password update"
+      (let [account-id   (-> (adp/-authenticate-account lrs
+                                                        test-username
+                                                        test-password)
+                             :result)
+            new-password "iLoveNoSql"]
+        (testing "Valid update"
+          (adp/-update-admin-password lrs test-username test-password new-password)
+          (is (-> (adp/-authenticate-account lrs
+                                             test-username
+                                             new-password)
+                  :result
+                  (= account-id))))
+        (testing "Invalid update"
+          (is (-> (adp/-update-admin-password
+                   lrs test-username "iLoveMongoDB" test-password)
+                  :result
+                  (= :lrsql.admin/invalid-password-error))))
+        ;; Change it back for subsequent tests
+        (adp/-update-admin-password
+         lrs test-username new-password test-password)))
     (testing "Admin account deletion"
       (let [account-id (-> (adp/-authenticate-account lrs
                                                       test-username

--- a/src/test/lrsql/admin/route_test.clj
+++ b/src/test/lrsql/admin/route_test.clj
@@ -163,8 +163,7 @@
                            (update-account-password
                             update-head
                             (u/write-json-str payload)))]
-        (is (-> (update-pass! {"username"     "myname"
-                               "old-password" "swordfish"
+        (is (-> (update-pass! {"old-password" "swordfish"
                                "new-password" new-pass})
                 :status
                 (= 200)))
@@ -175,26 +174,17 @@
                 :status
                 (= 200)))
         (testing "with the wrong password"
-          (is (-> (update-pass! {"username"     "myname"
-                                 "old-password" "verywrongpass"
+          (is (-> (update-pass! {"old-password" "verywrongpass"
                                  "new-password" "whocares"})
                   :status
                   (= 401))))
-        (testing "with a nonexistent account"
-          (is (-> (update-pass! {"username"     "jrbobdobbs"
-                                 "old-password" new-pass
-                                 "new-password" "swordfish"})
-                  :status
-                  (= 404))))
         (testing "without a change"
-          (is (-> (update-pass! {"username"     "myname"
-                                 "old-password" new-pass
+          (is (-> (update-pass! {"old-password" new-pass
                                  "new-password" new-pass})
                   :status
                   (= 400))))
         (testing "change it back"
-          (is (-> (update-pass! {"username"     "myname"
-                                 "old-password" new-pass
+          (is (-> (update-pass! {"old-password" new-pass
                                  "new-password" "swordfish"})
                   :status
                   (= 200))))))


### PR DESCRIPTION
[SQL-187] Allow updates to local admin passwords. Admin must provide old password to update.

- [X] Backend
- [X] API
- [X] Frontend - [PR here](https://github.com/yetanalytics/lrs-admin-ui/pull/43)

[SQL-187]: https://yet.atlassian.net/browse/SQL-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ