### PR TITLE
Fixed typo in protocol method

### DIFF
--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -84,7 +84,7 @@
   ;; Queries
   (-query-activity-profile-document [this tx input])
   (-query-activity-profile-document-ids [this tx input])
-  (-query-activity-profile-document-exists [this tx inpu]))
+  (-query-activity-profile-document-exists [this tx input]))
 
 (defprotocol AdminAccountBackend
   ;; Commands


### PR DESCRIPTION
It was in a protocol declaration so it didn't really mess anything up, but still.