### PR TITLE
[SQL-192] - later Java version support

### DIFF
--- a/src/main/lrsql/util/cert.clj
+++ b/src/main/lrsql/util/cert.clj
@@ -23,7 +23,7 @@
    [org.bouncycastle.asn1.x509
     X509Name]))
 
-(defn bc-selfie
+(defn selfie
   [& {:keys [^String dn
              ^Long days
              ^String alg]
@@ -33,7 +33,7 @@
   (let [^KeyPairGenerator kpg         (KeyPairGenerator/getInstance "RSA")
         ^KeyPair key-pair             (.generateKeyPair kpg)
         ^PrivateKey private-key       (.getPrivate key-pair)
-        ^PublicKey public-key       (.getPublic key-pair)
+        ^PublicKey public-key         (.getPublic key-pair)
         ^java.util.Date from          (new java.util.Date)
         ^java.lang.Long to-millis     (-> from .getTime (+ (* days 86400000)))
         ^java.util.Date to            (new java.util.Date to-millis)
@@ -59,7 +59,7 @@
    & selfie-args]
   (let [{:keys
          [^X509CertImpl cert
-          ^KeyPair key-pair]} (apply bc-selfie selfie-args)]
+          ^KeyPair key-pair]} (apply selfie selfie-args)]
     {:keystore (doto (KeyStore/getInstance
                       (KeyStore/getDefaultType))
                  (.load nil nil)

--- a/src/main/lrsql/util/cert.clj
+++ b/src/main/lrsql/util/cert.clj
@@ -12,74 +12,43 @@
     KeyPair
     KeyPairGenerator
     PrivateKey
+    PublicKey
     SecureRandom]
    [java.security.cert
     Certificate]
    [sun.security.x509
-    AlgorithmId
-    CertificateAlgorithmId
-    CertificateSerialNumber
-    CertificateValidity
-    CertificateVersion
-    CertificateX509Key
-    X500Name
-    X509CertImpl
-    X509CertInfo]))
+    X509CertImpl]
+   [org.bouncycastle.x509
+    X509V3CertificateGenerator]
+   [org.bouncycastle.asn1.x509
+    X509Name]))
 
-;; a la https://stackoverflow.com/a/44738069/3532563
-(defn selfie
-  "Return a self-signed cert & KeyPair"
+(defn bc-selfie
   [& {:keys [^String dn
              ^Long days
              ^String alg]
-      :or   {dn   "CN=com.yetanalytics.lrsql, OU=Dev, O=Yet Analytics, L=Baltimore, S=Maryland, C=US"
+      :or   {dn   "CN=com.yetanalytics.lrsql,OU=Dev,O=Yet Analytics,L=Baltimore,ST=Maryland,C=US"
              days 365000 ;; 1000 years of darkness
              alg  "SHA256withRSA"}}]
-  (let [;; gen a pair
-        ^KeyPairGenerator kpg         (KeyPairGenerator/getInstance "RSA")
+  (let [^KeyPairGenerator kpg         (KeyPairGenerator/getInstance "RSA")
         ^KeyPair key-pair             (.generateKeyPair kpg)
         ^PrivateKey private-key       (.getPrivate key-pair)
+        ^PublicKey public-key       (.getPublic key-pair)
         ^java.util.Date from          (new java.util.Date)
         ^java.lang.Long to-millis     (-> from .getTime (+ (* days 86400000)))
         ^java.util.Date to            (new java.util.Date to-millis)
-        ^CertificateValidity interval (new CertificateValidity from to)
         ^BigInteger sn                (new BigInteger 64 (new SecureRandom))
-        ^X500Name owner               (new X500Name dn)
-        ^AlgorithmId algo             (new AlgorithmId
-                                           AlgorithmId/md5WithRSAEncryption_oid)
-        ^X509CertInfo info
-        (doto (new X509CertInfo)
-          (.set X509CertInfo/VALIDITY interval)
-          (.set X509CertInfo/SERIAL_NUMBER
-                (new CertificateSerialNumber sn))
-          (.set X509CertInfo/SUBJECT owner)
-          (.set X509CertInfo/ISSUER owner)
-          (.set X509CertInfo/KEY
-                (new CertificateX509Key
-                     (.getPublic key-pair)))
-          (.set X509CertInfo/VERSION
-                (new CertificateVersion
-                     CertificateVersion/V3))
-          (.set X509CertInfo/ALGORITHM_ID
-                (new CertificateAlgorithmId
-                     algo)))
-
-        ^X509CertImpl cert      (doto (new X509CertImpl info)
-                                  ;; Sign the cert to identify the algorithm
-                                  (.sign private-key alg))
-        ;; Update the algorithm, and re-sign.
-        ^AlgorithmId algo-final (.get cert X509CertImpl/SIG_ALG)
-        ;; mutation of the info carried from example :()
-        _                       (.set info
-                                      (format
-                                       "%s.%s"
-                                       CertificateAlgorithmId/NAME
-                                       CertificateAlgorithmId/ALGORITHM)
-                                      algo-final)
-
-        ^X509CertImpl cert-final (doto (new X509CertImpl info)
-                                   (.sign private-key alg))]
-    {:cert     cert-final
+        ^X509Name issuer              (new X509Name dn)
+        generator
+        (doto (new X509V3CertificateGenerator)
+          (.setSerialNumber sn)
+          (.setSubjectDN issuer)
+          (.setIssuerDN issuer)
+          (.setNotBefore from)
+          (.setNotAfter to)
+          (.setSignatureAlgorithm alg)
+          (.setPublicKey public-key))]
+    {:cert     (.generate generator private-key)
      :key-pair key-pair}))
 
 (defn selfie-keystore
@@ -90,7 +59,7 @@
    & selfie-args]
   (let [{:keys
          [^X509CertImpl cert
-          ^KeyPair key-pair]} (apply selfie selfie-args)]
+          ^KeyPair key-pair]} (apply bc-selfie selfie-args)]
     {:keystore (doto (KeyStore/getInstance
                       (KeyStore/getDefaultType))
                  (.load nil nil)

--- a/src/main/lrsql/util/cert.clj
+++ b/src/main/lrsql/util/cert.clj
@@ -24,6 +24,8 @@
     X509Name]))
 
 (defn selfie
+  "Given a string dn, expiry length in days and algorithm type string, return 
+   a self-signed cert & KeyPair"
   [& {:keys [^String dn
              ^Long days
              ^String alg]


### PR DESCRIPTION
- Switched certgen to bouncycastle. It's cleaner anyway

Can anyone who reviews this please test it on whatever random JDKs they have locally? Over here I've done openjdk11 and 16.0/20