### PR TITLE
Add `-x 1.0.3` flag to conformance tests

### DIFF
--- a/src/test/lrsql/conformance_test.clj
+++ b/src/test/lrsql/conformance_test.clj
@@ -27,5 +27,6 @@
           (is (conf/conformant?
                "-e" url "-b" "-z" "-a"
                "-u" "username"
-               "-p" "password"))
+               "-p" "password"
+               "-x" "1.0.3"))
           (component/stop sys'))))))


### PR DESCRIPTION
This was needed after the lrs-conformance-test repo was updated to 2.0.0, which uses xAPI version 2.0.0.0 as its default