### PR TITLE
Reaction batch insert concurrency issue

### DIFF
--- a/src/main/lrsql/ops/query/reaction.clj
+++ b/src/main/lrsql/ops/query/reaction.clj
@@ -46,13 +46,14 @@
                  :message error-message}})
 
 (defn- reaction-query
-  [bk tx ruleset reaction-id trigger-id statement-identity]
+  [bk tx ruleset reaction-id trigger-id trigger-stored statement-identity]
   (try
     [true (ur/query-reaction
            bk
            tx
            {:ruleset            ruleset
             :trigger-id         trigger-id
+            :trigger-stored     trigger-stored
             :statement-identity statement-identity})]
     (catch Exception ex
       (log/errorf
@@ -112,9 +113,11 @@
                                          identityPaths statement)]
                  (if-not statement-identity
                    [] ;; ignore
-                   (let [[q-success ?q-result-or-error]
+                   (let [stored (get statement "stored")
+                         [q-success ?q-result-or-error]
                          (reaction-query
-                          bk tx ruleset reaction-id trigger-id statement-identity)]
+                          bk tx ruleset reaction-id trigger-id stored
+                          statement-identity)]
                      (if (false? q-success)
                        ;; Query Error
                        [?q-result-or-error]

--- a/src/main/lrsql/ops/util/reaction.clj
+++ b/src/main/lrsql/ops/util/reaction.clj
@@ -120,21 +120,35 @@
 (s/fdef render-ground
   :args (s/cat :bk rs/reaction-backend?
                :condition-names (s/every ::rs/condition-name)
-               :trigger-id ::rs/trigger-id)
+               :trigger-id ::rs/trigger-id
+               :trigger-stored ::rs/trigger-stored)
   :ret ::rs/sqlvec)
 
 (defn- render-ground
-  [bk condition-names trigger-id]
-  (bp/-snip-or
+  [bk condition-names trigger-id trigger-stored]
+  (bp/-snip-and
    bk
-   {:clauses (mapv
-              (fn [k]
-                (bp/-snip-clause
-                 bk
-                 {:left  (render-col bk k "statement_id")
-                  :op    "="
-                  :right (bp/-snip-val bk {:val trigger-id})}))
-              condition-names)}))
+   {:clauses
+    (conj
+     ;; ensure that all stmts are stored at or before trigger stmt stored time
+     (mapv (fn [k]
+             (bp/-snip-clause
+              bk
+              {:left  (render-col bk k "stored")
+               :op    "<="
+               :right (bp/-snip-val bk {:val trigger-stored})}))
+           condition-names)
+     ;; ensure that at least one statement is the trigger stmt
+     (bp/-snip-or
+      bk
+      {:clauses (mapv
+                 (fn [k]
+                   (bp/-snip-clause
+                    bk
+                    {:left  (render-col bk k "statement_id")
+                     :op    "="
+                     :right (bp/-snip-val bk {:val trigger-id})}))
+                 condition-names)}))}))
 
 (s/fdef query-reaction-sqlvec
   :args (s/cat :bk rs/reaction-backend?
@@ -145,6 +159,7 @@
   [bk
    {{:keys [conditions]} :ruleset
     :keys                [trigger-id
+                          trigger-stored
                           statement-identity]}]
   (let [condition-names (map name (keys conditions))]
     (bp/-snip-query-reaction
@@ -165,7 +180,7 @@
               (concat
                (when (seq statement-identity)
                  [(render-identity bk condition-names statement-identity)])
-               [(render-ground bk condition-names trigger-id)]
+               [(render-ground bk condition-names trigger-id trigger-stored)]
                (map
                 (fn [[condition-key condition]]
                   (render-condition

--- a/src/main/lrsql/spec/reaction.clj
+++ b/src/main/lrsql/spec/reaction.clj
@@ -98,6 +98,8 @@
 
 (s/def ::trigger-id uuid?)
 
+(s/def ::trigger-stored ::xs/timestamp)
+
 (s/def ::active boolean?)
 
 (s/def ::primary-key uuid?)
@@ -126,6 +128,7 @@
 (def query-reaction-input-spec
   (s/keys :req-un [::ruleset
                    ::trigger-id
+                   ::trigger-stored
                    ::statement-identity]))
 
 (def query-statement-reactions-input-spec

--- a/src/test/lrsql/ops/util/reaction_test.clj
+++ b/src/test/lrsql/ops/util/reaction_test.clj
@@ -31,22 +31,29 @@
 (use-fixtures :once support/instrumentation-fixture)
 (use-fixtures :each support/fresh-db-fixture)
 
+(defn- stored-by-stmt
+  [stmts stmt]
+  (-> (filter #(= (get % "id") (get stmt "id")) stmts)
+      first
+      (get "stored")))
+
 (deftest query-reaction-test
-  (let [sys  (support/test-system
-              :conf-overrides
-              {[:lrs :enable-reactions] false})
-        sys' (component/start sys)
-        lrs  (-> sys' :lrs)
-        bk   (:backend lrs)
-        ds   (-> sys' :lrs :connection :conn-pool)]
-
-    (doseq [s [tc/reaction-stmt-d
-               tc/reaction-stmt-a
-               tc/reaction-stmt-b
-               tc/reaction-stmt-c]]
-      (Thread/sleep 100)
-      (lrsp/-store-statements lrs tc/auth-ident [s] []))
-
+  (let [sys    (support/test-system
+                :conf-overrides
+                {[:lrs :enable-reactions] false})
+        sys'   (component/start sys)
+        lrs    (-> sys' :lrs)
+        bk     (:backend lrs)
+        ds     (-> sys' :lrs :connection :conn-pool)
+        _      (doseq [s [tc/reaction-stmt-d
+                          tc/reaction-stmt-a
+                          tc/reaction-stmt-b
+                          tc/reaction-stmt-c]]
+                 (Thread/sleep 100)
+                 (lrsp/-store-statements lrs tc/auth-ident [s] []))
+        stmts  (-> (lrsp/-get-statements lrs tc/auth-ident {} [])
+                   :statement-result
+                   :statements)]
     (try
       (testing "Returns relevant statements"
         (let [query-result (ur/query-reaction
@@ -54,6 +61,9 @@
                             {:ruleset    tc/simple-reaction-ruleset
                              :trigger-id (u/str->uuid
                                           (get tc/reaction-stmt-b "id"))
+                             :trigger-stored (stored-by-stmt
+                                              stmts
+                                              tc/reaction-stmt-b)
                              :statement-identity
                              {["actor" "mbox"] "mailto:bob@example.com"}})]
           ;; unambiguous, finds only a single row with a and b
@@ -67,8 +77,11 @@
                             {:ruleset
                              (merge tc/simple-reaction-ruleset
                                     {:identityPaths []})
-                             :trigger-id         (u/str->uuid
-                                                  (get tc/reaction-stmt-b "id"))
+                             :trigger-id     (u/str->uuid
+                                              (get tc/reaction-stmt-b "id"))
+                             :trigger-stored (stored-by-stmt
+                                              stmts
+                                              tc/reaction-stmt-b)
                              :statement-identity {}})]
           ;; ambiguous, finds a and b but ALSO d and b
           (is (= 2 (count query-result)))))
@@ -87,6 +100,9 @@
                                          :val  "bar"}]}}})
                              :trigger-id (u/str->uuid
                                           (get tc/reaction-stmt-d "id"))
+                             :trigger-stored (stored-by-stmt
+                                              stmts
+                                              tc/reaction-stmt-d)
                              :statement-identity
                              {["actor" "mbox"] "mailto:alice@example.com"}})]
           (is (= 1 (count query-result)))
@@ -109,6 +125,9 @@
                                          :val  1000}]}}})
                              :trigger-id (u/str->uuid
                                           (get tc/reaction-stmt-d "id"))
+                             :trigger-stored (stored-by-stmt
+                                              stmts
+                                              tc/reaction-stmt-d)
                              :statement-identity
                              {["actor" "mbox"] "mailto:alice@example.com"}})]
           (is (= 1 (count query-result)))
@@ -138,8 +157,8 @@
                                     :message "Unknown Query Error!"})))
       (testing "Finds only active reactions"
         (is (= [{:ruleset tc/simple-reaction-ruleset}]
-                 (->> (ur/query-active-reactions bk ds)
-                      (map #(select-keys % [:ruleset]))))))
+               (->> (ur/query-active-reactions bk ds)
+                    (map #(select-keys % [:ruleset]))))))
       (finally (component/stop sys')))))
 
 (deftest query-reaction-history-test
@@ -164,7 +183,7 @@
                            tc/reaction-stmt-b
                            tc/reaction-stmt-c
                            tc/reaction-stmt-d]]
-                     (u/str->uuid (get stmt "id")))]
+                 (u/str->uuid (get stmt "id")))]
 
     ;; store a statements with chained reaciton data
     (lrsp/-store-statements lrs
@@ -186,9 +205,9 @@
     (try
       (testing "Finds the reaction-history of each statement"
         (are [stmt-id reactions]
-            (= {:result reactions}
-               (ur/query-reaction-history
-                bk ds {:statement-id stmt-id}))
+             (= {:result reactions}
+                (ur/query-reaction-history
+                 bk ds {:statement-id stmt-id}))
           a-id #{}
           b-id #{reaction-0-id}
           c-id #{reaction-0-id reaction-1-id}


### PR DESCRIPTION
Added another condition to make sure only statements prior to trigger are used, in case a batch insert or another thread inserts while trigger is waiting to be processed. This necessitated updating a bunch of tests and stuff.