### PR TITLE
Update Pedestal to v0.6.2 to address CVEs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -24,22 +24,7 @@
   com.zaxxer/HikariCP                      {:mvn/version "5.0.0"
                                             :exclusions  [org.slf4j/slf4j-api]}
   ;; Pedestal and Jetty webserver deps 
-  io.pedestal/pedestal.jetty
-  {:mvn/version "0.6.1"
-   :exclusions
-   [org.eclipse.jetty/jetty-server
-    org.eclipse.jetty/jetty-servlet
-    org.eclipse.jetty.alpn/alpn-api
-    org.eclipse.jetty/jetty-alpn-server
-    org.eclipse.jetty.http2/http2-server
-    org.eclipse.jetty.websocket/websocket-api
-    org.eclipse.jetty.websocket/websocket-servlet
-    org.eclipse.jetty.websocket/websocket-server]}
-  org.eclipse.jetty/jetty-server           {:mvn/version "9.4.53.v20231009"}
-  org.eclipse.jetty/jetty-servlet          {:mvn/version "9.4.53.v20231009"}
-  org.eclipse.jetty.alpn/alpn-api          {:mvn/version "1.1.3.v20160715"}
-  org.eclipse.jetty/jetty-alpn-server      {:mvn/version "9.4.53.v20231009"}
-  org.eclipse.jetty.http2/http2-server     {:mvn/version "9.4.53.v20231009"}
+  io.pedestal/pedestal.jetty               {:mvn/version "0.6.2"}
   org.eclipse.jetty/jetty-alpn-java-server {:mvn/version "9.4.53.v20231009"}
   ;; Security deps
   buddy/buddy-core    {:mvn/version "1.11.418"


### PR DESCRIPTION
Update Pedestal to address [these CVEs](https://github.com/pedestal/pedestal/issues/763).

NOTE: For now this keeps Jetty at v9.x.x, but in the long term Pedestal's Jetty version will be updated to v11.x.x, so we will need to prepare for this eventuality.