### PR TITLE
Fix in-memory SQLite bug where DB is deleted upon connection close

### DIFF
--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -39,21 +39,24 @@ The following environment variables are aliases for [HikariCP properties](https:
 | `LRSQL_POOL_IDLE_TIMEOUT`                | `poolIdleTimeout`               | `600000`          | `≥ 10000` or `0`                                                                                                                                   |
 | `LRSQL_POOL_VALIDATION_TIMEOUT`          | `poolValidationTimeout`         | `5000`            | `≥ 250`, less than `poolConnectionTimeout`                                                                                                         |
 | `LRSQL_POOL_INITIALIZATION_FAIL_TIMEOUT` | `poolInitializationFailTimeout` | `1`               | Any integer                                                                                                                                        |
-| `LRSQL_POOL_MAX_LIFETIME`                | `poolMaxLifetime`               | `1800000`         | `≥ 30000` or `0`                                                                                                                                   |
-| `LRSQL_POOL_MINIMUM_IDLE`                | `poolMinimumIdle`               | `1`\* or `10`\*\* | `≥ 0`                                                                                                                                              |
-| `LRSQL_POOL_MAXIMUM_SIZE`                | `poolMaximumSize`               | `1`\* or `10`\*\* | `≥ 1`                                                                                                                                              |
+| `LRSQL_POOL_MAX_LIFETIME`                | `poolMaxLifetime`               | `1800000` or `0`\*\*         | `≥ 30000` or `0`                                                                                                                                   |
+| `LRSQL_POOL_MINIMUM_IDLE`                | `poolMinimumIdle`               | `1`\* or `10`\*\*\* | `≥ 0`                                                                                                                                              |
+| `LRSQL_POOL_MAXIMUM_SIZE`                | `poolMaximumSize`               | `1`\* or `10`\*\*\* | `≥ 1`                                                                                                                                              |
 | `LRSQL_POOL_ISOLATE_INTERNAL_QUERIES`    | `poolIsolateInternalQueries`    | `false`           | `true`/`false`                                                                                                                                     |
 | `LRSQL_POOL_LEAK_DETECTION_THRESHOLD`    | `poolLeakDetectionThreshold`    | `0`†              | `≥ 2000` or `0`                                                                                                                                    |
 | `LRSQL_POOL_TRANSACTION_ISOLATION`       | `poolTransactionIsolation`      | Not set           | [JDBC Connection constant](https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/java/sql/Connection.html) (e.g. `TRANSACTION_SERIALIZABLE`) |
 | `LRSQL_POOL_NAME`                        | `poolName`                      | Not set           | Any string                                                                                                                                         |
 
 \* SQLite default.
-\*\* Postgres default.
+\*\* SQLite in-memory default.
+\*\*\* Postgres default.
 † The property is set to be disabled by default.
 
 _NOTE 1:_ SQLite uses different defaults for `poolMinimumIdle` and `poolMaximumSize` than Postgres due to issues with multi-threading with those DBMSs. Setting `poolMaximumSize` to values other than `1` will potentially cause exceptions when running concurrent operations.
 
-_NOTE 2:_ None of the DBMSs that SQL LRS currently supports allow for `TRANSACTION_NONE` as a `poolTransactionIsolation` value.
+_NOTE 2:_ SQLite, while in in-memory mode, automatically deletes the database whenever the connection is removed, which can occur if a connection is closed and `maxLifetime` is exceeded. Thus, `maxLifetime` is set to `0`, denoting infinite connection lifetime, for convenience.
+
+_NOTE 3:_ None of the DBMSs that SQL LRS currently supports allow for `TRANSACTION_NONE` as a `poolTransactionIsolation` value.
 
 #### Metric Reporting via JMX
 

--- a/resources/lrsql/config/config.edn
+++ b/resources/lrsql/config/config.edn
@@ -30,7 +30,7 @@
  #profile
   {;; Test/Dev
    :test-sqlite     #include "test/default/connection.edn"
-   :test-sqlite-mem #include "test/default/connection.edn"
+   :test-sqlite-mem #include "test/sqlite_mem/connection.edn"
    :test-postgres   #include "test/postgres/connection.edn"
    :test-oidc       #include "test/default/connection.edn"
    ;; Production

--- a/resources/lrsql/config/config.edn
+++ b/resources/lrsql/config/config.edn
@@ -35,7 +35,7 @@
    :test-oidc       #include "test/default/connection.edn"
    ;; Production
    :prod-sqlite     #include "prod/default/connection.edn"
-   :prod-sqlite-mem #include "prod/default/connection.edn"
+   :prod-sqlite-mem #include "prod/sqlite_mem/connection.edn"
    :prod-postgres   #include "prod/postgres/connection.edn"}
  :tuning
  #profile

--- a/resources/lrsql/config/prod/sqlite_mem/connection.edn
+++ b/resources/lrsql/config/prod/sqlite_mem/connection.edn
@@ -1,0 +1,6 @@
+;; SQLite deletes the in-mem DB whenever a connection closes, which by default
+;; happens after 30 min/1800000 ms, so we set it to 0 to make the lifetime
+;; infinite.
+#merge
+ [#include "prod/default/connection.edn"
+  {:pool-max-lifetime #long #or [#env LRSQL_POOL_MAX_LIFETIME 0]}]

--- a/resources/lrsql/config/test/sqlite_mem/connection.edn
+++ b/resources/lrsql/config/test/sqlite_mem/connection.edn
@@ -1,0 +1,6 @@
+;; SQLite deletes the in-mem DB whenever a connection closes, which by default
+;; happens after 30 min/1800000 ms, so we set it to 0 to make the lifetime
+;; infinite.
+#merge
+ [#include "test/default/connection.edn"
+  {:pool-max-lifetime 0}]


### PR DESCRIPTION
When a HikariCP (or any JDBC connection) is closed, the entire database is deleted, as explained in [this article](https://grishaev.me/en/clj-sqlite/):

> The thing is, JDBC does not track DB connections by default. Every time you call for (jdbc/*) function, you create a new connection, perform an operation and close it. For such persistent data storages like Postgres or MySQL that’ fine although not effective (in our project, we use HikariCP to have a pool of open connections).
>
> **But for in-memory SQLite database, closing a connection to it leads to wiping the data completely out form the RAM.** So you need to track the connection in more precision way. You will create a connection by yourself and close it when the work is done.

In HikariCP, a connection is open for the duration of the `maxLifetime` property, after which it is closed and removed, thus deleting the SQLite in-memory database. This PR fixes it by setting `maxLifetime` to infinity (denoted by `0`) specifically for SQLite in-memory mode. 




