### PR TITLE
Update Logback to 1.3.14

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
   danlentz/clj-uuid                        {:mvn/version "0.1.9"}
   aero/aero                                {:mvn/version "1.1.6"}
   selmer/selmer                            {:mvn/version "1.12.59"}
-  ch.qos.logback/logback-classic           {:mvn/version "1.3.13"}
+  ch.qos.logback/logback-classic           {:mvn/version "1.3.14"}
   ;; DB/JDBC deps
   ;; - HikariCP: Need to exclude slf4j to make logback work properly
   ;; - HugSql: Use custom version instead of the released version (0.5.1)

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -54,7 +54,7 @@ The following environment variables are aliases for [HikariCP properties](https:
 
 _NOTE 1:_ SQLite uses different defaults for `poolMinimumIdle` and `poolMaximumSize` than Postgres due to issues with multi-threading with those DBMSs. Setting `poolMaximumSize` to values other than `1` will potentially cause exceptions when running concurrent operations.
 
-_NOTE 2:_ SQLite, while in in-memory mode, automatically deletes the database whenever the connection is removed, which can occur if a connection is closed and `maxLifetime` is exceeded. Thus, `maxLifetime` is set to `0`, denoting infinite connection lifetime, for convenience.
+_NOTE 2:_ SQLite, while in in-memory mode, automatically deletes the database whenever the connection is removed, which can occur if a connection is closed and `poolMaxLifetime` is exceeded. Thus, `poolMaxLifetime` is set to `0`, denoting infinite connection lifetime, for convenience.
 
 _NOTE 3:_ None of the DBMSs that SQL LRS currently supports allow for `TRANSACTION_NONE` as a `poolTransactionIsolation` value.
 


### PR DESCRIPTION
Update Logback to 1.3.14 to address CVE-2023-6481. Note that the underlying vulnerability was actually fixed in the previous update, but we still need to update for a more complete fix. From the [Logback website](https://logback.qos.ch/news.html#1.3.14):

> More complete fix for CVE-2023-6378 both for the 1.4.x series and the 1.3.x series...In order to encourage users to upgrade to versions 1.3.14/1.4.14 CVE-2023-6481 has been created even though the underlying vulnerability for both CVE records is identical.

In addition, we update the config variable name `maxLifetime` to `poolMaxLifetime` in the documentation, to address a naming oversight from the last update.