### PR TITLE
SQL-211 make identityPaths fuzzier

### DIFF
--- a/src/main/lrsql/util/reaction.clj
+++ b/src/main/lrsql/util/reaction.clj
@@ -56,7 +56,7 @@
                            m))
                        {}
                        identity-paths)]
-      (when (and found-paths (not (empty? found-paths)))
+      (when (seq found-paths)
         found-paths))))
 
 (s/fdef add-reaction-metadata

--- a/src/main/lrsql/util/reaction.clj
+++ b/src/main/lrsql/util/reaction.clj
@@ -41,19 +41,23 @@
 
 (defn statement-identity
   "Given a vector of identity paths and a statement, return a map of paths to
-  values. Return nil if any are missing or a collection is found."
+  values. Return nil if no specified paths or a collection is found."
   [identity-paths
    statement]
-  (reduce
-   (fn [m path]
-     (if-some [found-val (get-in statement
-                                 path)]
-       (if (coll? found-val)
-         (reduced nil)
-         (assoc m path found-val))
-       (reduced nil)))
-   {}
-   identity-paths))
+  (if (empty? identity-paths)
+    {} ;; empty explicitly covers all statements
+    (let [found-paths (reduce
+                       (fn [m path]
+                         (if-some [found-val (get-in statement
+                                                     path)]
+                           (if (coll? found-val)
+                             (reduced nil)
+                             (assoc m path found-val))
+                           m))
+                       {}
+                       identity-paths)]
+      (when (and found-paths (not (empty? found-paths)))
+        found-paths))))
 
 (s/fdef add-reaction-metadata
   :args (s/cat :statement ::xs/statement

--- a/src/test/lrsql/util/reaction_test.clj
+++ b/src/test/lrsql/util/reaction_test.clj
@@ -40,13 +40,26 @@
     {["actor" "mbox"] "mailto:bob@example.com"}
 
     [["actor" "mbox"]
+     ["actor" "mbox_sha1sum"]
+     ["actor" "openid"]
+     ["actor" "account" "homePage"]
+     ["actor" "account" "name"]]
+    {["actor" "mbox"] "mailto:bob@example.com"}
+
+    [["actor" "mbox"]
      ["context" "registration"]]
     {["actor" "mbox"]           "mailto:bob@example.com"
      ["context" "registration"] "6fbd600f-d17c-4c74-801a-2ec2e53231f7"}
 
     [["actor" "openid"]
      ["context" "registration"]]
-    nil))
+    {["context" "registration"] "6fbd600f-d17c-4c74-801a-2ec2e53231f7"}
+
+    [["actor" "openid"]]
+    nil
+
+    []
+    {}))
 
 (deftest add-reaction-metadata-test
   (let [reaction-id (u/generate-squuid)


### PR DESCRIPTION
[SQL-211] Previously identityPaths would not resolve if any were not found. Now they will resolve if _at least one_ is found.

[SQL-211]: https://yet.atlassian.net/browse/SQL-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ