### PR TITLE
Temporary (read: BAD) fix to casing issue in Reactions template vars

### DIFF
--- a/src/main/lrsql/util/reaction.clj
+++ b/src/main/lrsql/util/reaction.clj
@@ -5,6 +5,7 @@
             [lrsql.spec.common :as cs]
             [lrsql.spec.reaction :as rs]
             [lrsql.spec.statement :as ss]
+            [clojure.string :refer [lower-case]]
             [xapi-schema.spec :as xs]))
 
 (s/fdef path->string
@@ -80,7 +81,10 @@
   (walk/postwalk #(if (and (map? %)
                            (= (key (first %)) "$templatePath"))
                     (let [input-path (val (first %))
-                          path (update input-path 0 keyword)
+                          path (update input-path 0 (fn [cn]
+                                                      (-> cn 
+                                                          lower-case 
+                                                          keyword)))
                           result (get-in cond->statement path :not-found)]
                       (case result
                         :not-found (throw (ex-info (str "No value found at " input-path)


### PR DESCRIPTION
@milt @invaliduser I have uncovered an issue in reactions that is breaking UI testing, and I'm not sure how it even went unnoticed by both of us. For whatever reason SQLite does not respect alias case at all, so when you do something like:

```
SELECT condition_XAZ.payload as condition_XAZ
FROM xapi_statement as condition_XAZ
WHERE ((json_extract(condition_XAZ.payload, ?) = ?) AND (condition_XAZ.stored <= ? AND (condition_XAZ.statement_id = ?)) AND json_extract(condition_XAZ.payload, ?) = ?);
```
(and BTW the default generated titles of conditions have caps) - The actual edn row data returned from SQL ends up throwing out the case:

```
{:condition_xaz ...}
```

Which is fine except the canonical name/key for the condition is `condition_XAZ`, and that is what is used to perform variable injection. It concerns me that SQL is just doing whatever weird column conversion stuff it does, like what about whitespace or special characters etc. It makes me nervous that users are directly inputting something that is the query pivot of all the variable injection. I tried using double quotes on the alias because most SQL engines respect that to mean "absolutely do not mess with this alias" but alas SQLite explicitly does not support that trick.

This fix sorta kinda works for me to continue my work today, but it's extremely naive. We may need to think a bit on this one.