### PR TITLE
SQL-224 Reactions: encode condition names

### DIFF
--- a/src/test/lrsql/util/reaction_test.clj
+++ b/src/test/lrsql/util/reaction_test.clj
@@ -144,8 +144,8 @@
            (r/encode-condition-name "foo")))
     (is (not= (r/encode-condition-name "foo")
               (r/encode-condition-name "bar"))))
-  (testing "alphanumeric"
-    (is (re-matches #"[a-z0-9\_]*" (r/encode-condition-name "foo"))))
+  (testing "alphanumeric valid col name"
+    (is (re-matches #"[a-z][a-z0-9\_]*" (r/encode-condition-name "foo"))))
   (testing "reversible"
     (is (-> "foo"
             r/encode-condition-name

--- a/src/test/lrsql/util/reaction_test.clj
+++ b/src/test/lrsql/util/reaction_test.clj
@@ -137,3 +137,17 @@
            {:data  {:type :lrsql.util.reaction/invalid-path
                     :path ["completed_a" "actor" "birthday"]}
             :cause "No value found at [\"completed_a\" \"actor\" \"birthday\"]"}))))
+
+(deftest encode-condition-name-test
+  (testing "unique"
+    (is (= (r/encode-condition-name "foo")
+           (r/encode-condition-name "foo")))
+    (is (not= (r/encode-condition-name "foo")
+              (r/encode-condition-name "bar"))))
+  (testing "alphanumeric"
+    (is (re-matches #"[a-z0-9\_]*" (r/encode-condition-name "foo"))))
+  (testing "reversible"
+    (is (-> "foo"
+            r/encode-condition-name
+            r/decode-condition-name
+            (= "foo")))))


### PR DESCRIPTION
[SQL-224] Encode condition names so invalid SQL is not produced.

[SQL-224]: https://yet.atlassian.net/browse/SQL-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ