### PR TITLE
Update Cheshire to 5.12.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
   ;; Util deps
 
   camel-snake-kebab/camel-snake-kebab      {:mvn/version "0.4.2"}
-  cheshire/cheshire                        {:mvn/version "5.11.0"}
+  cheshire/cheshire                        {:mvn/version "5.12.0"}
   clojure.java-time/clojure.java-time      {:mvn/version "1.2.0"}
   danlentz/clj-uuid                        {:mvn/version "0.1.9"}
   aero/aero                                {:mvn/version "1.1.6"}


### PR DESCRIPTION
Updates the Cheshire library to 5.12.0 to use the latest version of Jackson.