### PR TITLE
SQL-230 add logout redirect url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Version of LRS Admin UI to use
 
-LRS_ADMIN_UI_VERSION ?= v0.1.14
+LRS_ADMIN_UI_VERSION ?= v0.1.15
 LRS_ADMIN_UI_LOCATION ?= https://github.com/yetanalytics/lrs-admin-ui/releases/download/${LRS_ADMIN_UI_VERSION}/lrs-admin-ui.zip
 LRS_ADMIN_ZIPFILE ?= lrs-admin-ui-${LRS_ADMIN_UI_VERSION}.zip
 

--- a/doc/env_vars.md
+++ b/doc/env_vars.md
@@ -148,6 +148,7 @@ _NOTE:_ `LRSQL_STMT_RETRY_LIMIT` and `LRSQL_STMT_RETRY_BUDGET` are used to mitig
 | `LRSQL_JWT_NO_VAL_ISSUER`         | `jwtNoValIssuer`         | (**DANGEROUS!** See `LRSQL_JWT_NO_VAL`) This variable configures which claim key to use for the issuer when token validation is turned off.    | Not Set |
 | `LRSQL_JWT_NO_VAL_ROLE_KEY`       | `jwtNoValRoleKey`        | (**DANGEROUS!** See `LRSQL_JWT_NO_VAL`) This variable configures which claim key to look in for the role when token validation is turned off.    | Not Set |
 | `LRSQL_JWT_NO_VAL_ROLE`           | `jwtNoValRole`           | (**DANGEROUS!** See `LRSQL_JWT_NO_VAL`) This variable configures what role must be present in the key above when token validation is turned off.    | Not Set |
+| `LRSQL_JWT_NO_VAL_LOGOUT_URL`     | `jwtNoValLogoutUrl`      | (**DANGEROUS!** See `LRSQL_JWT_NO_VAL`) This variable specifies a logout URL that the client will redirect to on user logout when token validation is turned off. | Not Set |
 
 #### OIDC
 

--- a/resources/lrsql/config/prod/default/webserver.edn
+++ b/resources/lrsql/config/prod/default/webserver.edn
@@ -11,6 +11,7 @@
  :jwt-no-val-issuer         #or [#env LRSQL_JWT_NO_VAL_ISSUER nil]
  :jwt-no-val-role-key       #or [#env LRSQL_JWT_NO_VAL_ROLE_KEY nil]
  :jwt-no-val-role           #or [#env LRSQL_JWT_NO_VAL_ROLE nil]
+ :jwt-no-val-logout-url     #or [#env LRSQL_JWT_NO_VAL_LOGOUT_URL nil]
  :sec-head-hsts             #or [#env LRSQL_SEC_HEAD_HSTS nil]
  :sec-head-frame            #or [#env LRSQL_SEC_HEAD_FRAME nil]
  :sec-head-content-type     #or [#env LRSQL_SEC_HEAD_CONTENT_TYPE nil]

--- a/resources/lrsql/config/test/default/webserver.edn
+++ b/resources/lrsql/config/test/default/webserver.edn
@@ -9,6 +9,7 @@
  :jwt-no-val-issuer         nil
  :jwt-no-val-role-key       nil
  :jwt-no-val-role           nil
+ :jwt-no-val-logout-url     nil
  :enable-http               true
  :enable-http2              true
  :ssl-port                  8443

--- a/src/main/lrsql/admin/interceptors/ui.clj
+++ b/src/main/lrsql/admin/interceptors/ui.clj
@@ -15,7 +15,12 @@
   config to inject:
     :enable-admin-status - boolean, determines if the admin status endpoint is
       enabled."
-  [{:keys [enable-admin-delete-actor enable-admin-status enable-reactions no-val? proxy-path]
+  [{:keys [enable-admin-delete-actor
+           enable-admin-status
+           enable-reactions
+           no-val?
+           no-val-logout-url
+           proxy-path]
     :or   {enable-admin-delete-actor false
            enable-admin-status false
            enable-reactions    false
@@ -32,11 +37,14 @@
                {:status 200
                 :body
                 (merge
-                 {:url-prefix                url-prefix
-                  :proxy-path                proxy-path
-                  :enable-stmt-html          (some? enable-stmt-html)
-                  :enable-admin-delete-actor enable-admin-delete-actor
-                  :enable-admin-status       enable-admin-status
-                  :enable-reactions          enable-reactions
-                  :no-val?                   no-val?}
+                 (cond-> {:url-prefix                url-prefix
+                          :proxy-path                proxy-path
+                          :enable-stmt-html          (some? enable-stmt-html)
+                          :enable-admin-delete-actor enable-admin-delete-actor
+                          :enable-admin-status       enable-admin-status
+                          :enable-reactions          enable-reactions
+                          :no-val?                   no-val?}
+                   (and no-val?
+                        (not-empty no-val-logout-url))
+                   (assoc :no-val-logout-url no-val-logout-url))
                  oidc-env)})))}))

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -190,6 +190,7 @@
            no-val-uname
            no-val-role-key
            no-val-role
+           no-val-logout-url
            enable-admin-delete-actor
            enable-admin-ui
            enable-admin-status
@@ -205,11 +206,11 @@
    routes]
   (let [common-interceptors      (make-common-interceptors lrs head-opts)
         common-interceptors-oidc (into common-interceptors oidc-interceptors)
-        no-val-opts              {:no-val? no-val?
-                                  :no-val-uname no-val-uname
-                                  :no-val-issuer no-val-issuer
+        no-val-opts              {:no-val?         no-val?
+                                  :no-val-uname    no-val-uname
+                                  :no-val-issuer   no-val-issuer
                                   :no-val-role-key no-val-role-key
-                                  :no-val-role no-val-role}]
+                                  :no-val-role     no-val-role}]
     (cset/union routes
                 (when enable-account-routes
                   (admin-account-routes
@@ -220,10 +221,11 @@
                   (admin-ui-routes
                    (into common-interceptors
                          oidc-ui-interceptors)
-                   {:enable-admin-status enable-admin-status
-                    :enable-reactions enable-reaction-routes
-                    :no-val? no-val?
-                    :proxy-path proxy-path
+                   {:enable-admin-status       enable-admin-status
+                    :enable-reactions          enable-reaction-routes
+                    :no-val?                   no-val?
+                    :no-val-logout-url         no-val-logout-url
+                    :proxy-path                proxy-path
                     :enable-admin-delete-actor enable-admin-delete-actor}))
                 (when enable-admin-status
                   (admin-status-routes
@@ -232,4 +234,5 @@
                   (admin-reaction-routes
                    common-interceptors secret leeway no-val-opts))
                 (when enable-admin-delete-actor
-                  (admin-lrs-management-routes common-interceptors-oidc secret leeway no-val-opts)))))
+                  (admin-lrs-management-routes
+                   common-interceptors-oidc secret leeway no-val-opts)))))

--- a/src/main/lrsql/spec/config.clj
+++ b/src/main/lrsql/spec/config.clj
@@ -158,6 +158,7 @@
 (s/def ::jwt-no-val-issuer (s/nilable string?))
 (s/def ::jwt-no-val-role-key (s/nilable string?))
 (s/def ::jwt-no-val-role (s/nilable string?))
+(s/def ::jwt-no-val-logout-url (s/nilable string?))
 
 (s/def ::key-file string?) ; TODO: correct file extension/path?
 (s/def ::key-alias string?)
@@ -225,6 +226,7 @@
                     ::jwt-no-val-issuer
                     ::jwt-no-val-role
                     ::jwt-no-val-role-key
+                    ::jwt-no-val-logout-url
                     ::sec-head-hsts
                     ::sec-head-frame
                     ::sec-head-content-type

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -44,6 +44,7 @@
                 jwt-no-val-issuer
                 jwt-no-val-role-key
                 jwt-no-val-role
+                jwt-no-val-logout-url
                 enable-clamav
                 clamav-host
                 clamav-port]
@@ -87,6 +88,7 @@
                :no-val-uname              jwt-no-val-uname
                :no-val-role-key           jwt-no-val-role-key
                :no-val-role               jwt-no-val-role
+               :no-val-logout-url         jwt-no-val-logout-url
                :secret                    private-key
                :enable-admin-delete-actor enable-admin-delete-actor
                :enable-admin-ui           enable-admin-ui


### PR DESCRIPTION
[SQL-230] When the `jwt-no-val-*` config options are used, `jwt-no-val-logout-url` specifies a URL to redirect to on logout.

~~[UI PR](https://github.com/yetanalytics/lrs-admin-ui/pull/68)~~

[SQL-230]: https://yet.atlassian.net/browse/SQL-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ