### PR TITLE
SQL-231 catch token exceptions in no-val mode

### DIFF
--- a/src/main/lrsql/admin/interceptors/jwt.clj
+++ b/src/main/lrsql/admin/interceptors/jwt.clj
@@ -31,7 +31,9 @@
                          (if (some? username)
                            (:result (adp/-ensure-account-oidc lrs username issuer))
                            result))
-                       (catch Exception _
+                       (catch Exception ex
+                         ;; We want any error here to return a 401, but we log
+                         (log/warnf ex "No-val JWT Error: %s" (ex-message ex))
                          :lrsql.admin/unauthorized-token-error))
                      ;; normal jwt, check signature etc
                      (admin-u/jwt->account-id token secret leeway))]

--- a/src/main/lrsql/admin/interceptors/jwt.clj
+++ b/src/main/lrsql/admin/interceptors/jwt.clj
@@ -31,7 +31,7 @@
                          (if (some? username)
                            (:result (adp/-ensure-account-oidc lrs username issuer))
                            result))
-                       (catch Exception ex_
+                       (catch Exception _
                          :lrsql.admin/unauthorized-token-error))
                      ;; normal jwt, check signature etc
                      (admin-u/jwt->account-id token secret leeway))]

--- a/src/main/lrsql/admin/interceptors/jwt.clj
+++ b/src/main/lrsql/admin/interceptors/jwt.clj
@@ -2,14 +2,15 @@
   (:require [io.pedestal.interceptor :refer [interceptor]]
             [io.pedestal.interceptor.chain :as chain]
             [lrsql.admin.protocol :as adp]
-            [lrsql.util.admin :as admin-u]))
+            [lrsql.util.admin :as admin-u]
+            [clojure.tools.logging :as log]))
 
 ;; NOTE: These interceptors are specifically for JWT validation.
 ;; For JWT generation see `account/generate-jwt`.
 
 (defn validate-jwt
-  "Validate that the header JWT is valid (e.g. not expired and signed properly). 
-   If no-val? is true run an entirely separate decoding that gets the username 
+  "Validate that the header JWT is valid (e.g. not expired and signed properly).
+   If no-val? is true run an entirely separate decoding that gets the username
    and issuer claims, verifies a role and ensures the account if necessary."
   [secret leeway {:keys [no-val? no-val-uname no-val-issuer no-val-role-key
                          no-val-role]}]

--- a/src/main/lrsql/admin/interceptors/jwt.clj
+++ b/src/main/lrsql/admin/interceptors/jwt.clj
@@ -23,13 +23,16 @@
                        admin-u/header->jwt)
             result (if no-val?
                      ;; decode jwt w/o validation and ensure account
-                     (let [{:keys [issuer username] :as result}
-                           (admin-u/proxy-jwt->username-and-issuer
-                            token no-val-uname no-val-issuer no-val-role-key
-                            no-val-role)]
-                       (if (some? username)
-                         (:result (adp/-ensure-account-oidc lrs username issuer))
-                         result))
+                     (try
+                       (let [{:keys [issuer username] :as result}
+                             (admin-u/proxy-jwt->username-and-issuer
+                              token no-val-uname no-val-issuer no-val-role-key
+                              no-val-role)]
+                         (if (some? username)
+                           (:result (adp/-ensure-account-oidc lrs username issuer))
+                           result))
+                       (catch Exception ex_
+                         :lrsql.admin/unauthorized-token-error))
                      ;; normal jwt, check signature etc
                      (admin-u/jwt->account-id token secret leeway))]
         (cond


### PR DESCRIPTION
[SQL-231] If no-val mode is used and no token is present or is malformed we can get an NPE and a 500 response. This change puts a try/catch around the token decoding code that leads to a 401 if there is not a valid token, rather than the 500.

[SQL-231]: https://yet.atlassian.net/browse/SQL-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ