### PR TITLE
Pedestal CVE updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   nvd_scan:
     uses: yetanalytics/workflow-nvd/.github/workflows/nvd-scan.yml@v1
     with:
-      nvd-clojure-version: "3.3.0"
+      nvd-clojure-version: "3.2.0"
       classpath-command: "clojure -Spath -Adb-sqlite:db-postgres"
       nvd-config-filename: ".nvd/config.json"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   nvd_scan:
     uses: yetanalytics/workflow-nvd/.github/workflows/nvd-scan.yml@v1
     with:
-      nvd-clojure-version: "3.2.0"
+      nvd-clojure-version: "3.3.0"
       classpath-command: "clojure -Spath -Adb-sqlite:db-postgres"
       nvd-config-filename: ".nvd/config.json"
 

--- a/.nvd/suppression.xml
+++ b/.nvd/suppression.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <!-- The FP affects the Golang, not Java, version of msgpack -->
-    <suppress>
-        <notes><![CDATA[
-        file name: msgpack-0.6.12.jar
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.msgpack/msgpack@.*$</packageUrl>
-        <cve>CVE-2022-41719</cve>
-    </suppress>
     <!-- This CVE affects a single version of Postgres Server itself, not the driver at all and cannot be patched in this project -->
     <suppress base="true">
         <notes><![CDATA[

--- a/deps.edn
+++ b/deps.edn
@@ -25,7 +25,9 @@
   com.zaxxer/HikariCP                      {:mvn/version "5.0.0"
                                             :exclusions  [org.slf4j/slf4j-api]}
   ;; Pedestal and Jetty webserver deps 
-  io.pedestal/pedestal.jetty               {:mvn/version "0.6.3"}
+  io.pedestal/pedestal.jetty               {:mvn/version "0.6.3"
+                                            :exclusions  [org.eclipse.jetty.http2/http2-server]}
+  org.eclipse.jetty.http2/http2-server     {:mvn/version "9.4.54.v20240208"}
   org.eclipse.jetty/jetty-alpn-java-server {:mvn/version "9.4.54.v20240208"}
   ;; Security deps
   buddy/buddy-core    {:mvn/version "1.11.418"

--- a/deps.edn
+++ b/deps.edn
@@ -25,7 +25,7 @@
   com.zaxxer/HikariCP                      {:mvn/version "5.0.0"
                                             :exclusions  [org.slf4j/slf4j-api]}
   ;; Pedestal and Jetty webserver deps 
-  io.pedestal/pedestal.jetty               {:mvn/version "0.6.2"}
+  io.pedestal/pedestal.jetty               {:mvn/version "0.6.3"}
   org.eclipse.jetty/jetty-alpn-java-server {:mvn/version "9.4.53.v20231009"}
   ;; Security deps
   buddy/buddy-core    {:mvn/version "1.11.418"

--- a/deps.edn
+++ b/deps.edn
@@ -26,7 +26,7 @@
                                             :exclusions  [org.slf4j/slf4j-api]}
   ;; Pedestal and Jetty webserver deps 
   io.pedestal/pedestal.jetty               {:mvn/version "0.6.3"}
-  org.eclipse.jetty/jetty-alpn-java-server {:mvn/version "9.4.53.v20231009"}
+  org.eclipse.jetty/jetty-alpn-java-server {:mvn/version "9.4.54.v20240208"}
   ;; Security deps
   buddy/buddy-core    {:mvn/version "1.11.418"
                        :exclusions [org.bouncycastle/bcprov-jdk18on]}


### PR DESCRIPTION
Update Pedestal to 0.6.3, address CVE-2024-22201, and remove unused NVD suppressions.