### PR TITLE
update to latest clojure to resolve CVE-2024-22871

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src/main" "resources"]
  :deps
  {;; Clojure core deps
-  org.clojure/clojure                      {:mvn/version "1.11.1"}
+  org.clojure/clojure                      {:mvn/version "1.11.2"}
   org.clojure/tools.logging                {:mvn/version "1.1.0"}
   org.clojure/core.memoize                 {:mvn/version "1.0.250"}
   clojure-interop/java.security            {:mvn/version "1.0.5"}


### PR DESCRIPTION
The core team has added mitigation for CVE-2024-22871. Version 1.11.2 of Clojure contains this.