### PR TITLE
Docker image OS upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.14
+FROM alpine:3.19.1
 
 ADD target/bundle /lrsql
-ADD .java_modules /xapipe/.java_modules
+ADD .java_modules /lrsql/.java_modules
 
 # replace the linux runtime via jlink
 RUN apk update \
@@ -10,7 +10,7 @@ RUN apk update \
         && update-ca-certificates \
         && apk add --no-cache openjdk11 \
         && mkdir -p /lrsql/runtimes \
-        && jlink --output /lrsql/runtimes/linux/ --add-modules $(cat /xapipe/.java_modules) \
+        && jlink --output /lrsql/runtimes/linux/ --add-modules $(cat /lrsql/.java_modules) \
         && apk del openjdk11 \
         && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
upgraded alpine to 3.19.1 in order to get openjdk 11.0.22* runtime