### PR TITLE
memoize custom lang map fn

### DIFF
--- a/src/main/lrsql/admin/interceptors/ui.clj
+++ b/src/main/lrsql/admin/interceptors/ui.clj
@@ -47,7 +47,7 @@
                           :enable-reactions          enable-reactions
                           :no-val?                   no-val?
                           :admin-language-code       admin-language-code
-                          :custom-language           custom-language-map}
+                          :custom-language           (custom-language-map)}
                    (and no-val?
                         (not-empty no-val-logout-url))
                    (assoc :no-val-logout-url no-val-logout-url))

--- a/src/main/lrsql/init/localization.clj
+++ b/src/main/lrsql/init/localization.clj
@@ -6,9 +6,13 @@
 (def lang-path
   "lrsql/localization/language.json")
 
-(def custom-language-map
+(defn custom-language-map*
   "The language map function to render customized admin frontend language maps"
+  []
   (-> lang-path
       io/resource
       slurp
       json/parse-string))
+
+(def custom-language-map
+  (memoize custom-language-map*))


### PR DESCRIPTION
Using a def should AOT-compile the custom language map, which we don't want. It doesn't appear to do this in practice, but an explicit memoization of the function will ensure that the language map is customizable at any level of complilation