### PR TITLE
Update build process to use tools.build

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -110,17 +110,15 @@
                                com.yetanalytics/xapi-schema]}}}
   ;; Build alias invoked like clojure -Xbuild uber
   :build
-  {:replace-deps {org.clojure/core.async          {:mvn/version "1.6.673"}
-                  com.github.seancorfield/depstar {:mvn/version "2.1.267"
-                                                   :exclusions [org.clojure/core.async]}}
+  {:replace-deps {io.github.clojure/tools.build {:git/tag "v0.10.0"
+                                                 :git/sha "3a2c484"}}
    :extra-paths  ["src/build"]
    :ns-default   lrsql.build}
   ;; Alias for dev so you can use from repl w/o breakage
   ;; Note the :extra-deps instead of :replace-deps
   :build-dev
-  {:extra-deps  {org.clojure/core.async          {:mvn/version "1.6.673"}
-                 com.github.seancorfield/depstar {:mvn/version "2.1.267"
-                                                  :exclusions [org.clojure/core.async]}}
+  {:extra-deps  {io.github.clojure/tools.build {:git/tag "v0.10.0"
+                                                :git/sha "3a2c484"}}
    :extra-paths ["src/build"]}
   :nvd
   {:replace-deps {nvd-clojure/nvd-clojure {:mvn/version "2.6.0"}}

--- a/src/build/lrsql/build.clj
+++ b/src/build/lrsql/build.clj
@@ -1,35 +1,48 @@
 (ns lrsql.build
   "Build utils for LRSQL artifacts"
-  (:require [hf.depstar :as depstar]))
+  (:require [clojure.tools.build.api :as b]))
 
-(def uber-params
-  {:jar        "target/bundle/lrsql.jar"
-   :aot        true
-   :aliases    [:db-sqlite :db-postgres]
-   :compile-ns :all
-   :no-pom     true
-   ;; Don't ship crypto - shouldn't be included in the build path anyways,
-   ;; but we exclude them here as extra defense.
-   ;; On the other hand, we keep the unobfuscated OSS source code so that users
-   ;; have easy access to it.
-   :exclude    ["^.*jks$"
-                "^.*key$"
-                "^.*pem$"]})
+;; We add the `src/db` subdirectories separately to ensure that all `src` paths
+;; in the code start w/ `lrsql/` (see: the calls to `hugsql.core/def-db-fns`)
+(def src-dirs
+  ["src/main"
+   "resources"
+   "src/db/sqlite"
+   "src/db/postgres"])
+
+(def class-dir
+  "target/classes/")
+
+;; Don't ship crypto - shouldn't be included in the build path anyways,
+;; but we exclude them here as extra defense.
+;; On the other hand, we keep the unobfuscated OSS source code so that users
+;; have easy access to it.
+(def ignored-file-regexes
+  ["^.*jks$"
+   "^.*key$"
+   "^.*pem$"])
+
+(def uberjar-file
+  "target/bundle/lrsql.jar")
+
+(def basis
+  (b/create-basis
+   {:project "deps.edn"
+    :aliases [:db-sqlite :db-postgres]}))
 
 (defn uber
-  "All backends, as an uberjar"
-  [params]
-  (-> uber-params
-      (merge params)
-      (depstar/uberjar)))
-
-(defn uber-manual
-  "All backends, as an uberjar, manually
-  Ensure that target dir is empty prior to use"
-  [params]
-  (-> (merge uber-params
-             {:target-dir "target"})
-      (merge params)
-      (depstar/aot)
-      (assoc :jar-type :uber)
-      (depstar/build)))
+  "Create an Uberjar at `target/bundle/lrsql.jar` that can be executed to
+   run the SQL LRS app, in either SQLite or Postgres mode."
+  [_]
+  (b/copy-dir
+   {:src-dirs   src-dirs
+    :target-dir class-dir
+    :ignores    ignored-file-regexes})
+  (b/compile-clj
+   {:basis     basis
+    :src-dirs  src-dirs
+    :class-dir class-dir})
+  (b/uber
+   {:basis     basis
+    :class-dir class-dir
+    :uber-file uberjar-file}))


### PR DESCRIPTION
The current build process uses the now-deprecated [depstar](https://github.com/seancorfield/depstar) library, so we replace it with the [tools.build](https://github.com/clojure/tools.build/) library.