### PR TITLE
Fix clj-kondo errors and warnings

### DIFF
--- a/src/main/lrsql/backend/data.clj
+++ b/src/main/lrsql/backend/data.clj
@@ -38,8 +38,13 @@
   [json-labels json-kw-labels]
   ;; Note: due to a long-standing bug, the byte array extension needs to come
   ;; first: https://clojure.atlassian.net/browse/CLJ-1381#icft=CLJ-1381
+  ;;
+  ;; Note: clj-kondo does not recognize the use of a non-simple-symbol in
+  ;; `extend-protocol` so we add the ignore (make sure to comment it out if
+  ;; you're editing this code).
+  #_{:clj-kondo/ignore [:syntax]}
   (extend-protocol ReadableColumn
-    (Class/forName "[B")
+    (Class/forName "[B") ; Evaulates to `[B`
     (read-column-by-label [^"[B" b ^String label]
       (parse-json-payload json-labels json-kw-labels label b))
     (read-column-by-index [^"[B" b ^ResultSetMetaData rsmeta ^long i]

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -5,7 +5,6 @@
             [io.pedestal.http :as http]
             [com.yetanalytics.lrs.pedestal.routes :refer [build]]
             [com.yetanalytics.lrs.pedestal.interceptor :as i]
-            [clojure.core :refer [format]]
             [lrsql.admin.routes :refer [add-admin-routes]]
             [lrsql.init.oidc :as oidc]
             [lrsql.init.clamav :as clamav]

--- a/src/main/lrsql/util.clj
+++ b/src/main/lrsql/util.clj
@@ -1,6 +1,6 @@
 (ns lrsql.util
   (:require [clj-uuid]
-            [java-time]
+            [java-time.api           :as jt]
             [java-time.properties    :as jt-props]
             [clojure.spec.alpha      :as s]
             [clojure.tools.logging   :as log]
@@ -51,7 +51,7 @@
 (defn current-time
   "Return the current time as a java.util.Instant timestamp."
   []
-  (java-time/instant))
+  (jt/instant))
 
 (def valid-units
   (set (map jt-props/unit-key jt-props/predefined-units)))
@@ -68,7 +68,7 @@
    that was offset by the given amount. Valid units are given by
    `java-time.repl/show-units`."
   [^Instant ts offset-amount offset-unit]
-  (.plus ts offset-amount (java-time/unit offset-unit)))
+  (.plus ts offset-amount (jt/unit offset-unit)))
 
 (s/fdef str->time
   :args (s/cat :ts-str ::xs/timestamp)
@@ -78,12 +78,12 @@
   "Parse an ISO 8601 timestamp string into a java.util.Instant timestamp. The
   two parse fns are to support the Z and the +00:00 offset timestamp formats"
   [ts-str]
-  (wrap-parse-fn java-time/instant "timestamp" ts-str
+  (wrap-parse-fn jt/instant "timestamp" ts-str
                  :retry-parse-fn #(-> %
                                       ;; This step only needed for < JVM 11.
                                       ;; Newer will parse offset right away.
-                                      java-time/offset-date-time
-                                      java-time/instant)))
+                                      jt/offset-date-time
+                                      jt/instant)))
 
 (s/fdef time->str
   :args (s/cat :ts instant-spec)
@@ -93,7 +93,7 @@
   "Convert a java.util.Instant timestamp into a string. Said string is
    normalized according to the requirements of the lrs library."
   [ts]
-  (normalize (java-time/format ts)))
+  (normalize (jt/format ts)))
 
 (s/fdef time->millis
   :args (s/cat :ts instant-spec)

--- a/src/main/lrsql/util/reaction.clj
+++ b/src/main/lrsql/util/reaction.clj
@@ -6,8 +6,7 @@
             [lrsql.spec.reaction :as rs]
             [lrsql.spec.statement :as ss]
             [xapi-schema.spec :as xs]
-            [buddy.core.codecs :as bc]
-            [buddy.core.codecs.base64 :as b64]))
+            [buddy.core.codecs :as bc]))
 
 (s/fdef path->string
   :args (s/cat :path ::rs/path
@@ -127,9 +126,10 @@
   "Given a condition name string, encode it as hex."
   [condition-name]
   (-> condition-name
-      b64/encode
+      bc/str->bytes
+      bc/bytes->b64
       bc/bytes->hex
-      (->> (format "cond_%s")))) ;; add prefix to be valid SQL colname
+      (->> (format "cond_%s")))) ; add prefix to be valid SQL colname
 
 (s/fdef decode-condition-name
   :args (s/cat :encoded-condition-name string?)
@@ -139,7 +139,7 @@
   "Convert a condition name back to human-readable"
   [encoded-condition-name]
   (-> encoded-condition-name
-      (subs 5) ;; remove prefix
+      (subs 5) ; remove prefix
       bc/hex->bytes
-      b64/decode
+      bc/b64->bytes
       bc/bytes->str))

--- a/src/test/lrsql/util/reaction_test.clj
+++ b/src/test/lrsql/util/reaction_test.clj
@@ -139,6 +139,11 @@
             :cause "No value found at [\"completed_a\" \"actor\" \"birthday\"]"}))))
 
 (deftest encode-condition-name-test
+  (testing "hex values"
+    (is (= "cond_5a6d397649474a6863673d3d"
+           (r/encode-condition-name "foo bar")))
+    (is (= "foo bar"
+           (r/decode-condition-name "cond_5a6d397649474a6863673d3d"))))
   (testing "unique"
     (is (= (r/encode-condition-name "foo")
            (r/encode-condition-name "foo")))


### PR DESCRIPTION
I noticed there were a bunch of clj-kondo errors and warnings, so I addressed them by changing out deprecated functions, adding ignores, and removing redundant imports.