### PR TITLE
Empty language maps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -40,12 +40,12 @@
   xyz.capybara/clamav-client      {:mvn/version "2.1.2"}
   ;; Yet Analytics deps
   com.yetanalytics/lrs
-  {:mvn/version "1.2.17"
+  {:mvn/version "1.2.18"
    :exclusions  [org.clojure/clojure
                  org.clojure/clojurescript
                  com.yetanalytics/xapi-schema]}
   com.yetanalytics/xapi-schema
-  {:mvn/version "1.2.2"
+  {:mvn/version "1.3.0"
    :exclusions  [org.clojure/clojure
                  org.clojure/clojurescript]}
   com.yetanalytics/colossal-squuid

--- a/src/main/lrsql/util/statement.clj
+++ b/src/main/lrsql/util/statement.clj
@@ -17,14 +17,23 @@
 ;; suggested by the spec:
 ;; https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#requirements-14
 
+(def ^:private dissocable-keys
+  "xAPI Statement properties that can be dissoc'd if the map value is empty.
+   The first three are for Verb, Activity, and Attachment lang maps.
+   The latter three are for top-level Statement or Activity properties.
+   We need to specify in order to allow other maps, e.g. extensions,
+   to remain empty."
+  #{"display" "name" "description" "context" "result" "definition"})
+
 (defn- dissoc-empty-maps
   "Remove all empty maps from `statement`, at all nesting levels."
   [statement]
   (w/postwalk
    (fn [x]
      (if (map-entry? x)
-       (let [v (second x)]
-         (when-not (and (map? v) (empty? v))
+       (let [k (first x)
+             v (second x)]
+         (when-not (and (dissocable-keys k) (empty? v))
            x))
        x))
    statement))

--- a/src/main/lrsql/util/statement.clj
+++ b/src/main/lrsql/util/statement.clj
@@ -68,7 +68,7 @@
         (u/generate-squuid*)
         squuid-ts-str
         (u/time->str squuid-ts)
-        {{activity-def* "description"} "object"
+        {{activity-def* "definition"} "object"
          context* "context"
          result*  "result"
          :as statement*}

--- a/src/main/lrsql/util/statement.clj
+++ b/src/main/lrsql/util/statement.clj
@@ -31,12 +31,12 @@
     (update "verb" dissoc-empty-lang-maps*)
     ;; Dissoc empty object activity name + description
     (= "Activity" (get-in statement ["object" "objectType"]))
-    (update "object"
-            (fn [{:strs [choices scale sources target steps] :as object}]
-              (cond-> (dissoc-empty-lang-maps* object)
+    (update-in ["object" "definition"]
+            (fn [{:strs [choices scale source target steps] :as obj-def}]
+              (cond-> (dissoc-empty-lang-maps* obj-def)
                 choices (update "choices" #(mapv dissoc-empty-lang-maps* %))
                 scale   (update "scale" #(mapv dissoc-empty-lang-maps* %))
-                sources (update "sources" #(mapv dissoc-empty-lang-maps* %))
+                source  (update "source" #(mapv dissoc-empty-lang-maps* %))
                 target  (update "target" #(mapv dissoc-empty-lang-maps* %))
                 steps   (update "steps" #(mapv dissoc-empty-lang-maps* %)))))
     ;; Dissoc empty attachemnt name + description

--- a/src/test/lrsql/util/statement_test.clj
+++ b/src/test/lrsql/util/statement_test.clj
@@ -80,24 +80,29 @@
                      "object"      (assoc sample-activity
                                           "definition"
                                           {"name"        {}
-                                           "description" {}
-                                           ;; Doesn't form a valid statement but
-                                           ;; we need to test these lang maps
-                                           "choices"     [{"name"        {}
-                                                           "description" {}}]
-                                           "scale"       [{"name"        {}
-                                                           "description" {}}]
-                                           "source"      [{"name"        {}
-                                                           "description" {}}]
-                                           "target"      [{"name"        {}
-                                                           "description" {}}]
-                                           "steps"       [{"name"        {}
-                                                           "description" {}}]})
+                                           "description" {}})
                      "attachments" [(-> sample-attachment
                                         (assoc "display" {})
                                         (assoc "description" {}))]
                      "context"     {}
-                     "result"      {}}]
+                     "result"      {}}
+        statement-4  {"id"     sample-id
+                      "actor"  sample-group
+                      "verb"   sample-verb
+                      "object" (assoc sample-activity
+                                      "definition"
+                                      {;; Doesn't form a valid statement but
+                                       ;; we need to test these lang maps
+                                       "choices" [{"id"          "Choice"
+                                                   "description" {}}]
+                                       "scale"   [{"id"          "Scale"
+                                                   "description" {}}]
+                                       "source"  [{"id"          "Source"
+                                                   "description" {}}]
+                                       "target"  [{"id"          "Target"
+                                                   "description" {}}]
+                                       "steps"   [{"id"          "Step"
+                                                   "description" {}}]})}]
     (testing "adds timestamp, stored, version, and authority"
       (let [statement* (su/prepare-statement lrs-authority statement-1)]
         (is (inst? (u/str->time (get statement* "timestamp"))))
@@ -117,6 +122,18 @@
                                      "display"
                                      "description")]}
              (-> (su/prepare-statement lrs-authority statement-3)
+                 (dissoc "timestamp" "stored" "authority" "version"))))
+      (is (= {"id"     sample-id
+              "actor"  sample-group
+              "verb"   sample-verb
+              "object" (assoc sample-activity
+                              "definition"
+                              {"choices" [{"id" "Choice"}]
+                               "scale"   [{"id" "Scale"}]
+                               "source"  [{"id" "Source"}]
+                               "target"  [{"id" "Target"}]
+                               "steps"   [{"id" "Step"}]})}
+             (-> (su/prepare-statement lrs-authority statement-4)
                  (dissoc "timestamp" "stored" "authority" "version")))))))
 
 (deftest statements-equal-test

--- a/src/test/lrsql/util/statement_test.clj
+++ b/src/test/lrsql/util/statement_test.clj
@@ -1,6 +1,7 @@
 (ns lrsql.util.statement-test
   (:require [clojure.test :refer [deftest testing is]]
-            [lrsql.util.statement :as su]))
+            [lrsql.util.statement :as su]
+            [lrsql.util :as u]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Fixtures
@@ -46,6 +47,14 @@
   {"id"         "http://www.example.com/tincan/activities/multipart"
    "objectType" "Activity"})
 
+(def sample-attachment
+  {"usageType"   "http://example.com/attachment-usage/test"
+   "display"     {"en-US" "A test attachment"}
+   "description" {"en-US" "A test attachment (description)"}
+   "contentType" "text/plain"
+   "length"      27
+   "sha2"        "495395e777cd98da653df9615d09c0fd6bb2f8d4788394cd53c56a3bfdcd848a"})
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -54,17 +63,49 @@
   (let [lrs-authority     {"mbox"       "mailto:a@example.com"
                            "objectType" "Agent"}
         foreign-authority {"mbox"       "mailto:b@example.com"
-                           "objectType" "Agent"}]
+                           "objectType" "Agent"}
+        ;; Statements
+        statement-1 {"id"     sample-id
+                     "actor"  sample-group
+                     "verb"   sample-verb
+                     "object" sample-activity}
+        statement-2 {"id"        sample-id
+                     "actor"     sample-group
+                     "verb"      sample-verb
+                     "object"    sample-activity
+                     "authority" foreign-authority}
+        statement-3 {"id"          sample-id
+                     "actor"       sample-group
+                     "verb"        (assoc sample-verb "display" {})
+                     "object"      (assoc sample-activity
+                                          "definition"
+                                          {"name"        {}
+                                           "description" {}})
+                     "attachments" [(-> sample-attachment
+                                        (assoc "display" {})
+                                        (assoc "description" {}))]
+                     "context"     {}
+                     "result"      {}}]
+    (testing "adds timestamp, stored, version, and authority"
+      (let [statement* (su/prepare-statement lrs-authority statement-1)]
+        (is (inst? (u/str->time (get statement* "timestamp"))))
+        (is (inst? (u/str->time (get statement* "stored"))))
+        (is (= su/xapi-version (get statement* "version")))
+        (is (= lrs-authority (get statement* "authority")))))
     (testing "overwrites authority"
       (is (= lrs-authority
-             (-> (su/prepare-statement
-                  lrs-authority
-                  {"id"        sample-id
-                   "actor"     sample-group
-                   "verb"      sample-verb
-                   "object"    sample-activity
-                   "authority" foreign-authority})
-                 (get "authority")))))))
+             (-> (su/prepare-statement lrs-authority statement-2)
+                 (get "authority")))))
+    (testing "dissocs empty maps"
+      (is (= {"id"          sample-id
+              "actor"       sample-group
+              "verb"        sample-verb-dissoc
+              "object"      sample-activity-dissoc
+              "attachments" [(dissoc sample-attachment
+                                     "display"
+                                     "description")]}
+             (-> (su/prepare-statement lrs-authority statement-3)
+                 (dissoc "timestamp" "stored" "authority" "version")))))))
 
 (deftest statements-equal-test
   (testing "statement equality"

--- a/src/test/lrsql/util/statement_test.clj
+++ b/src/test/lrsql/util/statement_test.clj
@@ -80,7 +80,19 @@
                      "object"      (assoc sample-activity
                                           "definition"
                                           {"name"        {}
-                                           "description" {}})
+                                           "description" {}
+                                           ;; Doesn't form a valid statement but
+                                           ;; we need to test these lang maps
+                                           "choices"     [{"name"        {}
+                                                           "description" {}}]
+                                           "scale"       [{"name"        {}
+                                                           "description" {}}]
+                                           "source"      [{"name"        {}
+                                                           "description" {}}]
+                                           "target"      [{"name"        {}
+                                                           "description" {}}]
+                                           "steps"       [{"name"        {}
+                                                           "description" {}}]})
                      "attachments" [(-> sample-attachment
                                         (assoc "display" {})
                                         (assoc "description" {}))]


### PR DESCRIPTION
- Update the underlying xapi-schema lib version to allow for empty language maps in xAPI Statements
- Despite the above, automatically remove empty maps in xAPI Statements (lang maps, `context`, `result`, and Activity `definition`) before insertion