### PR TITLE
Simplify SQLite migration queries

### DIFF
--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -110,7 +110,7 @@
     (when-not (some? (query-xapi-statement-reaction-id-exists tx))
       (xapi-statement-add-reaction-id! tx)
       (xapi-statement-add-trigger-id! tx))
-    (when-not (= "CASCADE" (:on-delete (first (query-statement-to-actor-has-cascade-delete? tx))))
+    (when-not (some? (query-statement-to-actor-has-cascade-delete tx))
       (update-schema-simple! tx alter-statement-to-actor-add-cascade-delete!))
     (log/infof "sqlite schema_version: %d"
                (:schema_version (query-schema-version tx))))

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -81,7 +81,7 @@
     (create-credential-table! tx)
     (create-credential-to-scope-table! tx))
   (-update-all! [_ tx]
-    (when (= 1 (:notnull (query-admin-account-passhash-notnull tx)))
+    (when (some? (query-admin-account-passhash-notnull tx))
       (update-schema-simple! tx alter-admin-account-passhash-optional!))
     (when-not (some? (query-admin-account-oidc-issuer-exists tx))
       (alter-admin-account-add-openid-issuer! tx))

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -500,8 +500,14 @@ ALTER TABLE xapi_statement ADD COLUMN reaction_id TEXT REFERENCES reaction(id);
 -- :doc Adds `xapi_statement.trigger_id`
 ALTER TABLE xapi_statement ADD COLUMN trigger_id TEXT REFERENCES xapi_statement(statement_id);
 
---:name query-statement-to-actor-has-cascade-delete?
-SELECT on_delete FROM pragma_foreign_key_list("statement_to_actor") WHERE "table" = "xapi_statement"
+-- :name query-statement-to-actor-has-cascade-delete
+-- :command :query
+-- :result :one
+-- :doc Query to see whether the `statement_to_actor` foreign key in the table `xapi_statement` does CASCADE when its referenced row is deleted.
+SELECT 1
+FROM pragma_foreign_key_list('statement_to_actor')
+WHERE "table" = 'xapi_statement'
+AND on_delete = 'CASCADE';
 
 -- :name alter-statement-to-actor-add-cascade-delete!
 -- :command :execute

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -275,8 +275,11 @@ PRAGMA schema_version = :sql:schema_version
 -- :name query-admin-account-passhash-notnull
 -- :command :query
 -- :result :one
--- :doc Query to see if admin_account passhash is required.
-SELECT "notnull" FROM pragma_table_info('admin_account') WHERE name = 'passhash'
+-- :doc Query to see if admin_account passhash is required. Returns 1 if the passhash is not nullable (i.e. not optional).
+SELECT 1
+FROM pragma_table_info('admin_account')
+WHERE name = 'passhash'
+AND "notnull" = 1 -- non-nullable is true
 
 -- :name alter-admin-account-passhash-optional!
 -- :command :execute

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -276,10 +276,8 @@ PRAGMA schema_version = :sql:schema_version
 -- :command :query
 -- :result :one
 -- :doc Query to see if admin_account passhash is required. Returns 1 if the passhash is not nullable (i.e. not optional).
-SELECT 1
-FROM pragma_table_info('admin_account')
-WHERE name = 'passhash'
-AND "notnull" = 1 -- non-nullable is true
+SELECT 1 FROM pragma_table_info('admin_account')
+WHERE name = 'passhash' AND "notnull" = 1 -- non-nullable is true
 
 -- :name alter-admin-account-passhash-optional!
 -- :command :execute
@@ -409,7 +407,6 @@ ALTER TABLE xapi_statement ADD COLUMN stored TIMESTAMP
 UPDATE xapi_statement SET stored = strftime('%Y-%m-%dT%H:%M:%f000000Z', json_extract(payload, '$.stored'))
 WHERE stored IS NULL;
 
-
 /* Migration 2023-05-11-00 - Convert timestamps for consistency */
 
 -- :name query-state-document-last-modified-is-timestamp
@@ -504,10 +501,8 @@ ALTER TABLE xapi_statement ADD COLUMN trigger_id TEXT REFERENCES xapi_statement(
 -- :command :query
 -- :result :one
 -- :doc Query to see whether the `statement_to_actor` foreign key in the table `xapi_statement` does CASCADE when its referenced row is deleted.
-SELECT 1
-FROM pragma_foreign_key_list('statement_to_actor')
-WHERE "table" = 'xapi_statement'
-AND on_delete = 'CASCADE';
+SELECT 1 FROM pragma_foreign_key_list('statement_to_actor')
+WHERE "table" = 'xapi_statement' AND on_delete = 'CASCADE';
 
 -- :name alter-statement-to-actor-add-cascade-delete!
 -- :command :execute

--- a/src/dev/lrsql/user.clj
+++ b/src/dev/lrsql/user.clj
@@ -77,6 +77,14 @@
     (jdbc/execute!
      ds
      ["SELECT 1
+       FROM pragma_foreign_key_list('statement_to_actor')
+       WHERE \"table\" = 'xapi_statement'
+       AND on_delete = 'CASCADE'
+      "])
+    
+    (jdbc/execute!
+     ds
+     ["SELECT 1
        FROM (
          SELECT sql
          FROM sqlite_master

--- a/src/dev/lrsql/user.clj
+++ b/src/dev/lrsql/user.clj
@@ -70,6 +70,13 @@
     (jdbc/execute!
      ds
      ["SELECT 1
+       FROM pragma_table_info('admin_account')
+       WHERE name = 'passhash'
+       AND \"notnull\" = 1"])
+    
+    (jdbc/execute!
+     ds
+     ["SELECT 1
        FROM (
          SELECT sql
          FROM sqlite_master


### PR DESCRIPTION
Ensure all migration queries return 1 vs null, rather than more detailed values. This change only applies in SQLite since Postgres queries are all already like this.

Based on this comment: https://github.com/yetanalytics/lrsql/pull/407#discussion_r1644877445