### PR TITLE
Docker remove bench

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM alpine:3.19.1
 ADD target/bundle /lrsql
 ADD .java_modules /lrsql/.java_modules
 
-
 # replace the linux runtime via jlink
 RUN apk update \
         && apk upgrade \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.19.1
 ADD target/bundle /lrsql
 ADD .java_modules /lrsql/.java_modules
 
+
 # replace the linux runtime via jlink
 RUN apk update \
         && apk upgrade \
@@ -13,6 +14,9 @@ RUN apk update \
         && jlink --output /lrsql/runtimes/linux/ --add-modules $(cat /lrsql/.java_modules) \
         && apk del openjdk11 \
         && rm -rf /var/cache/apk/*
+
+# delete bench utils for leaner container
+RUN rm -rf /lrsql/bench*
 
 WORKDIR /lrsql
 EXPOSE 8080


### PR DESCRIPTION
keep container lean.

No need to recut release right now, as its not a priority, just didnt want to forget before the next release.