### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
   build_jre:
     needs: get_modules
-    uses: yetanalytics/runtimer/.github/workflows/runtimer.yml@0.1.3-java-11-temurin
+    uses: yetanalytics/runtimer/.github/workflows/runtimer.yml@0.2.0-java-11-temurin-SNAPSHOT
     with:
       java-version: '11'
       java-distribution: 'temurin'
@@ -45,17 +45,17 @@ jobs:
 
     # GET RUNTIMES FROM ARTIFACTS
     - name: Download ubuntu-latest Artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ubuntu-20.04-jre
 
     - name: Download macOS-latest Artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: macos-12-jre
 
     - name: Download windows-latest Artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: windows-2022-jre
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
         folder: target/bundle/doc
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
   build_jre:
     needs: get_modules
-    uses: yetanalytics/workflow-runtimer/.github/workflows/runtimer.yml@1
+    uses: yetanalytics/workflow-runtimer/.github/workflows/runtimer.yml@v1
     with:
       java-version: '11'
       java-distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
         images: yetanalytics/lrsql
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         context: .
         push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
   build_jre:
     needs: get_modules
-    uses: yetanalytics/runtimer/.github/workflows/runtimer.yml@0.2.0-java-11-temurin-SNAPSHOT
+    uses: yetanalytics/workflow-runtimer/.github/workflows/runtimer.yml@1
     with:
       java-version: '11'
       java-distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup CI Environment
-      uses: yetanalytics/actions/setup-env@v0.0.4
+      uses: yetanalytics/action-setup-env@v1
 
     # BUILD WITHOUT RUNTIME
     - name: Build Bundle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: List Java modules
         id: echo-modules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup CI Environment
-      uses: yetanalytics/action-setup-env@v1
+      uses: yetanalytics/action-setup-env@v2
 
     # BUILD WITHOUT RUNTIME
     - name: Build Bundle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
         files: lrsql.zip
 
     - name: Deploy Documentation
-      uses: JamesIves/github-pages-deploy-action@v4.4.1
+      uses: JamesIves/github-pages-deploy-action@v4.6.4
       with:
         branch: gh-pages
         folder: target/bundle/doc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
         unzip lrsql.zip -d target/bundle
 
     - name: Craft Draft Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         # Defaults:
         # name: [tag name]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: yetanalytics/lrsql
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     needs: build_jre
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup CI Environment
       uses: yetanalytics/action-setup-env@v1
@@ -78,14 +78,14 @@ jobs:
 
     - name: Archive Bundle (Branch Pushes)
       if: ${{ github.ref_type == 'branch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: lrsql-artifact-${{ github.sha }}
         path: lrsql.zip
 
     - name: Archive Bundle (Tag Pushes)
       if: ${{ github.ref_type == 'tag' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: lrsql-artifact-${{ github.ref_name }}
         path: lrsql.zip
@@ -96,10 +96,10 @@ jobs:
     if: ${{ github.ref_type == 'tag' }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Download Bundle Artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: lrsql-artifact-${{ github.ref_name }}
 

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -29,4 +29,4 @@ jobs:
         run: make clean pom.xml
 
       - name: Submit Dependency Snapshot
-        uses: advanced-security/maven-dependency-submission-action@v3
+        uses: advanced-security/maven-dependency-submission-action@v4

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -16,7 +16,7 @@ jobs:
         uses: yetanalytics/action-setup-env@v2
 
       - name: Cache Deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -29,4 +29,4 @@ jobs:
         run: make clean pom.xml
 
       - name: Submit Dependency Snapshot
-        uses: advanced-security/maven-dependency-submission-action@v4
+        uses: advanced-security/maven-dependency-submission-action@v3

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup CI Environment
         uses: yetanalytics/action-setup-env@v1

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup CI Environment
-        uses: yetanalytics/action-setup-env@v1
+        uses: yetanalytics/action-setup-env@v2
 
       - name: Cache Deps
         uses: actions/cache@v3

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   nvd_scan:
-    uses: yetanalytics/workflow-nvd/.github/workflows/nvd-scan.yml@v1
+    uses: yetanalytics/workflow-nvd/.github/workflows/nvd-scan.yml@v2
     with:
       nvd-clojure-version: "3.3.0"
       classpath-command: "clojure -Spath -Adb-sqlite:db-postgres"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup CI Environment
-        uses: yetanalytics/actions/setup-env@v0.0.4
+        uses: yetanalytics/action-setup-env@v2.0.0-SNAPSHOT
 
       - name: Run Makefile Target ${{ matrix.target }}
         run: make ${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       nvd-config-filename: ".nvd/config.json"
 
   lint:
-    uses: yetanalytics/workflow-linter/.github/workflows/linter.yml@v2023.01.20
+    uses: yetanalytics/workflow-linter/.github/workflows/linter.yml@v2024.08.01-SNAPSHOT
     with:
       lint-directories: "src/bench src/build src/db src/main src/test"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup CI Environment
-        uses: yetanalytics/actions/setup-env@v0.0.4
+        uses: yetanalytics/action-setup-env@v1
 
       - name: Run Makefile Target ${{ matrix.target }}
         run: make ${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup CI Environment
-        uses: yetanalytics/action-setup-env@v1
+        uses: yetanalytics/action-setup-env@v2
 
       - name: Run Makefile Target ${{ matrix.target }}
         run: make ${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup CI Environment
-        uses: yetanalytics/action-setup-env@v2.0.0-SNAPSHOT
+        uses: yetanalytics/actions/setup-env@v0.0.4
 
       - name: Run Makefile Target ${{ matrix.target }}
         run: make ${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   nvd_scan:
-    uses: yetanalytics/workflow-nvd/.github/workflows/nvd-scan.yml@v1
+    uses: yetanalytics/workflow-nvd/.github/workflows/nvd-scan.yml@v2
     with:
       nvd-clojure-version: "3.3.0"
       classpath-command: "clojure -Spath -Adb-sqlite:db-postgres"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup CI Environment
         uses: yetanalytics/action-setup-env@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       nvd-config-filename: ".nvd/config.json"
 
   lint:
-    uses: yetanalytics/workflow-linter/.github/workflows/linter.yml@v2024.08.01-SNAPSHOT
+    uses: yetanalytics/workflow-linter/.github/workflows/linter.yml@v2024.08.01
     with:
       lint-directories: "src/bench src/build src/db src/main src/test"
 


### PR DESCRIPTION
Update most actions and reusable workflows:
- actions/checkout to v4
- actions/download-artifact to v4
- actions/upload-artifact to v4
- softprops/action-gh-release to v2
- JamesIves/github-pages-deploy-action to v4.6.4
- docker/login-action to v3
- docker/metadata-action to v5
- docker/build-push-action to v6 (jump update from v3)
- yetanalytics/action-setup-env to v2
- yetanalytics/workflow-nvd to v2
- yetanalytics/[workflow-]runtimer to v1 (in new repo)
- yetanalytics/workflow-linter to v2024.08.01

Leave the following action un-updated, however:
- advanced-security/maven-dependency-submission-action to v4, as this has [additional breaking changes](https://github.com/advanced-security/maven-dependency-submission-action/releases/tag/v4.0.0) besides Node updates

Testing of the release actions was done via uploading a dummy version, v0.7.21-SNAPSHOT: https://github.com/yetanalytics/lrsql/actions/runs/11017112155