### PR TITLE
patch commons-io to 2.14.0 to resolve CVE-2024-47554

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -16,6 +16,7 @@
   aero/aero                                {:mvn/version "1.1.6"}
   selmer/selmer                            {:mvn/version "1.12.59"}
   ch.qos.logback/logback-classic           {:mvn/version "1.3.14"}
+  commons-io/commons-io                    {:mvn/version "2.14.0"}
   ;; DB/JDBC deps
   ;; - HikariCP: Need to exclude slf4j to make logback work properly
   ;; - HugSql: Use custom version instead of the released version (0.5.1)
@@ -43,7 +44,7 @@
   less-awful-ssl/less-awful-ssl   {:mvn/version "1.0.6"}
   xyz.capybara/clamav-client      {:mvn/version "2.1.2"}
   ;; Yet Analytics deps
-  
+
   com.yetanalytics/lrs
   {:mvn/version "1.2.19"
    :exclusions  [org.clojure/clojure


### PR DESCRIPTION
patch commons-io to 2.14.0 to resolve CVE-2024-47554

Resolves https://github.com/yetanalytics/lrsql/security/dependabot/17