### PR TITLE
Jetty CVE fixes

### DIFF
--- a/.nvd/suppression.xml
+++ b/.nvd/suppression.xml
@@ -18,6 +18,7 @@
         <cpe>cpe:/a:clojure:clojure</cpe>
         <cve>CVE-2017-20189</cve>
     </suppress>
+    <!-- TODO: Remove suppression once we update to Jetty 12 -->
     <suppress>
         <notes><![CDATA[
         file name: jetty-http-9.4.54.v20240208.jar

--- a/.nvd/suppression.xml
+++ b/.nvd/suppression.xml
@@ -18,4 +18,11 @@
         <cpe>cpe:/a:clojure:clojure</cpe>
         <cve>CVE-2017-20189</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        file name: jetty-http-9.4.54.v20240208.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-http@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-6763</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/deps.edn
+++ b/deps.edn
@@ -27,10 +27,15 @@
   com.zaxxer/HikariCP                      {:mvn/version "5.0.0"
                                             :exclusions  [org.slf4j/slf4j-api]}
   ;; Pedestal and Jetty webserver deps
-  io.pedestal/pedestal.jetty               {:mvn/version "0.6.3"
-                                            :exclusions  [org.eclipse.jetty.http2/http2-server]}
-  org.eclipse.jetty.http2/http2-server     {:mvn/version "9.4.54.v20240208"}
-  org.eclipse.jetty/jetty-alpn-java-server {:mvn/version "9.4.54.v20240208"}
+  io.pedestal/pedestal.jetty               {:mvn/version "0.6.3"}
+  org.eclipse.jetty/jetty-server           {:mvn/version "9.4.56.v20240826"}
+  org.eclipse.jetty/jetty-servlet          {:mvn/version "9.4.56.v20240826"}
+  org.eclipse.jetty/jetty-alpn-server      {:mvn/version "9.4.56.v20240826"}
+  org.eclipse.jetty.http2/http2-server     {:mvn/version "9.4.56.v20240826"}
+  org.eclipse.jetty/jetty-alpn-java-server {:mvn/version "9.4.56.v20240826"}
+  org.eclipse.jetty.websocket/websocket-api     {:mvn/version "9.4.56.v20240826"}
+  org.eclipse.jetty.websocket/websocket-servlet {:mvn/version "9.4.56.v20240826"}
+  org.eclipse.jetty.websocket/websocket-server  {:mvn/version "9.4.56.v20240826"}
   ;; Security deps
   buddy/buddy-core    {:mvn/version "1.11.418"
                        :exclusions [org.bouncycastle/bcprov-jdk18on


### PR DESCRIPTION
Small PR to address the following CVEs:
- CVE-2024-6763: Suppress since our code does not utilize the HttpURI class, which is how the vulnerability is exposed
- CVE-2024-8184: Update Jetty to 9.4.56.v20240826
