### PR TITLE
[SQL-267] `/admin/verify` endpoint

### DIFF
--- a/doc/endpoints.md
+++ b/doc/endpoints.md
@@ -43,6 +43,7 @@ The response body contains a newly generated JSON Web Token (JWT) on success. A 
 #### Misc Admin Routes
 
 - `GET http://example.org/admin/env`: Get select environment variables about the configuration which may aid in client-side operations.
+- `GET http://example.org/admin/openapi`: Get an OpenAPI JSON spec of the endpoint API, which can then be visualized using an OpenAPI viewer like Swagger.
 - `DELETE http://example.org/admin/agents`: Runs a *hard delete* of all records of an actor, and associated records (statements, attachments, etc).  Intended for privacy purposes like GDPR.  Body should be a JSON object of form `{"actor-ifi":<actor-ifi>}`.  Disabled unless the configuration variable enableAdminDeleteActor to be set to `true`.
 
 ### Reaction Management Routes

--- a/doc/endpoints.md
+++ b/doc/endpoints.md
@@ -44,6 +44,7 @@ The response body contains a newly generated JSON Web Token (JWT) on success. A 
 
 - `GET http://example.org/admin/env`: Get select environment variables about the configuration which may aid in client-side operations.
 - `GET http://example.org/admin/openapi`: Get an OpenAPI JSON spec of the endpoint API, which can then be visualized using an OpenAPI viewer like Swagger.
+- `GET http://example.org/admin/status`: Get LRS status information, such as the number of statements in the LRS.
 - `DELETE http://example.org/admin/agents`: Runs a *hard delete* of all records of an actor, and associated records (statements, attachments, etc).  Intended for privacy purposes like GDPR.  Body should be a JSON object of form `{"actor-ifi":<actor-ifi>}`.  Disabled unless the configuration variable enableAdminDeleteActor to be set to `true`.
 
 ### Reaction Management Routes

--- a/doc/endpoints.md
+++ b/doc/endpoints.md
@@ -31,6 +31,7 @@ The response body contains a newly generated JSON Web Token (JWT) on success. A 
 - `DELETE http://example.org/admin/account`: Delete an existing account. The JSON request body must contain a UUID `account-id` value. The endpoint returns a JSON object with the ID of the deleted account on success and returns a `404 NOT FOUND` error if the account does not exist.
 - `GET http://example.org/admin/account`: Return an array of all admin accounts in the system on success.
 - `GET http://example.org/admin/me`: Returns the currently authenticated admin accounts on success.
+- `GET http://example.org/admin/verify`: Returns a `204 OK` response, without a body, on success (the success conditions are the same as the `/admin/me` endpoint).
 
 #### Admin Credential Routes
 

--- a/doc/endpoints.md
+++ b/doc/endpoints.md
@@ -31,7 +31,7 @@ The response body contains a newly generated JSON Web Token (JWT) on success. A 
 - `DELETE http://example.org/admin/account`: Delete an existing account. The JSON request body must contain a UUID `account-id` value. The endpoint returns a JSON object with the ID of the deleted account on success and returns a `404 NOT FOUND` error if the account does not exist.
 - `GET http://example.org/admin/account`: Return an array of all admin accounts in the system on success.
 - `GET http://example.org/admin/me`: Returns the currently authenticated admin accounts on success.
-- `GET http://example.org/admin/verify`: Returns a `204 OK` response, without a body, on success (the success conditions are the same as the `/admin/me` endpoint).
+- `GET http://example.org/admin/verify`: Returns a `204 No Content` response, without a body, on success (the success conditions are the same as the `/admin/me` endpoint).
 
 #### Admin Credential Routes
 

--- a/src/main/lrsql/admin/interceptors/account.clj
+++ b/src/main/lrsql/admin/interceptors/account.clj
@@ -250,10 +250,10 @@
                :response
                {:status 200 :body result})))}))
 
-(def bodyless
-  "Return a 204 OK response without a body."
+(def no-content
+  "Return a 204 No Content response, without a body."
   (interceptor
-   {:name ::get-bodyless
+   {:name ::get-no-content
     :enter
     (fn get-account [ctx]
       (assoc ctx :response {:status 204}))}))

--- a/src/main/lrsql/admin/interceptors/account.clj
+++ b/src/main/lrsql/admin/interceptors/account.clj
@@ -250,6 +250,14 @@
                :response
                {:status 200 :body result})))}))
 
+(def bodyless
+  "Return a 204 OK response without a body."
+  (interceptor
+   {:name ::get-bodyless
+    :enter
+    (fn get-account [ctx]
+      (assoc ctx :response {:status 204}))}))
+
 (defn generate-jwt
   "Upon account login, generate a new JSON web token."
   [secret exp]

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -101,7 +101,7 @@
                                   (gs/a (gs/o {:account-id :t#string 
                                                :username :t#string})))
                   401 (g/rref :error-401)}})
-    ;; Get my accounts
+    ;; Get my account
     (gc/annotate
      ["/admin/me" :get (conj common-interceptors
                              (ji/validate-jwt
@@ -115,6 +115,18 @@
       :responses {200 (g/response  "Account object referring to own account"
                                    (gs/o {:account-id :t#string
                                           :username :t#string}) )
+                  401 (g/rref :error-401)}})
+    ;; Check that I am logged in
+    (gc/annotate
+     ["/admin/verify" :get (conj common-interceptors
+                                 (ji/validate-jwt
+                                  jwt-secret jwt-leeway no-val-opts)
+                                 ji/validate-jwt-account
+                                 ai/bodyless)]
+     {:description "Verify that querying account is logged in"
+      :operationId :verify-own-account
+      :security [{:bearerAuth []}]
+      :responses {204 (g/response "No body")
                   401 (g/rref :error-401)}})
     ;; Delete account (and associated credentials)
     (gc/annotate

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -122,11 +122,11 @@
                                  (ji/validate-jwt
                                   jwt-secret jwt-leeway no-val-opts)
                                  ji/validate-jwt-account
-                                 ai/bodyless)]
+                                 ai/no-content)]
      {:description "Verify that querying account is logged in"
       :operationId :verify-own-account
       :security [{:bearerAuth []}]
-      :responses {204 (g/response "No body")
+      :responses {204 (g/response "No content body")
                   401 (g/rref :error-401)}})
     ;; Delete account (and associated credentials)
     (gc/annotate

--- a/src/test/lrsql/admin/route_test.clj
+++ b/src/test/lrsql/admin/route_test.clj
@@ -75,6 +75,11 @@
   (curl/get "http://0.0.0.0:8080/admin/me"
             {:headers headers}))
 
+(defn- verify-me
+  [headers]
+  (curl/get "http://0.0.0.0:8080/admin/verify"
+            {:headers headers}))
+
 (defn- update-account-password
   [headers
    body]
@@ -133,7 +138,11 @@
         headers   (merge content-type seed-auth)
         orig-pass "Swordfish100?"
         req-body  (u/write-json-str {"username" "mylongname"
-                                     "password" orig-pass})]
+                                     "password" orig-pass})
+        ;; Corrupted JWT
+        bad-jwt   (apply str (butlast seed-jwt))
+        bad-auth  {"Authorization" (str "Bearer " bad-jwt)}
+        bad-head  (merge content-type bad-auth)]
     (try
       (testing "seed jwt retrieved"
         ;; Sanity check that the test credentials are in place
@@ -210,6 +219,13 @@
           (is (= 200 status))
           ;; is the created user
           (is (= (get edn-body "username") admin-user-default))))
+      (testing "verify my admin account"
+        (let [{:keys [status]} (verify-me headers)]
+          ;; success
+          (is (= 204 status))))
+      (testing "ensure corrupted JWTs do not pass"
+        (is-err-code (get-me bad-head) 401)
+        (is-err-code (verify-me bad-head) 401))
       (testing "log into the `myname` account"
         (let [{:keys [status body]}
               (login-account content-type req-body)


### PR DESCRIPTION
Add an `/admin/verify` endpoint* that returns a bodyless `204 OK` response when the current JWT is authenticated. This is essentially the `/admin/me` endpoint but without the body. This will be useful for the client to use when polling the server to check if the user is currently authenticated.

Also add `/admin/openapi` and `/admin/status` to the endpoint docs since for some reason they were not included before.

NOTE: name may be subject to change based on suggestions