### PR TITLE
[SQL-222] Admin logout endpoint

### DIFF
--- a/doc/endpoints.md
+++ b/doc/endpoints.md
@@ -27,6 +27,7 @@ The following examples use `http://example.org` as the URL body. All methods ret
   * `password` must contain at least one of the following special characters: `!@#$%^&*_-+=?`.
 
 The response body contains a newly generated JSON Web Token (JWT) on success. A `401 UNAUTHORIZED` status code is returned if the credentials are incorrect.
+- `POST http://example.org/admin/account/logout`: Log out of the current account. This will revoke any unexpired JWTs associated with the user. (NOTE: This endpoint will return a `400 BAD REQUEST` error if `LRSQL_JWT_NO_VAL` is set to `true`.)
 - `POST http://example.org/admin/account/create`: Create a new admin account. The request body must be a JSON object that contains `username` and `password` strings. The endpoint returns a JSON object with the ID (UUID) of the newly created user on success, and returns a `409 CONFLICT` if the account already exists.
 - `DELETE http://example.org/admin/account`: Delete an existing account. The JSON request body must contain a UUID `account-id` value. The endpoint returns a JSON object with the ID of the deleted account on success and returns a `404 NOT FOUND` error if the account does not exist.
 - `GET http://example.org/admin/account`: Return an array of all admin accounts in the system on success.

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -201,8 +201,6 @@
   bp/JWTBlocklistBackend
   (-insert-blocked-jwt! [_ tx input]
     (insert-blocked-jwt! tx input))
-  (-delete-blocked-jwt-by-account! [_ tx input]
-    (delete-blocked-jwt-by-account! tx input))
   (-delete-blocked-jwt-by-time! [_ tx input]
     (delete-blocked-jwt-by-time! tx input))
   (-query-blocked-jwt [_ tx input]

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -76,7 +76,8 @@
     (when (nil? (check-statement-to-actor-cascading-delete tx))
       (add-statement-to-actor-cascading-delete! tx))
     (when (some? (query-varchar-exists tx))
-      (convert-varchars-to-text! tx)))
+      (convert-varchars-to-text! tx))
+    (create-blocked-jwt-table! tx))
 
   bp/BackendUtil
   (-txn-retry? [_ ex]
@@ -196,6 +197,16 @@
     (query-account-exists tx input))
   (-query-account-count-local [_ tx]
     (query-account-count-local tx))
+
+  bp/JWTBlocklistBackend
+  (-insert-blocked-jwt! [_ tx input]
+    (insert-blocked-jwt! tx input))
+  (-delete-blocked-jwt-by-account! [_ tx input]
+    (delete-blocked-jwt-by-account! tx input))
+  (-delete-blocked-jwt-by-time! [_ tx input]
+    (delete-blocked-jwt-by-time! tx input))
+  (-query-blocked-jwt [_ tx input]
+    (query-blocked-jwt-exists tx input))
 
   bp/CredentialBackend
   (-insert-credential! [_ tx input]

--- a/src/db/postgres/lrsql/postgres/sql/ddl.sql
+++ b/src/db/postgres/lrsql/postgres/sql/ddl.sql
@@ -496,6 +496,6 @@ ALTER TABLE reaction ALTER COLUMN title TYPE TEXT;
 -- :doc Create the `blocked_jwt` table and associated indexes if they do not exist yet.
 CREATE TABLE IF NOT EXISTS blocked_jwt (
   jwt        TEXT PRIMARY KEY,
-  evict_time TIMESTAMP
+  evict_time TIMESTAMP WITH TIME ZONE
 );
 CREATE INDEX IF NOT EXISTS blocked_jwt_evict_time_idx ON blocked_jwt(evict_time);

--- a/src/db/postgres/lrsql/postgres/sql/ddl.sql
+++ b/src/db/postgres/lrsql/postgres/sql/ddl.sql
@@ -488,3 +488,16 @@ ALTER TABLE lrs_credential ALTER COLUMN secret_key TYPE TEXT;
 ALTER TABLE credential_to_scope ALTER COLUMN api_key TYPE TEXT;
 ALTER TABLE credential_to_scope ALTER COLUMN secret_key TYPE TEXT;
 ALTER TABLE reaction ALTER COLUMN title TYPE TEXT;
+
+/* Migration 2024-10-31 - Add JWT Blocklist Table */
+
+-- :name create-blocked-jwt-table!
+-- :command :execute
+-- :doc Create the `blocked_jwt` table and associated indexes if they do not exist yet.
+CREATE TABLE IF NOT EXISTS blocked_jwt (
+  account_id TEXT NOT NULL REFERENCES admin_account(id) ON DELETE CASCADE,
+  expiration TIMESTAMP,
+  PRIMARY KEY (account_id, expiration)
+);
+CREATE INDEX IF NOT EXISTS blocked_jwt_account_id_idx ON blocked_jwt(account_id);
+CREATE INDEX IF NOT EXISTS blocked_jwt_expiration_idx ON blocked_jwt(expiration);

--- a/src/db/postgres/lrsql/postgres/sql/ddl.sql
+++ b/src/db/postgres/lrsql/postgres/sql/ddl.sql
@@ -495,7 +495,7 @@ ALTER TABLE reaction ALTER COLUMN title TYPE TEXT;
 -- :command :execute
 -- :doc Create the `blocked_jwt` table and associated indexes if they do not exist yet.
 CREATE TABLE IF NOT EXISTS blocked_jwt (
-  account_id TEXT NOT NULL REFERENCES admin_account(id) ON DELETE CASCADE,
+  account_id UUID NOT NULL REFERENCES admin_account(id) ON DELETE CASCADE,
   expiration TIMESTAMP,
   PRIMARY KEY (account_id, expiration)
 );

--- a/src/db/postgres/lrsql/postgres/sql/ddl.sql
+++ b/src/db/postgres/lrsql/postgres/sql/ddl.sql
@@ -495,9 +495,7 @@ ALTER TABLE reaction ALTER COLUMN title TYPE TEXT;
 -- :command :execute
 -- :doc Create the `blocked_jwt` table and associated indexes if they do not exist yet.
 CREATE TABLE IF NOT EXISTS blocked_jwt (
-  account_id UUID NOT NULL REFERENCES admin_account(id) ON DELETE CASCADE,
-  expiration TIMESTAMP,
-  PRIMARY KEY (account_id, expiration)
+  jwt        TEXT PRIMARY KEY,
+  evict_time TIMESTAMP
 );
-CREATE INDEX IF NOT EXISTS blocked_jwt_account_id_idx ON blocked_jwt(account_id);
-CREATE INDEX IF NOT EXISTS blocked_jwt_expiration_idx ON blocked_jwt(expiration);
+CREATE INDEX IF NOT EXISTS blocked_jwt_evict_time_idx ON blocked_jwt(evict_time);

--- a/src/db/postgres/lrsql/postgres/sql/delete.sql
+++ b/src/db/postgres/lrsql/postgres/sql/delete.sql
@@ -111,16 +111,9 @@ DELETE FROM actor WHERE actor_ifi = :actor-ifi;
 
 /* JWT Blocklist */
 
--- :name delete-blocked-jwt-by-account!
--- :command :execute
--- :result :affected
--- :doc Delete all blocked JWTs associated with a given `:account-id`.
-DELETE FROM blocked_jwt
-WHERE account_id = :account-id;
-
 -- :name delete-blocked-jwt-by-time!
 -- :command :execute
 -- :result :affected
--- :doc Delete all blocked JWTs where `:current-time` is past the expiration time.
+-- :doc Delete all blocked JWTs where `:current-time` is past the eviction time.
 DELETE FROM blocked_jwt
-WHERE expiration <= :current-time;
+WHERE evict_time <= :current-time;

--- a/src/db/postgres/lrsql/postgres/sql/delete.sql
+++ b/src/db/postgres/lrsql/postgres/sql/delete.sql
@@ -118,7 +118,7 @@ DELETE FROM actor WHERE actor_ifi = :actor-ifi;
 DELETE FROM blocked_jwt
 WHERE account_id = :account-id;
 
--- :name :delete-blocked-jwt-by-time!
+-- :name delete-blocked-jwt-by-time!
 -- :command :execute
 -- :result :affected
 -- :doc Delete all blocked JWTs where `:current-time` is past the expiration time.

--- a/src/db/postgres/lrsql/postgres/sql/delete.sql
+++ b/src/db/postgres/lrsql/postgres/sql/delete.sql
@@ -108,3 +108,19 @@ DELETE FROM state_document WHERE agent_ifi = :actor-ifi;
 
 DELETE FROM actor WHERE actor_ifi = :actor-ifi;
 ------------------end delete-actor--------------------
+
+/* JWT Blocklist */
+
+-- :name delete-blocked-jwt-by-account!
+-- :command :execute
+-- :result :affected
+-- :doc Delete all blocked JWTs associated with a given `:account-id`.
+DELETE FROM blocked_jwt
+WHERE account_id = :account-id;
+
+-- :name :delete-blocked-jwt-by-time!
+-- :command :execute
+-- :result :affected
+-- :doc Delete all blocked JWTs where `:current-time` is past the expiration time.
+DELETE FROM blocked_jwt
+WHERE expiration <= :current-time;

--- a/src/db/postgres/lrsql/postgres/sql/insert.sql
+++ b/src/db/postgres/lrsql/postgres/sql/insert.sql
@@ -165,9 +165,9 @@ INSERT INTO reaction (
 -- :name insert-blocked-jwt!
 -- :command :insert
 -- :result :affected
--- :doc Given a JWT-extracted `:account-id` and `:expiration`, insert a new blocked JWT.
+-- :doc Insert a `:jwt` and a `:eviction-time` into the blocklist.
 INSERT INTO blocked_jwt (
-  account_id, expiration
+  jwt, evict_time
 ) VALUES (
-  :account-id, :expiration
+  :jwt, :eviction-time
 );

--- a/src/db/postgres/lrsql/postgres/sql/insert.sql
+++ b/src/db/postgres/lrsql/postgres/sql/insert.sql
@@ -162,7 +162,7 @@ INSERT INTO reaction (
 
 /* JWT Blocklist */
 
--- :ame insert-blocked-jwt!
+-- :name insert-blocked-jwt!
 -- :command :insert
 -- :result :affected
 -- :doc Given a JWT-extracted `:account-id` and `:expiration`, insert a new blocked JWT.

--- a/src/db/postgres/lrsql/postgres/sql/insert.sql
+++ b/src/db/postgres/lrsql/postgres/sql/insert.sql
@@ -159,3 +159,15 @@ INSERT INTO reaction (
 ) VALUES (
   :primary-key, :title, :ruleset, :active, :created, :modified
 );
+
+/* JWT Blocklist */
+
+-- :ame insert-blocked-jwt!
+-- :command :insert
+-- :result :affected
+-- :doc Given a JWT-extracted `:account-id` and `:expiration`, insert a new blocked JWT.
+INSERT INTO blocked_jwt (
+  account_id, expiration
+) VALUES (
+  :account-id, :expiration
+);

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -427,3 +427,13 @@ WITH RECURSIVE trigger_history (statement_id, reaction_id, trigger_id) AS (
 SELECT reaction_id
 FROM trigger_history
 WHERE reaction_id IS NOT NULL;
+
+/* JWT Blocklist */
+
+-- :name query-blocked-jwt-exists
+-- :command :query
+-- :result :one
+-- :doc Query that at least one blocked JWT with `:username` and whose expiration is after `:current-time` exists.
+SELECT 1 FROM blocked_jwt
+WHERE account_id = :account-id
+AND :current-time < expiration;

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -433,7 +433,6 @@ WHERE reaction_id IS NOT NULL;
 -- :name query-blocked-jwt-exists
 -- :command :query
 -- :result :one
--- :doc Query that at least one blocked JWT with `:username` and whose expiration is after `:current-time` exists.
+-- :doc Query that `:jwt` is in the blocklist.
 SELECT 1 FROM blocked_jwt
-WHERE account_id = :account-id
-AND :current-time < expiration;
+WHERE jwt = :jwt;

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -113,8 +113,7 @@
     (when-not (some? (query-statement-to-actor-has-cascade-delete tx))
       (update-schema-simple! tx alter-statement-to-actor-add-cascade-delete!))
     (create-blocked-jwt-table! tx)
-    (create-blocked-jwt-account-id-idx! tx)
-    (create-blocked-jwt-expiration-idx! tx)
+    (create-blocked-jwt-evict-time-idx! tx)
     (log/infof "sqlite schema_version: %d"
                (:schema_version (query-schema-version tx))))
 
@@ -243,13 +242,11 @@
   bp/JWTBlocklistBackend
   (-insert-blocked-jwt! [_ tx input]
     (insert-blocked-jwt! tx input))
-  (-delete-blocked-jwt-by-account! [_ tx input]
-    (delete-blocked-jwt-by-account! tx input))
   (-delete-blocked-jwt-by-time! [_ tx input]
     (delete-blocked-jwt-by-time! tx input))
   (-query-blocked-jwt [_ tx input]
     (query-blocked-jwt-exists tx input))
-  
+
   bp/CredentialBackend
   (-insert-credential! [_ tx input]
     (insert-credential! tx input))

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -113,7 +113,7 @@
     (when-not (some? (query-statement-to-actor-has-cascade-delete tx))
       (update-schema-simple! tx alter-statement-to-actor-add-cascade-delete!))
     (create-blocked-jwt-table! tx)
-    (create-blocked-jwt-username-idx! tx)
+    (create-blocked-jwt-account-id-idx! tx)
     (create-blocked-jwt-expiration-idx! tx)
     (log/infof "sqlite schema_version: %d"
                (:schema_version (query-schema-version tx))))

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -112,6 +112,9 @@
       (xapi-statement-add-trigger-id! tx))
     (when-not (some? (query-statement-to-actor-has-cascade-delete tx))
       (update-schema-simple! tx alter-statement-to-actor-add-cascade-delete!))
+    (create-blocked-jwt-table! tx)
+    (create-blocked-jwt-username-idx! tx)
+    (create-blocked-jwt-expiration-idx! tx)
     (log/infof "sqlite schema_version: %d"
                (:schema_version (query-schema-version tx))))
 
@@ -237,6 +240,16 @@
   (-query-account-count-local [_ tx]
     (query-account-count-local tx))
 
+  bp/JWTBlocklistBackend
+  (-insert-blocked-jwt! [_ tx input]
+    (insert-blocked-jwt! tx input))
+  (-delete-blocked-jwt-by-account! [_ tx input]
+    (delete-blocked-jwt-by-account! tx input))
+  (-delete-blocked-jwt-by-time! [_ tx input]
+    (delete-blocked-jwt-by-time! tx input))
+  (-query-blocked-jwt [_ tx input]
+    (query-blocked-jwt-exists tx input))
+  
   bp/CredentialBackend
   (-insert-credential! [_ tx input]
     (insert-credential! tx input))

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -149,8 +149,6 @@ CREATE INDEX IF NOT EXISTS sts_ancestor_id_idx ON statement_to_statement(ancesto
 -- :doc Create an index on the `statement_to_statement.descendant_id` column.
 CREATE INDEX IF NOT EXISTS sts_descendant_id_idx ON statement_to_statement(descendant_id)
 
-
-
 /* Document Tables */
 
 -- :name create-state-document-table!
@@ -524,3 +522,25 @@ SET sql = 'CREATE TABLE statement_to_actor (
   FOREIGN KEY (actor_ifi, actor_type) REFERENCES actor(actor_ifi, actor_type)
 )'
 WHERE type = 'table' AND name = 'statement_to_actor'
+;
+
+/* Migration 2024-10-31 - Add JWT Blocklist Table */
+
+-- :name create-blocked-jwt-table!
+-- :command :execute
+-- :doc Create the `blocked_jwt` table if it does not exist yet.
+CREATE TABLE IF NOT EXISTS blocked_jwt (
+  account_id TEXT NOT NULL REFERENCES admin_account(id) ON DELETE CASCADE,
+  expiration TIMESTAMP,
+  PRIMARY KEY (account_id, expiration)
+);
+
+-- :name create-blocked-jwt-account-id-idx!
+-- :command :execute
+-- :doc Create the `blocked_jwt_account_id_idx` table if it does not exist yet.
+CREATE INDEX IF NOT EXISTS blocked_jwt_account_id_idx ON blocked_jwt(account_id);
+
+-- :name create-blocked-jwt-expiration-idx!
+-- :command :execute
+-- :doc Create the `blocked_jwt_expiration_idx` table if it does not exist yet.
+CREATE INDEX IF NOT EXISTS blocked_jwt_expiration_idx ON blocked_jwt(expiration);

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -530,17 +530,11 @@ WHERE type = 'table' AND name = 'statement_to_actor'
 -- :command :execute
 -- :doc Create the `blocked_jwt` table if it does not exist yet.
 CREATE TABLE IF NOT EXISTS blocked_jwt (
-  account_id TEXT NOT NULL REFERENCES admin_account(id) ON DELETE CASCADE,
-  expiration TIMESTAMP,
-  PRIMARY KEY (account_id, expiration)
+  jwt        TEXT PRIMARY KEY,
+  evict_time TIMESTAMP
 );
 
--- :name create-blocked-jwt-account-id-idx!
+-- :name create-blocked-jwt-evict-time-idx!
 -- :command :execute
--- :doc Create the `blocked_jwt_account_id_idx` table if it does not exist yet.
-CREATE INDEX IF NOT EXISTS blocked_jwt_account_id_idx ON blocked_jwt(account_id);
-
--- :name create-blocked-jwt-expiration-idx!
--- :command :execute
--- :doc Create the `blocked_jwt_expiration_idx` table if it does not exist yet.
-CREATE INDEX IF NOT EXISTS blocked_jwt_expiration_idx ON blocked_jwt(expiration);
+-- :doc Create the `blocked_jwt_evict_time_idx` table if it does not exist yet.
+CREATE INDEX IF NOT EXISTS blocked_jwt_evict_time_idx ON blocked_jwt(evict_time);

--- a/src/db/sqlite/lrsql/sqlite/sql/delete.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/delete.sql
@@ -126,16 +126,9 @@ DELETE FROM actor WHERE actor_ifi = :actor-ifi
 
 /* JWT Blocklist */
 
--- :name delete-blocked-jwt-by-account!
--- :command :execute
--- :result :affected
--- :doc Delete all blocked JWTs associated with a given `:account-id`.
-DELETE FROM blocked_jwt
-WHERE account_id = :account-id;
-
 -- :name delete-blocked-jwt-by-time!
 -- :command :execute
 -- :result :affected
--- :doc Delete all blocked JWTs where `:current-time` is past the expiration time.
+-- :doc Delete all blocked JWTs where `:current-time` is past the eviction time.
 DELETE FROM blocked_jwt
-WHERE expiration <= :current-time;
+WHERE evict_time <= :current-time;

--- a/src/db/sqlite/lrsql/sqlite/sql/delete.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/delete.sql
@@ -123,3 +123,19 @@ DELETE FROM state_document WHERE agent_ifi = :actor-ifi
 -- :command :execute
 -- :result :affected
 DELETE FROM actor WHERE actor_ifi = :actor-ifi
+
+/* JWT Blocklist */
+
+-- :name delete-blocked-jwt-by-account!
+-- :command :execute
+-- :result :affected
+-- :doc Delete all blocked JWTs associated with a given `:account-id`.
+DELETE FROM blocked_jwt
+WHERE account_id = :account-id;
+
+-- :name :delete-blocked-jwt-by-time!
+-- :command :execute
+-- :result :affected
+-- :doc Delete all blocked JWTs where `:current-time` is past the expiration time.
+DELETE FROM blocked_jwt
+WHERE expiration <= :current-time;

--- a/src/db/sqlite/lrsql/sqlite/sql/delete.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/delete.sql
@@ -133,7 +133,7 @@ DELETE FROM actor WHERE actor_ifi = :actor-ifi
 DELETE FROM blocked_jwt
 WHERE account_id = :account-id;
 
--- :name :delete-blocked-jwt-by-time!
+-- :name delete-blocked-jwt-by-time!
 -- :command :execute
 -- :result :affected
 -- :doc Delete all blocked JWTs where `:current-time` is past the expiration time.

--- a/src/db/sqlite/lrsql/sqlite/sql/insert.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/insert.sql
@@ -165,9 +165,9 @@ INSERT INTO reaction (
 -- :name insert-blocked-jwt!
 -- :command :insert
 -- :result :affected
--- :doc Given a JWT-extracted `:account-id` and `:expiration`, insert a new blocked JWT.
+-- :doc Insert a `:jwt` and a `:eviction-time` into the blocklist.
 INSERT INTO blocked_jwt (
-  account_id, expiration
+  jwt, evict_time
 ) VALUES (
-  :account-id, :expiration
+  :jwt, :eviction-time
 );

--- a/src/db/sqlite/lrsql/sqlite/sql/insert.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/insert.sql
@@ -162,7 +162,7 @@ INSERT INTO reaction (
 
 /* JWT Blocklist */
 
--- :ame insert-blocked-jwt!
+-- :name insert-blocked-jwt!
 -- :command :insert
 -- :result :affected
 -- :doc Given a JWT-extracted `:account-id` and `:expiration`, insert a new blocked JWT.

--- a/src/db/sqlite/lrsql/sqlite/sql/insert.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/insert.sql
@@ -159,3 +159,15 @@ INSERT INTO reaction (
 ) VALUES (
   :primary-key, :title, :ruleset, :active, :created, :modified
 );
+
+/* JWT Blocklist */
+
+-- :ame insert-blocked-jwt!
+-- :command :insert
+-- :result :affected
+-- :doc Given a JWT-extracted `:account-id` and `:expiration`, insert a new blocked JWT.
+INSERT INTO blocked_jwt (
+  account_id, expiration
+) VALUES (
+  :account-id, :expiration
+);

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -401,7 +401,6 @@ WHERE reaction_id IS NOT NULL;
 -- :name query-blocked-jwt-exists
 -- :command :query
 -- :result :one
--- :doc Query that at least one blocked JWT with `:account_id` and whose expiration is after `:current-time` exists.
+-- :doc Query that `:jwt` is in the blocklist.
 SELECT 1 FROM blocked_jwt
-WHERE account_id = :account-id
-AND :current-time < expiration;
+WHERE jwt = :jwt

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -395,3 +395,13 @@ WITH RECURSIVE trigger_history (statement_id, reaction_id, trigger_id) AS (
 SELECT reaction_id
 FROM trigger_history
 WHERE reaction_id IS NOT NULL;
+
+/* JWT Blocklist */
+
+-- :name query-blocked-jwt-exists
+-- :command :query
+-- :result :one
+-- :doc Query that at least one blocked JWT with `:account_id` and whose expiration is after `:current-time` exists.
+SELECT 1 FROM blocked_jwt
+WHERE account_id = :account-id
+AND :current-time < expiration;

--- a/src/main/lrsql/admin/interceptors/account.clj
+++ b/src/main/lrsql/admin/interceptors/account.clj
@@ -287,11 +287,16 @@
                {:keys [jwt account-id]} :lrsql.admin.interceptors.jwt/data}
               ctx]
           (adp/-purge-blocklist lrs) ; Update blocklist upon logout
-          (adp/-block-jwt lrs jwt exp)
-          (assoc (chain/terminate ctx)
-                 :response
-                 {:status 200
-                  :body   {:account-id account-id}}))
+          (let [result (adp/-block-jwt lrs jwt exp)]
+            (if-not (contains? result :error)
+              (assoc (chain/terminate ctx)
+                     :response
+                     {:status 200
+                      :body   {:account-id account-id}})
+              (assoc (chain/terminate ctx)
+                     :response
+                     {:status 409
+                      :body   {:error "JWT has already been revoked."}}))))
         (assoc (chain/terminate ctx)
                :response
                {:status 400

--- a/src/main/lrsql/admin/interceptors/account.clj
+++ b/src/main/lrsql/admin/interceptors/account.clj
@@ -293,16 +293,11 @@
                {:keys [jwt account-id]} :lrsql.admin.interceptors.jwt/data}
               ctx]
           (adp/-purge-blocklist lrs leeway) ; Update blocklist upon logout
-          (let [result (adp/-block-jwt lrs jwt exp)]
-            (if-not (contains? result :error)
-              (assoc (chain/terminate ctx)
-                     :response
-                     {:status 200
-                      :body   {:account-id account-id}})
-              (assoc (chain/terminate ctx)
-                     :response
-                     {:status 409
-                      :body   {:error "JWT has already been revoked."}}))))
+          (adp/-block-jwt lrs jwt exp)
+          (assoc (chain/terminate ctx)
+                 :response
+                 {:status 200
+                  :body   {:account-id account-id}}))
         (assoc (chain/terminate ctx)
                :response
                {:status 400

--- a/src/main/lrsql/admin/interceptors/account.clj
+++ b/src/main/lrsql/admin/interceptors/account.clj
@@ -259,10 +259,12 @@
    {:name ::generate-jwt
     :enter
     (fn generate-jwt [ctx]
-      (let [{{:keys [account-id]} ::data}
+      (let [{lrs :com.yetanalytics/lrs
+             {:keys [account-id]} ::data}
             ctx
             json-web-token
             (admin-u/account-id->jwt account-id secret exp)]
+        (adp/-purge-blocklist lrs) ; Update blocklist upon login
         (assoc ctx
                :response
                {:status 200
@@ -284,6 +286,7 @@
         (let [{lrs :com.yetanalytics/lrs
                {:keys [jwt account-id]} :lrsql.admin.interceptors.jwt/data}
               ctx]
+          (adp/-purge-blocklist lrs) ; Update blocklist upon logout
           (adp/-block-jwt lrs jwt exp)
           (assoc (chain/terminate ctx)
                  :response

--- a/src/main/lrsql/admin/interceptors/account.clj
+++ b/src/main/lrsql/admin/interceptors/account.clj
@@ -293,7 +293,9 @@
     (fn add-jwt-to-blocklist [ctx]
       (if-not no-val?
         (let [{lrs :com.yetanalytics/lrs
-               {:keys [account-id expiration]} ::data} ctx]
+               {:keys [account-id expiration]}
+               :lrsql.admin.interceptors.jwt/data}
+              ctx]
           (adp/-block-jwt lrs account-id expiration)
           (assoc (chain/terminate ctx)
                  :response

--- a/src/main/lrsql/admin/interceptors/account.clj
+++ b/src/main/lrsql/admin/interceptors/account.clj
@@ -262,17 +262,15 @@
 
 (defn generate-jwt
   "Upon account login, generate a new JSON web token."
-  [secret exp leeway]
+  [secret exp]
   (interceptor
    {:name ::generate-jwt
     :enter
     (fn generate-jwt [ctx]
-      (let [{lrs :com.yetanalytics/lrs
-             {:keys [account-id]} ::data}
+      (let [{{:keys [account-id]} ::data}
             ctx
             json-web-token
             (admin-u/account-id->jwt account-id secret exp)]
-        (adp/-purge-blocklist lrs leeway) ; Update blocklist upon login
         (assoc ctx
                :response
                {:status 200

--- a/src/main/lrsql/admin/interceptors/account.clj
+++ b/src/main/lrsql/admin/interceptors/account.clj
@@ -123,15 +123,16 @@
                  {:status 401
                   :body   {:error "Invalid Account Credentials"}}))))}))
 
-(def unblock-admin-jwts
+(defn unblock-admin-jwts
   "Remove all JWTs associated with the user account from the blocklist."
+  [leeway]
   (interceptor
    {:name ::remove-jwt-from-blocklist
     :enter
     (fn remove-jwt-from-blocklist [ctx]
       (let [{lrs :com.yetanalytics/lrs
              {:keys [account-id]} ::data} ctx]
-        (adp/-unblock-jwts lrs account-id)
+        (adp/-unblock-jwts lrs account-id leeway)
         ctx))}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -286,7 +287,7 @@
 (defn block-admin-jwt
   "Add the current JWT to the blocklist. Return an error if we are in
    no-val mode."
-  [no-val?]
+  [leeway no-val?]
   (interceptor
    {:name ::add-jwt-to-blocklist
     :enter
@@ -296,7 +297,7 @@
                {:keys [account-id expiration]}
                :lrsql.admin.interceptors.jwt/data}
               ctx]
-          (adp/-block-jwt lrs account-id expiration)
+          (adp/-block-jwt lrs account-id expiration leeway)
           (assoc (chain/terminate ctx)
                  :response
                  {:status 200

--- a/src/main/lrsql/admin/interceptors/jwt.clj
+++ b/src/main/lrsql/admin/interceptors/jwt.clj
@@ -38,7 +38,7 @@
           (admin-u/jwt->payload token secret leeway)]
       (if (keyword? result)
         result
-        (if-not (adp/-jwt-blocked? lrs account-id)
+        (if-not (adp/-jwt-blocked? lrs account-id leeway)
           result
           :lrsql.admin/unauthorized-token-error)))
     (catch Exception ex

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -22,7 +22,7 @@
   (-purge-blocklist [this]
     "Purge the blocklist of any JWTs that have expired since they were added.")
   (-block-jwt [this jwt expiration]
-    "Block `jwt` and apply an associated `expiration` number of seconds.")
+    "Block `jwt` and apply an associated `expiration` number of seconds. Returns an error if `jwt` is already in the blocklist.")
   (-jwt-blocked? [this jwt]
     "Is `jwt` on the blocklist?"))
 

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -19,11 +19,11 @@
     "Update the password for an admin account given old and new passwords."))
 
 (defprotocol AdminJWTManager
-  (-block-jwt [this account-id expiration]
-    "Block the JWT with this account and expiration time. Purge expired JWTs from the blocklist if necessary.")
-  (-unblock-jwts [this account-id]
+  (-block-jwt [this account-id expiration leeway]
+    "Block the JWT with this account, expiration time, and leeway. Purge expired JWTs from the blocklist if necessary.")
+  (-unblock-jwts [this account-id leeway]
     "Unblock the JWTs associated with this account. Purge expired JWTs from the blocklist if necessary.")
-  (-jwt-blocked? [this account-id]
+  (-jwt-blocked? [this account-id leeway]
     "Is an unexpired JWT with this account on the blocklist?"))
 
 (defprotocol APIKeyManager

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -19,8 +19,10 @@
     "Update the password for an admin account given old and new passwords."))
 
 (defprotocol AdminJWTManager
+  (-purge-blocklist [this]
+    "Purge the blocklist of any JWTs that have expired since they were added.")
   (-block-jwt [this jwt expiration]
-    "Block `jwt` and apply an associated `expiration` number of seconds. Purge expired JWTs from the blocklist if necessary.")
+    "Block `jwt` and apply an associated `expiration` number of seconds.")
   (-jwt-blocked? [this jwt]
     "Is `jwt` on the blocklist?"))
 

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -19,7 +19,7 @@
     "Update the password for an admin account given old and new passwords."))
 
 (defprotocol AdminJWTManager
-  (-purge-blocklist [this]
+  (-purge-blocklist [this leeway]
     "Purge the blocklist of any JWTs that have expired since they were added.")
   (-block-jwt [this jwt expiration]
     "Block `jwt` and apply an associated `expiration` number of seconds. Returns an error if `jwt` is already in the blocklist.")

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -20,9 +20,9 @@
 
 (defprotocol AdminJWTManager
   (-block-jwt [this account-id expiration]
-    "Block the JWT with this account and expiration time. Purge the cache if necessary.")
+    "Block the JWT with this account and expiration time. Purge expired JWTs from the blocklist if necessary.")
   (-unblock-jwts [this account-id]
-    "Unblock the JWTs associated with this account.")
+    "Unblock the JWTs associated with this account. Purge expired JWTs from the blocklist if necessary.")
   (-jwt-blocked? [this account-id]
     "Is an unexpired JWT with this account on the blocklist?"))
 

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -18,6 +18,14 @@
   (-update-admin-password [this account-id old-password new-password]
     "Update the password for an admin account given old and new passwords."))
 
+(defprotocol AdminJWTManager
+  (-block-jwt [this account-id expiration]
+    "Block the JWT with this account and expiration time. Purge the cache if necessary.")
+  (-unblock-jwts [this account-id]
+    "Unblock the JWTs associated with this account.")
+  (-jwt-blocked? [this account-id]
+    "Is an unexpired JWT with this account on the blocklist?"))
+
 (defprotocol APIKeyManager
   (-create-api-keys [this account-id scopes]
     "Create a new API key pair with the associated scopes.")

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -19,12 +19,10 @@
     "Update the password for an admin account given old and new passwords."))
 
 (defprotocol AdminJWTManager
-  (-block-jwt [this account-id expiration leeway]
-    "Block the JWT with this account, expiration time, and leeway. Purge expired JWTs from the blocklist if necessary.")
-  (-unblock-jwts [this account-id leeway]
-    "Unblock the JWTs associated with this account. Purge expired JWTs from the blocklist if necessary.")
-  (-jwt-blocked? [this account-id leeway]
-    "Is an unexpired JWT with this account on the blocklist?"))
+  (-block-jwt [this jwt expiration]
+    "Block `jwt` and apply an associated `expiration` number of seconds. Purge expired JWTs from the blocklist if necessary.")
+  (-jwt-blocked? [this jwt]
+    "Is `jwt` on the blocklist?"))
 
 (defprotocol APIKeyManager
   (-create-api-keys [this account-id scopes]

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -33,14 +33,14 @@
    (i/lrs-interceptor lrs)])
 
 (defn admin-account-routes
-  [common-interceptors jwt-secret jwt-exp jwt-leeway no-val-opts]
+  [common-interceptors jwt-secret jwt-exp jwt-leeway {:keys [no-val?] :as no-val-opts}]
   #{;; Log into an existing account
     (gc/annotate
      ["/admin/account/login" :post (conj common-interceptors
                                          (ai/validate-params
                                           :strict? false)
                                          ai/authenticate-admin
-                                         ai/unblock-admin-jwts
+                                         (ai/unblock-admin-jwts jwt-leeway)
                                          (ai/generate-jwt jwt-secret jwt-exp))
       :route-name :lrsql.admin.account/login]
      {:description "Log into an existing account"
@@ -58,7 +58,7 @@
                                           (ji/validate-jwt
                                            jwt-secret jwt-leeway no-val-opts)
                                           ji/validate-jwt-account
-                                          (ai/block-admin-jwt (:no-val? no-val-opts)))
+                                          (ai/block-admin-jwt jwt-leeway no-val?))
       :route-name :lrsql.admin.account/logout]
      {:description "Log out of this account"
       :operationId :logout

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -40,7 +40,8 @@
                                          (ai/validate-params
                                           :strict? false)
                                          ai/authenticate-admin
-                                         (ai/generate-jwt jwt-secret jwt-exp))
+                                         (ai/generate-jwt
+                                          jwt-secret jwt-exp jwt-leeway))
       :route-name :lrsql.admin.account/login]
      {:description "Log into an existing account"
       :requestBody (g/request (gs/o {:username :t#string
@@ -57,7 +58,8 @@
                                           (ji/validate-jwt
                                            jwt-secret jwt-leeway no-val-opts)
                                           ji/validate-jwt-account
-                                          (ai/block-admin-jwt jwt-exp no-val?))
+                                          (ai/block-admin-jwt
+                                           jwt-exp jwt-leeway no-val?))
       :route-name :lrsql.admin.account/logout]
      {:description "Log out of this account"
       :operationId :logout

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -52,6 +52,7 @@
                                          :json-web-token :t#string}))
                   400 (g/rref :error-400)
                   401 (g/rref :error-401)}})
+    ;; Log out of current account
     (gc/annotate
      ["/admin/account/logout" :post (conj common-interceptors
                                           (ji/validate-jwt

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -40,7 +40,6 @@
                                          (ai/validate-params
                                           :strict? false)
                                          ai/authenticate-admin
-                                         (ai/unblock-admin-jwts jwt-leeway)
                                          (ai/generate-jwt jwt-secret jwt-exp))
       :route-name :lrsql.admin.account/login]
      {:description "Log into an existing account"
@@ -58,7 +57,7 @@
                                           (ji/validate-jwt
                                            jwt-secret jwt-leeway no-val-opts)
                                           ji/validate-jwt-account
-                                          (ai/block-admin-jwt jwt-leeway no-val?))
+                                          (ai/block-admin-jwt jwt-exp no-val?))
       :route-name :lrsql.admin.account/logout]
      {:description "Log out of this account"
       :operationId :logout

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -40,6 +40,7 @@
                                          (ai/validate-params
                                           :strict? false)
                                          ai/authenticate-admin
+                                         ai/unblock-admin-jwts
                                          (ai/generate-jwt jwt-secret jwt-exp))
       :route-name :lrsql.admin.account/login]
      {:description "Log into an existing account"
@@ -49,6 +50,19 @@
       :responses {200 (g/response "Account ID and JWT"
                                   (gs/o {:account-id :t#string
                                          :json-web-token :t#string}))
+                  400 (g/rref :error-400)
+                  401 (g/rref :error-401)}})
+    (gc/annotate
+     ["/admin/account/logout" :post (conj common-interceptors
+                                          (ji/validate-jwt
+                                           jwt-secret jwt-leeway no-val-opts)
+                                          ji/validate-jwt-account
+                                          (ai/block-admin-jwt (:no-val? no-val-opts)))
+      :route-name :lrsql.admin.account/logout]
+     {:description "Log out of this account"
+      :operationId :logout
+      :responses {200 (g/response "Account ID"
+                                  (gs/o {:account-id :t#string}))
                   400 (g/rref :error-400)
                   401 (g/rref :error-401)}})
     ;; Create new account

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -41,7 +41,7 @@
                                           :strict? false)
                                          ai/authenticate-admin
                                          (ai/generate-jwt
-                                          jwt-secret jwt-exp jwt-leeway))
+                                          jwt-secret jwt-exp))
       :route-name :lrsql.admin.account/login]
      {:description "Log into an existing account"
       :requestBody (g/request (gs/o {:username :t#string

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -101,6 +101,14 @@
   (-query-all-admin-accounts [this tx])
   (-query-account-count-local [this tx]))
 
+(defprotocol JWTBlocklistBackend
+  ;; Commands
+  (-insert-blocked-jwt! [this tx input])
+  (-delete-blocked-jwt-by-account! [this tx input])
+  (-delete-blocked-jwt-by-time! [this tx input])
+  ;; Queries
+  (-query-blocked-jwt [this tx input]))
+
 (defprotocol CredentialBackend
   ;; Commands
   (-insert-credential! [this tx input])

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -104,7 +104,6 @@
 (defprotocol JWTBlocklistBackend
   ;; Commands
   (-insert-blocked-jwt! [this tx input])
-  (-delete-blocked-jwt-by-account! [this tx input])
   (-delete-blocked-jwt-by-time! [this tx input])
   ;; Queries
   (-query-blocked-jwt [this tx input]))

--- a/src/main/lrsql/input/admin/jwt.clj
+++ b/src/main/lrsql/input/admin/jwt.clj
@@ -9,6 +9,14 @@
   (-> (u/current-time)
       (u/offset-time exp :seconds)))
 
+(defn- current-time
+  "Generate the current time, offset by `leeway` number of seconds earlier.
+   
+   See: `buddy.sign.jwt/validate-claims`"
+  [leeway]
+  (-> (u/current-time)
+      (u/offset-time (* -1 leeway) :seconds)))
+
 (s/fdef query-blocked-jwt-input
   :args (s/cat :jwt ::jwts/jwt)
   :ret jwts/query-blocked-jwt-input-spec)
@@ -28,9 +36,9 @@
    :eviction-time (eviction-time exp)})
 
 (s/fdef purge-blocklist-input
-  :args (s/cat)
+  :args (s/cat :leeway ::jwts/leeway)
   :ret jwts/purge-blocklist-input-spec)
 
 (defn purge-blocklist-input
-  []
-  {:current-time (u/current-time)})
+  [leeway]
+  {:current-time (current-time leeway)})

--- a/src/main/lrsql/input/admin/jwt.clj
+++ b/src/main/lrsql/input/admin/jwt.clj
@@ -20,11 +20,17 @@
 (s/fdef insert-blocked-jwt-input
   :args (s/cat :jwt ::jwts/jwt
                :exp ::jwts/exp)
-  :ret (s/and jwts/insert-blocked-jwt-input-spec
-              #_jwts/delete-blocked-jwt-time-input-spec))
+  :ret jwts/insert-blocked-jwt-input-spec)
 
 (defn insert-blocked-jwt-input
   [jwt exp]
   {:jwt           jwt
-   :eviction-time (eviction-time exp)
-   :current-time  (u/current-time)})
+   :eviction-time (eviction-time exp)})
+
+(s/fdef purge-blocklist-input
+  :args (s/cat)
+  :ret jwts/purge-blocklist-input-spec)
+
+(defn purge-blocklist-input
+  []
+  {:current-time (u/current-time)})

--- a/src/main/lrsql/input/admin/jwt.clj
+++ b/src/main/lrsql/input/admin/jwt.clj
@@ -3,33 +3,44 @@
             [lrsql.spec.admin.jwt :as jwts]
             [lrsql.util :as u]))
 
+(defn- current-time
+  "Generate the current time, offset by `leeway` number of seconds earlier.
+   
+   See: `buddy.sign.jwt/validate-claims`"
+  [leeway]
+  (-> (u/current-time)
+      (u/offset-time (* -1 leeway) :seconds)))
+
 (s/fdef query-blocked-jwt-input
-  :args (s/cat :account-id ::jwts/account-id)
+  :args (s/cat :account-id ::jwts/account-id
+               :leeway ::jwts/leeway)
   :ret jwts/query-blocked-jwt-input-spec)
 
 (defn query-blocked-jwt-input
-  [account-id]
+  [account-id leeway]
   {:account-id   account-id
-   :current-time (u/current-time)})
+   :current-time (current-time leeway)})
 
 (s/fdef insert-blocked-jwt-input
   :args (s/cat :account-id ::jwts/account-id
-               :expiration ::jwts/expiration)
+               :expiration ::jwts/expiration
+               :leeway ::jwts/leeway)
   :ret (s/and jwts/insert-blocked-jwt-input-spec
               jwts/delete-blocked-jwt-time-input-spec))
 
 (defn insert-blocked-jwt-input
-  [account-id expiration]
+  [account-id expiration leeway]
   {:account-id   account-id
    :expiration   expiration
-   :current-time (u/current-time)})
+   :current-time (current-time leeway)})
 
 (s/fdef delete-blocked-jwts-input
-  :args (s/cat :account-id ::jwts/account-id)
+  :args (s/cat :account-id ::jwts/account-id
+               :leeway ::jwts/leeway)
   :ret (s/and jwts/delete-blocked-jwt-account-input-spec
               jwts/delete-blocked-jwt-time-input-spec))
 
 (defn delete-blocked-jwts-input
-  [account-id]
+  [account-id leeway]
   {:account-id   account-id
-   :current-time (u/current-time)})
+   :current-time (current-time leeway)})

--- a/src/main/lrsql/input/admin/jwt.clj
+++ b/src/main/lrsql/input/admin/jwt.clj
@@ -1,0 +1,35 @@
+(ns lrsql.input.admin.jwt
+  (:require [clojure.spec.alpha :as s]
+            [lrsql.spec.admin.jwt :as jwts]
+            [lrsql.util :as u]))
+
+(s/fdef query-blocked-jwt-input
+  :args (s/cat :account-id ::jwts/account-id)
+  :ret jwts/query-blocked-jwt-input-spec)
+
+(defn query-blocked-jwt-input
+  [account-id]
+  {:account-id   account-id
+   :current-time (u/current-time)})
+
+(s/fdef insert-blocked-jwt-input
+  :args (s/cat :account-id ::jwts/account-id
+               :expiration ::jwts/expiration)
+  :ret (s/and jwts/insert-blocked-jwt-input-spec
+              jwts/delete-blocked-jwt-time-input-spec))
+
+(defn insert-blocked-jwt-input
+  [account-id expiration]
+  {:account-id   account-id
+   :expiration   expiration
+   :current-time (u/current-time)})
+
+(s/fdef delete-blocked-jwts-input
+  :args (s/cat :account-id ::jwts/account-id)
+  :ret (s/and jwts/delete-blocked-jwt-account-input-spec
+              jwts/delete-blocked-jwt-time-input-spec))
+
+(defn delete-blocked-jwts-input
+  [account-id]
+  {:account-id   account-id
+   :current-time (u/current-time)})

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -131,8 +131,7 @@
 (defn insert-blocked-jwt!
   "Insert a new JWT `:account-id` and `:expiration` to the blocklist table."
   [bk tx input]
-  (println input)
-  (println (bp/-insert-blocked-jwt! bk tx input))
+  (bp/-insert-blocked-jwt! bk tx input)
   {:result (:account-id input)})
 
 (s/fdef delete-blocked-jwts!

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -3,7 +3,8 @@
             [lrsql.backend.protocol :as bp]
             [lrsql.input.admin :as admin-i]
             [lrsql.spec.common :refer [transaction?]]
-            [lrsql.spec.admin :as ads]))
+            [lrsql.spec.admin :as ads]
+            [lrsql.spec.admin.jwt :as jwts]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Admin Account Insertion
@@ -105,3 +106,43 @@
                                 ensure-input)]
       (bp/-insert-admin-account-oidc! bk tx insert-input)
       {:result primary-key})))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Admin JWTs
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(s/fdef purge-blocklist!
+  :args (s/cat :bk jwts/admin-jwt-backend?
+               :tx transaction?
+               :input jwts/delete-blocked-jwt-time-input-spec))
+
+(defn purge-blocklist!
+  "Delete all JWTs from the blocklist that have expired, i.e. whose expirations
+   are before the `:current-time` in `input`."
+  [bk tx input]
+  (bp/-delete-blocked-jwt-by-time! bk tx input))
+
+(s/fdef insert-blocked-jwt!
+  :args (s/cat :bk jwts/admin-jwt-backend?
+               :tx transaction?
+               :input jwts/insert-blocked-jwt-input-spec)
+  :ret jwts/blocked-jwt-op-result-spec)
+
+(defn insert-blocked-jwt!
+  "Insert a new JWT `:account-id` and `:expiration` to the blocklist table."
+  [bk tx input]
+  (println input)
+  (println (bp/-insert-blocked-jwt! bk tx input))
+  {:result (:account-id input)})
+
+(s/fdef delete-blocked-jwts!
+  :args (s/cat :bk jwts/admin-jwt-backend?
+               :tx transaction?
+               :input jwts/delete-blocked-jwt-account-input-spec)
+  :ret jwts/blocked-jwt-op-result-spec)
+
+(defn delete-blocked-jwts!
+  "Delete all JWTs associated with `:account-id` from the blocklist."
+  [bk tx input]
+  (bp/-delete-blocked-jwt-by-account! bk tx input)
+  {:result (:account-id input)})

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -114,13 +114,15 @@
 (s/fdef purge-blocklist!
   :args (s/cat :bk jwts/admin-jwt-backend?
                :tx transaction?
-               :input any? #_jwts/delete-blocked-jwt-time-input-spec))
+               :input jwts/purge-blocklist-input-spec)
+  :ret nil?)
 
 (defn purge-blocklist!
   "Delete all JWTs from the blocklist that have expired, i.e. whose expirations
    are before the `:current-time` in `input`."
   [bk tx input]
-  (bp/-delete-blocked-jwt-by-time! bk tx input))
+  (bp/-delete-blocked-jwt-by-time! bk tx input)
+  nil)
 
 (s/fdef insert-blocked-jwt!
   :args (s/cat :bk jwts/admin-jwt-backend?

--- a/src/main/lrsql/ops/command/admin.clj
+++ b/src/main/lrsql/ops/command/admin.clj
@@ -114,7 +114,7 @@
 (s/fdef purge-blocklist!
   :args (s/cat :bk jwts/admin-jwt-backend?
                :tx transaction?
-               :input jwts/delete-blocked-jwt-time-input-spec))
+               :input any? #_jwts/delete-blocked-jwt-time-input-spec))
 
 (defn purge-blocklist!
   "Delete all JWTs from the blocklist that have expired, i.e. whose expirations
@@ -132,16 +132,4 @@
   "Insert a new JWT `:account-id` and `:expiration` to the blocklist table."
   [bk tx input]
   (bp/-insert-blocked-jwt! bk tx input)
-  {:result (:account-id input)})
-
-(s/fdef delete-blocked-jwts!
-  :args (s/cat :bk jwts/admin-jwt-backend?
-               :tx transaction?
-               :input jwts/delete-blocked-jwt-account-input-spec)
-  :ret jwts/blocked-jwt-op-result-spec)
-
-(defn delete-blocked-jwts!
-  "Delete all JWTs associated with `:account-id` from the blocklist."
-  [bk tx input]
-  (bp/-delete-blocked-jwt-by-account! bk tx input)
-  {:result (:account-id input)})
+  {:result (:jwt input)})

--- a/src/main/lrsql/ops/query/admin.clj
+++ b/src/main/lrsql/ops/query/admin.clj
@@ -3,6 +3,7 @@
             [lrsql.backend.protocol :as bp]
             [lrsql.spec.common :refer [transaction?]]
             [lrsql.spec.admin :as ads]
+            [lrsql.spec.admin.jwt :as jwts]
             [lrsql.spec.admin.status :as ss]
             [lrsql.util :as u]
             [lrsql.util.admin :as au]))
@@ -70,6 +71,10 @@
            :username username})
         (bp/-query-all-admin-accounts bk tx)))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Admin LRS Status
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (s/fdef query-status
   :args (s/cat :bk ss/admin-status-backend?
                :tx transaction?
@@ -110,3 +115,18 @@
               {:stored (u/pad-time-str stored_time)
                :count  scount})
             (bp/-query-timeline bk tx (:timeline params))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Admin JWTs
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(s/fdef query-blocked-jwt-exists
+  :args (s/cat :bk jwts/admin-jwt-backend?
+               :tx transaction?
+               :input jwts/query-blocked-jwt-input-spec)
+  :ret jwts/blocked-jwt-query-result-spec)
+
+(defn query-blocked-jwt-exists
+  "Query whether an unexpired JWT for the account exists."
+  [bk tx input]
+  (boolean (bp/-query-blocked-jwt bk tx input)))

--- a/src/main/lrsql/spec/admin/jwt.clj
+++ b/src/main/lrsql/spec/admin/jwt.clj
@@ -16,30 +16,24 @@
 ;; Inputs
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(s/def ::account-id :lrsql.spec.admin/account-id)
-(s/def ::current-time c/instant-spec)
-(s/def ::expiration c/instant-spec)
-(s/def ::leeway ::config/jwt-exp-leeway)
+(s/def ::jwt string?)
+(s/def ::exp ::config/jwt-exp-time)
+(s/def ::eviction-time c/instant-spec)
 
 (def query-blocked-jwt-input-spec
-  (s/keys :req-un [::account-id
-                   ::current-time]))
+  (s/keys :req-un [::jwt]))
 
 (def insert-blocked-jwt-input-spec
-  (s/keys :req-un [::account-id
-                   ::expiration]))
+  (s/keys :req-un [::jwt ::eviction-time]))
 
-(def delete-blocked-jwt-account-input-spec
-  (s/keys :req-un [::account-id]))
-
-(def delete-blocked-jwt-time-input-spec
+#_(def delete-blocked-jwt-time-input-spec
   (s/keys :req-un [::current-time]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Results
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(s/def :lrsql.spec.admin.jwt.command/result ::account-id)
+(s/def :lrsql.spec.admin.jwt.command/result any? #_::account-id)
 
 (def blocked-jwt-op-result-spec
   (s/keys :req-un [:lrsql.spec.admin.jwt.command/result]))

--- a/src/main/lrsql/spec/admin/jwt.clj
+++ b/src/main/lrsql/spec/admin/jwt.clj
@@ -18,6 +18,7 @@
 
 (s/def ::jwt string?)
 (s/def ::exp ::config/jwt-exp-time)
+(s/def ::leeway ::config/jwt-exp-leeway)
 (s/def ::eviction-time c/instant-spec)
 (s/def ::current-time c/instant-spec)
 

--- a/src/main/lrsql/spec/admin/jwt.clj
+++ b/src/main/lrsql/spec/admin/jwt.clj
@@ -1,7 +1,8 @@
 (ns lrsql.spec.admin.jwt
   (:require [clojure.spec.alpha :as s]
             [lrsql.backend.protocol :as bp]
-            [lrsql.spec.common :as c]))
+            [lrsql.spec.common :as c]
+            [lrsql.spec.config :as config]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Interface
@@ -18,6 +19,7 @@
 (s/def ::account-id :lrsql.spec.admin/account-id)
 (s/def ::current-time c/instant-spec)
 (s/def ::expiration c/instant-spec)
+(s/def ::leeway ::config/jwt-exp-leeway)
 
 (def query-blocked-jwt-input-spec
   (s/keys :req-un [::account-id

--- a/src/main/lrsql/spec/admin/jwt.clj
+++ b/src/main/lrsql/spec/admin/jwt.clj
@@ -1,0 +1,46 @@
+(ns lrsql.spec.admin.jwt
+  (:require [clojure.spec.alpha :as s]
+            [lrsql.backend.protocol :as bp]
+            [lrsql.spec.common :as c]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Interface
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn admin-jwt-backend?
+  [bk]
+  (satisfies? bp/JWTBlocklistBackend bk))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Inputs
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(s/def ::account-id :lrsql.spec.admin/account-id)
+(s/def ::current-time c/instant-spec)
+(s/def ::expiration c/instant-spec)
+
+(def query-blocked-jwt-input-spec
+  (s/keys :req-un [::account-id
+                   ::current-time]))
+
+(def insert-blocked-jwt-input-spec
+  (s/keys :req-un [::account-id
+                   ::expiration]))
+
+(def delete-blocked-jwt-account-input-spec
+  (s/keys :req-un [::account-id]))
+
+(def delete-blocked-jwt-time-input-spec
+  (s/keys :req-un [::current-time]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Results
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(s/def :lrsql.spec.admin.jwt.command/result ::account-id)
+
+(def blocked-jwt-op-result-spec
+  (s/keys :req-un [:lrsql.spec.admin.jwt.command/result]))
+
+(def blocked-jwt-query-result-spec
+  boolean?)

--- a/src/main/lrsql/spec/admin/jwt.clj
+++ b/src/main/lrsql/spec/admin/jwt.clj
@@ -19,6 +19,7 @@
 (s/def ::jwt string?)
 (s/def ::exp ::config/jwt-exp-time)
 (s/def ::eviction-time c/instant-spec)
+(s/def ::current-time c/instant-spec)
 
 (def query-blocked-jwt-input-spec
   (s/keys :req-un [::jwt]))
@@ -26,14 +27,14 @@
 (def insert-blocked-jwt-input-spec
   (s/keys :req-un [::jwt ::eviction-time]))
 
-#_(def delete-blocked-jwt-time-input-spec
+(def purge-blocklist-input-spec
   (s/keys :req-un [::current-time]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Results
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(s/def :lrsql.spec.admin.jwt.command/result any? #_::account-id)
+(s/def :lrsql.spec.admin.jwt.command/result ::jwt)
 
 (def blocked-jwt-op-result-spec
   (s/keys :req-un [:lrsql.spec.admin.jwt.command/result]))

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -307,12 +307,17 @@
             {:result result})))))
   
   adp/AdminJWTManager
+  (-purge-blocklist
+   [this]
+   (let [conn (lrs-conn this)
+         input (admin-jwt-input/purge-blocklist-input)]
+     (jdbc/with-transaction [tx conn]
+       (admin-cmd/purge-blocklist! backend tx input))))
   (-block-jwt
    [this jwt exp]
    (let [conn      (lrs-conn this)
          jwt-input (admin-jwt-input/insert-blocked-jwt-input jwt exp)]
      (jdbc/with-transaction [tx conn]
-       (admin-cmd/purge-blocklist! backend tx jwt-input)
        (admin-cmd/insert-blocked-jwt! backend tx jwt-input))))
   (-jwt-blocked?
    [this jwt]

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -308,27 +308,16 @@
   
   adp/AdminJWTManager
   (-block-jwt
-   [this account-id expiration leeway]
+   [this jwt exp]
    (let [conn      (lrs-conn this)
-         jwt-input (admin-jwt-input/insert-blocked-jwt-input account-id
-                                                             expiration
-                                                             leeway)]
+         jwt-input (admin-jwt-input/insert-blocked-jwt-input jwt exp)]
      (jdbc/with-transaction [tx conn]
        (admin-cmd/purge-blocklist! backend tx jwt-input)
        (admin-cmd/insert-blocked-jwt! backend tx jwt-input))))
-  (-unblock-jwts
-   [this account-id leeway]
-   (let [conn      (lrs-conn this)
-         jwt-input (admin-jwt-input/delete-blocked-jwts-input account-id
-                                                              leeway)]
-     (jdbc/with-transaction [tx conn]
-       (admin-cmd/purge-blocklist! backend tx jwt-input)
-       (admin-cmd/delete-blocked-jwts! backend tx jwt-input))))
   (-jwt-blocked?
-   [this account-id leeway]
+   [this jwt]
    (let [conn      (lrs-conn this)
-         jwt-input (admin-jwt-input/query-blocked-jwt-input account-id
-                                                            leeway)]
+         jwt-input (admin-jwt-input/query-blocked-jwt-input jwt)]
      (jdbc/with-transaction [tx conn]
        (admin-q/query-blocked-jwt-exists backend tx jwt-input))))
 

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -308,9 +308,9 @@
   
   adp/AdminJWTManager
   (-purge-blocklist
-   [this]
-   (let [conn (lrs-conn this)
-         input (admin-jwt-input/purge-blocklist-input)]
+   [this leeway]
+   (let [conn  (lrs-conn this)
+         input (admin-jwt-input/purge-blocklist-input leeway)]
      (jdbc/with-transaction [tx conn]
        (admin-cmd/purge-blocklist! backend tx input))))
   (-block-jwt

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -308,24 +308,27 @@
   
   adp/AdminJWTManager
   (-block-jwt
-   [this account-id expiration]
+   [this account-id expiration leeway]
    (let [conn      (lrs-conn this)
          jwt-input (admin-jwt-input/insert-blocked-jwt-input account-id
-                                                             expiration)]
+                                                             expiration
+                                                             leeway)]
      (jdbc/with-transaction [tx conn]
        (admin-cmd/purge-blocklist! backend tx jwt-input)
        (admin-cmd/insert-blocked-jwt! backend tx jwt-input))))
   (-unblock-jwts
-   [this account-id]
+   [this account-id leeway]
    (let [conn      (lrs-conn this)
-         jwt-input (admin-jwt-input/delete-blocked-jwts-input account-id)]
+         jwt-input (admin-jwt-input/delete-blocked-jwts-input account-id
+                                                              leeway)]
      (jdbc/with-transaction [tx conn]
        (admin-cmd/purge-blocklist! backend tx jwt-input)
        (admin-cmd/delete-blocked-jwts! backend tx jwt-input))))
   (-jwt-blocked?
-   [this account-id]
+   [this account-id leeway]
    (let [conn      (lrs-conn this)
-         jwt-input (admin-jwt-input/query-blocked-jwt-input account-id)]
+         jwt-input (admin-jwt-input/query-blocked-jwt-input account-id
+                                                            leeway)]
      (jdbc/with-transaction [tx conn]
        (admin-q/query-blocked-jwt-exists backend tx jwt-input))))
 

--- a/src/main/lrsql/util.clj
+++ b/src/main/lrsql/util.clj
@@ -85,6 +85,16 @@
                                       jt/offset-date-time
                                       jt/instant)))
 
+(s/fdef millis->time
+  :args (s/cat :ts-millis nat-int?)
+  :ret instant-spec)
+
+(defn millis->time
+  "Convert a number representing the number of milliseconds since January 1,
+   1970 to a java.util.Instant timestamp."
+  [ts-millis]
+  (jt/instant ts-millis))
+
 (s/fdef time->str
   :args (s/cat :ts instant-spec)
   :ret ::xs/timestamp)

--- a/src/test/lrsql/admin/protocol_test.clj
+++ b/src/test/lrsql/admin/protocol_test.clj
@@ -127,40 +127,18 @@
         (let [bad-account-id #uuid "00000000-0000-4000-8000-000000000000"]
           (is (not (adp/-existing-account? lrs bad-account-id)))))
       (testing "Admin JWTs"
-        (let [expiration-2 (u/current-time)
-              expiration   (u/offset-time expiration-2 3600 :seconds)
-              account-id   (:result
-                            (adp/-authenticate-account lrs
-                                                       test-username
-                                                       test-password))
-              account-id-2 (:result
-                            (adp/-authenticate-account lrs
-                                                       test-username-2
-                                                       test-password))
-              leeway       2]
+        (let [expiration 1000
+              jwt-1      "Foo"
+              jwt-2      "Bar"]
           (testing "- block"
-            (is (= account-id   ; Current JWT
-                   (:result (adp/-block-jwt lrs account-id expiration leeway))))
-            (is (= account-id-2 ; Expired JWT (need to add after to avoid purge)
-                   (:result (adp/-block-jwt lrs account-id-2 expiration-2 leeway))))
+            (is (= jwt-1 ; Current JWT
+                   (:result (adp/-block-jwt lrs jwt-1 expiration))))
+            (is (= jwt-2 ; Expired JWT (need to add after to avoid purge)
+                   (:result (adp/-block-jwt lrs jwt-2 expiration))))
             (is (true?
-                 (adp/-jwt-blocked? lrs account-id leeway)))
-            (is (true? ; Not expired thanks to leeway
-                 (adp/-jwt-blocked? lrs account-id leeway)))
-            (Thread/sleep 2000) ; Wait 2 seconds to accommodate leeway
+                 (adp/-jwt-blocked? lrs jwt-1)))
             (is (false? ; Expired JWT doesn't count as blocked
-                 (adp/-jwt-blocked? lrs account-id-2 leeway))))
-          (testing "- unblock"
-            (is (= account-id
-                   (:result (adp/-unblock-jwts lrs account-id leeway))))
-            (is (false?
-                 (adp/-jwt-blocked? lrs account-id leeway)))
-            (is (false?
-                 (adp/-jwt-blocked? lrs account-id-2 leeway)))
-            (is (= account-id-2
-                   (:result (adp/-unblock-jwts lrs account-id-2 leeway))))
-            (is (false?
-                 (adp/-jwt-blocked? lrs account-id-2 leeway))))))
+                 (adp/-jwt-blocked? lrs jwt-2))))))
       (testing "Admin password update"
         (let [account-id   (-> (adp/-authenticate-account lrs
                                                           test-username

--- a/src/test/lrsql/admin/protocol_test.clj
+++ b/src/test/lrsql/admin/protocol_test.clj
@@ -130,7 +130,13 @@
         (let [expiration 1000
               jwt-1      "Foo"
               jwt-2      "Bar"]
-          (testing "- block"
+          (is (false?
+               (adp/-jwt-blocked? lrs jwt-1)))
+          (is (= jwt-1
+                 (:result (adp/-block-jwt lrs jwt-1 expiration))))
+          (is (true?
+               (adp/-jwt-blocked? lrs jwt-1)))
+          #_(testing "- block"
             (is (= jwt-1 ; Current JWT
                    (:result (adp/-block-jwt lrs jwt-1 expiration))))
             (is (= jwt-2 ; Expired JWT (need to add after to avoid purge)

--- a/src/test/lrsql/admin/protocol_test.clj
+++ b/src/test/lrsql/admin/protocol_test.clj
@@ -151,7 +151,9 @@
             (is (false?
                  (adp/-jwt-blocked? lrs jwt-1)))
             (is (true?
-                 (adp/-jwt-blocked? lrs jwt-2))))))
+                 (adp/-jwt-blocked? lrs jwt-2))))
+          (testing "- cannot insert duplicates into blocklist"
+            (is (some? (:error (adp/-block-jwt lrs jwt-2 expiration)))))))
       (testing "Admin password update"
         (let [account-id   (-> (adp/-authenticate-account lrs
                                                           test-username

--- a/src/test/lrsql/admin/protocol_test.clj
+++ b/src/test/lrsql/admin/protocol_test.clj
@@ -127,23 +127,30 @@
         (let [bad-account-id #uuid "00000000-0000-4000-8000-000000000000"]
           (is (not (adp/-existing-account? lrs bad-account-id)))))
       (testing "Admin JWTs"
-        (let [expiration 1000
+        (let [expiration 2
               jwt-1      "Foo"
               jwt-2      "Bar"]
-          (is (false?
-               (adp/-jwt-blocked? lrs jwt-1)))
-          (is (= jwt-1
-                 (:result (adp/-block-jwt lrs jwt-1 expiration))))
-          (is (true?
-               (adp/-jwt-blocked? lrs jwt-1)))
-          #_(testing "- block"
-            (is (= jwt-1 ; Current JWT
+          (testing "- are unblocked by default"
+            (is (false?
+                 (adp/-jwt-blocked? lrs jwt-1)))
+            (is (false?
+                 (adp/-jwt-blocked? lrs jwt-2))))
+          (testing "- can be blocked"
+            (is (= jwt-1
                    (:result (adp/-block-jwt lrs jwt-1 expiration))))
-            (is (= jwt-2 ; Expired JWT (need to add after to avoid purge)
+            (Thread/sleep 2000)
+            (is (= jwt-2
                    (:result (adp/-block-jwt lrs jwt-2 expiration))))
             (is (true?
                  (adp/-jwt-blocked? lrs jwt-1)))
-            (is (false? ; Expired JWT doesn't count as blocked
+            (is (true?
+                 (adp/-jwt-blocked? lrs jwt-2))))
+          (testing "- can be purged from blocklist only when expired"
+            (is (= nil
+                   (adp/-purge-blocklist lrs)))
+            (is (false?
+                 (adp/-jwt-blocked? lrs jwt-1)))
+            (is (true?
                  (adp/-jwt-blocked? lrs jwt-2))))))
       (testing "Admin password update"
         (let [account-id   (-> (adp/-authenticate-account lrs

--- a/src/test/lrsql/admin/protocol_test.clj
+++ b/src/test/lrsql/admin/protocol_test.clj
@@ -122,7 +122,7 @@
         (let [bad-account-id #uuid "00000000-0000-4000-8000-000000000000"]
           (is (not (adp/-existing-account? lrs bad-account-id)))))
       (testing "Admin JWTs"
-        (let [expiration (u/current-time)
+        (let [expiration (.plusSeconds (u/current-time) 3600)
               account-id (:result
                           (adp/-authenticate-account lrs
                                                      test-username

--- a/src/test/lrsql/admin/protocol_test.clj
+++ b/src/test/lrsql/admin/protocol_test.clj
@@ -121,6 +121,22 @@
           (is (adp/-existing-account? lrs account-id)))
         (let [bad-account-id #uuid "00000000-0000-4000-8000-000000000000"]
           (is (not (adp/-existing-account? lrs bad-account-id)))))
+      (testing "Admin JWTs"
+        (let [expiration (u/current-time)
+              account-id (:result
+                          (adp/-authenticate-account lrs
+                                                     test-username
+                                                     test-password))]
+          (testing "- block"
+            (is (= account-id
+                   (:result (adp/-block-jwt lrs account-id expiration))))
+            (is (true?
+                 (adp/-jwt-blocked? lrs account-id))))
+          (testing "- unblock"
+            (is (= account-id
+                   (:result (adp/-unblock-jwts lrs account-id))))
+            (is (false?
+                 (adp/-jwt-blocked? lrs account-id))))))
       (testing "Admin password update"
         (let [account-id   (-> (adp/-authenticate-account lrs
                                                           test-username

--- a/src/test/lrsql/admin/route_test.clj
+++ b/src/test/lrsql/admin/route_test.clj
@@ -497,6 +497,8 @@
         (let [{:keys [status]} (logout-account headers)]
           (is (= 200 status)))
         (is-err-code (get-me headers) 401)
+        ;; Logout again, should be unauthenticated
+        (is-err-code (logout-account headers) 401)
         ;; Login
         (let [{:keys [status body]} (login-account content-type seed-body)
               new-jwt  (-> body

--- a/src/test/lrsql/admin/route_test.clj
+++ b/src/test/lrsql/admin/route_test.clj
@@ -480,8 +480,7 @@
         ;; Logout
         (let [{:keys [status]} (logout-account headers)]
           (is (= 200 status)))
-        (let [{:keys [status]} (get-me headers)]
-          (is (= 401 status)))
+        (is-err-code (get-me headers) 401)
         ;; Login
         (let [{:keys [status body]} (login-account content-type seed-body)
               new-jwt  (-> body

--- a/src/test/lrsql/input/input_test.clj
+++ b/src/test/lrsql/input/input_test.clj
@@ -5,6 +5,7 @@
             [lrsql.input.activity     :as i-av]
             [lrsql.input.attachment   :as i-at]
             [lrsql.input.admin        :as i-admin]
+            [lrsql.input.admin.jwt    :as i-adm-jwt]
             [lrsql.input.admin.status :as i-adm-stat]
             [lrsql.input.auth         :as i-auth]
             [lrsql.input.statement    :as i-stmt]
@@ -56,6 +57,12 @@
     (is (nil? (check-validate `i-admin/query-validate-admin-input)))
     (is (nil? (check-validate `i-admin/query-admin-exists-input)))
     (is (nil? (check-validate `i-admin/delete-admin-input)))))
+
+(deftest test-admin-jwt
+  (testing "admin JWT inputs"
+    (is (nil? (check-validate `i-adm-jwt/query-blocked-jwt-input)))
+    (is (nil? (check-validate `i-adm-jwt/insert-blocked-jwt-input)))
+    (is (nil? (check-validate `i-adm-jwt/delete-blocked-jwts-input)))))
 
 (deftest test-admin-status
   (testing "admin status inputs"

--- a/src/test/lrsql/input/input_test.clj
+++ b/src/test/lrsql/input/input_test.clj
@@ -61,8 +61,7 @@
 (deftest test-admin-jwt
   (testing "admin JWT inputs"
     (is (nil? (check-validate `i-adm-jwt/query-blocked-jwt-input)))
-    (is (nil? (check-validate `i-adm-jwt/insert-blocked-jwt-input)))
-    (is (nil? (check-validate `i-adm-jwt/delete-blocked-jwts-input)))))
+    (is (nil? (check-validate `i-adm-jwt/insert-blocked-jwt-input)))))
 
 (deftest test-admin-status
   (testing "admin status inputs"

--- a/src/test/lrsql/util/admin_test.clj
+++ b/src/test/lrsql/util/admin_test.clj
@@ -16,16 +16,16 @@
       (is (= test-id
              (-> test-id
                  (ua/account-id->jwt "secret" 3600)
-                 (ua/jwt->payload "secret" 1))))
+                 (ua/jwt->account-id "secret" 1))))
       (is (= :lrsql.admin/unauthorized-token-error
-             (ua/jwt->payload nil "secret" 3600)))
+             (ua/jwt->account-id nil "secret" 3600)))
       (is (= :lrsql.admin/unauthorized-token-error
-             (ua/jwt->payload "not-a-jwt" "secret" 3600)))
+             (ua/jwt->account-id "not-a-jwt" "secret" 3600)))
       (is (= :lrsql.admin/unauthorized-token-error
              (-> test-id
                  (ua/account-id->jwt "secret" 3600)
-                 (ua/jwt->payload "different-secret" 1))))
+                 (ua/jwt->account-id "different-secret" 1))))
       (is (= :lrsql.admin/unauthorized-token-error
              (let [tok (ua/account-id->jwt test-id "secret" 1)
                    _   (Thread/sleep 1001)]
-               (ua/jwt->payload tok "secret" 0)))))))
+               (ua/jwt->account-id tok "secret" 0)))))))

--- a/src/test/lrsql/util/admin_test.clj
+++ b/src/test/lrsql/util/admin_test.clj
@@ -16,16 +16,16 @@
       (is (= test-id
              (-> test-id
                  (ua/account-id->jwt "secret" 3600)
-                 (ua/jwt->account-id "secret" 1))))
+                 (ua/jwt->payload "secret" 1))))
       (is (= :lrsql.admin/unauthorized-token-error
-             (ua/jwt->account-id nil "secret" 3600)))
+             (ua/jwt->payload nil "secret" 3600)))
       (is (= :lrsql.admin/unauthorized-token-error
-             (ua/jwt->account-id "not-a-jwt" "secret" 3600)))
+             (ua/jwt->payload "not-a-jwt" "secret" 3600)))
       (is (= :lrsql.admin/unauthorized-token-error
              (-> test-id
                  (ua/account-id->jwt "secret" 3600)
-                 (ua/jwt->account-id "different-secret" 1))))
+                 (ua/jwt->payload "different-secret" 1))))
       (is (= :lrsql.admin/unauthorized-token-error
              (let [tok (ua/account-id->jwt test-id "secret" 1)
                    _   (Thread/sleep 1001)]
-               (ua/jwt->account-id tok "secret" 0)))))))
+               (ua/jwt->payload tok "secret" 0)))))))

--- a/src/test/lrsql/util/admin_test.clj
+++ b/src/test/lrsql/util/admin_test.clj
@@ -16,16 +16,22 @@
       (is (= test-id
              (-> test-id
                  (ua/account-id->jwt "secret" 3600)
-                 (ua/jwt->account-id "secret" 1))))
+                 (ua/jwt->payload "secret" 1)
+                 :account-id)))
+      (is (inst?
+           (-> test-id
+               (ua/account-id->jwt "secret" 3600)
+               (ua/jwt->payload "secret" 1)
+               :expiration)))
       (is (= :lrsql.admin/unauthorized-token-error
-             (ua/jwt->account-id nil "secret" 3600)))
+             (ua/jwt->payload nil "secret" 3600)))
       (is (= :lrsql.admin/unauthorized-token-error
-             (ua/jwt->account-id "not-a-jwt" "secret" 3600)))
+             (ua/jwt->payload "not-a-jwt" "secret" 3600)))
       (is (= :lrsql.admin/unauthorized-token-error
              (-> test-id
                  (ua/account-id->jwt "secret" 3600)
-                 (ua/jwt->account-id "different-secret" 1))))
+                 (ua/jwt->payload "different-secret" 1))))
       (is (= :lrsql.admin/unauthorized-token-error
              (let [tok (ua/account-id->jwt test-id "secret" 1)
                    _   (Thread/sleep 1001)]
-               (ua/jwt->account-id tok "secret" 0)))))))
+               (ua/jwt->payload tok "secret" 0)))))))


### PR DESCRIPTION
Implement a `/admin/account/logout` endpoint that revokes the user's current JWT. The revocation is implemented using a blocklist implemented in the SQL database, that is purged of expired tokens whenever the user performs a login or logout.

The blocklist expiration is determined by `LRSQL_JWT_EXP_TIME`, since that is the shorted time interval the revocation can safely last (otherwise if we revoke a JWT immediately after it's issued, but un-revoke it before the token expires via blocklist purging, then the revocation becomes pointless).

Important refactors:
- Extracted out JWT decoding and verification functions from `validate-jwt` interceptor
- JWT decoding functions now return maps instead of scalars
- Surround admin route tests with try-finally blocks