### PR TITLE
Update workflow-runtimer version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
   build_jre:
     needs: get_modules
-    uses: yetanalytics/workflow-runtimer/.github/workflows/runtimer.yml@v1
+    uses: yetanalytics/workflow-runtimer/.github/workflows/runtimer.yml@v2
     with:
       java-version: '11'
       java-distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,12 +47,12 @@ jobs:
     - name: Download ubuntu-latest Artifact
       uses: actions/download-artifact@v4
       with:
-        name: ubuntu-20.04-jre
+        name: ubuntu-22.04-jre
 
     - name: Download macOS-latest Artifact
       uses: actions/download-artifact@v4
       with:
-        name: macos-12-jre
+        name: macos-14-jre
 
     - name: Download windows-latest Artifact
       uses: actions/download-artifact@v4
@@ -63,10 +63,10 @@ jobs:
     - name: Unzip the runtimes
       run: |
         mkdir -p target/bundle/runtimes
-        unzip ubuntu-20.04-jre.zip -d target/bundle/runtimes
-        mv target/bundle/runtimes/ubuntu-20.04 target/bundle/runtimes/linux
-        unzip macos-12-jre.zip -d target/bundle/runtimes
-        mv target/bundle/runtimes/macos-12 target/bundle/runtimes/macos
+        unzip ubuntu-22.04-jre.zip -d target/bundle/runtimes
+        mv target/bundle/runtimes/ubuntu-22.04 target/bundle/runtimes/linux
+        unzip macos-14-jre.zip -d target/bundle/runtimes
+        mv target/bundle/runtimes/macos-14 target/bundle/runtimes/macos
         unzip windows-2022-jre.zip -d target/bundle/runtimes
         mv target/bundle/runtimes/windows-2022 target/bundle/runtimes/windows
 


### PR DESCRIPTION
Update the version of the workflow-runtimer reusable workflow in order to update to Ubuntu 22.04 and MacOS 14; the latter is critical due to MacOS 12 being deprecated in GitHub Actions.