### PR TITLE
Activity Definition Upsert

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -51,7 +51,7 @@
   ;; Yet Analytics deps
 
   com.yetanalytics/lrs
-  {:mvn/version "1.2.21"
+  {:mvn/version "1.3.0"
    :exclusions  [org.clojure/clojure
                  org.clojure/clojurescript
                  com.yetanalytics/xapi-schema]}

--- a/src/test/lrsql/lrs_test.clj
+++ b/src/test/lrsql/lrs_test.clj
@@ -416,21 +416,15 @@
       (testing "agent query"
         (is (= {:person
                 {"objectType" "Person"
-                 "name" ["Sample Agent 1"]
-                 "mbox" ["mailto:sample.agent@example.com"]}}
+                 "name"       ["Sample Agent 1"]
+                 "mbox"       ["mailto:sample.agent@example.com"]}}
                (lrsp/-get-person lrs auth-ident {:agent agt-1}))))
 
       (testing "activity query"
         ;; Activity was updated between stmt-0 and stmt-1
         ;; Result should contain full definition.
         (is (= {:activity
-                {"id"         "http://www.example.com/tincan/activities/multipart"
-                 "objectType" "Activity"
-                 "definition" {"type"        "http://www.example.com/activity-types/test"
-                               "name"        {"en-US" "Multi Part Activity"
-                                              "zh-CN" "多元部分Activity"}
-                               "description" {"en-US" "Multi Part Activity Description"
-                                              "zh-CN" "多元部分Activity的简述"}}}}
+                (get stmt-1 "object")}
                (lrsp/-get-activity lrs auth-ident {:activityId act-1}))))
 
       (testing "Extremely long IRIs"
@@ -451,13 +445,7 @@
         (lrsp/-store-statements lrs auth-ident [stmt-0] [])
         ;; Activity was updated between stmt-1 and stmt-0
         (is (= {:activity
-                {"id"         "http://www.example.com/tincan/activities/multipart"
-                 "objectType" "Activity"
-                 "definition" {"type"        "http://www.example.com/activity-types/test"
-                               "name"        {"en-US" "Multi Part Activity"
-                                              "zh-CN" "多元部分Activity"}
-                               "description" {"en-US" "Multi Part Activity Description"
-                                              "zh-CN" "多元部分Activity的简述"}}}}
+                (get stmt-1 "object")}
                (lrsp/-get-activity lrs auth-ident {:activityId act-1}))))
 
       (finally

--- a/src/test/lrsql/lrs_test.clj
+++ b/src/test/lrsql/lrs_test.clj
@@ -444,7 +444,6 @@
   (let [sys   (support/test-system)
         sys'  (component/start sys)
         lrs   (-> sys' :lrs)
-        pre   (-> sys' :webserver :config :url-prefix)
         act-1 (get-in stmt-1 ["object" "id"])]
     (try
       (testing "activity query (reverse)"


### PR DESCRIPTION
This PR illustrates a bug with SQL LRS where certain activity definition fields can be "forgotten" when multiple instances of an activity enter the LRS, one without a definition and one with. While the name and description fields appear to be preserved, the `type` field does not.

I've modified `stmt-1` in the lrs tests to have an activity type to show the issue. Note that when `stmt-0` (without a definition) precedes `stmt-1` (with a definition), the resulting activity query is missing the type field. When it is the other way around, `stmt-1` preceding `stmt-0`, the type field shows up.

The issue is resolved by updating the `lrs` lib's `merge-activity` function to allow updates to all definition fields, and to atomically update interaction activity fields.