### PR TITLE
Update base UI path to `/admin/ui`

### DIFF
--- a/src/main/lrsql/admin/interceptors/ui.clj
+++ b/src/main/lrsql/admin/interceptors/ui.clj
@@ -1,5 +1,6 @@
 (ns lrsql.admin.interceptors.ui
   (:require [ring.util.response :as resp]
+            [selmer.parser :as selm-parser]
             [io.pedestal.interceptor :refer [interceptor]]
             [com.yetanalytics.lrs.pedestal.interceptor :as i]
             [lrsql.admin.interceptors.oidc :as oidc-i]
@@ -7,9 +8,12 @@
 
 (defn get-spa
   "Handler function that returns the index.html file."
-  [_]
-  (-> (resp/resource-response "public/admin/index.html")
-      (assoc-in [:headers "Content-Type"] "text/html")))
+  [path-prefix]
+  (fn [_]
+    (-> (selm-parser/render-file "public/admin/index.html"
+                                 {:prefix path-prefix})
+        resp/response
+        (resp/content-type "text/html"))))
 
 (defn admin-ui-redirect
   "Handler function to redirect to the admin UI."

--- a/src/main/lrsql/admin/interceptors/ui.clj
+++ b/src/main/lrsql/admin/interceptors/ui.clj
@@ -15,7 +15,7 @@
   "Handler function to redirect to the admin ui"
   [path-prefix]
   (fn [_]
-    (resp/redirect (str path-prefix "/admin"))))
+    (resp/redirect (str path-prefix "/admin/ui"))))
 
 (defn get-env
   "Provide select config data to client upon request. Takes a map with static

--- a/src/main/lrsql/admin/interceptors/ui.clj
+++ b/src/main/lrsql/admin/interceptors/ui.clj
@@ -5,11 +5,17 @@
             [lrsql.admin.interceptors.oidc :as oidc-i]
             [lrsql.init.localization :refer [custom-language-map]]))
 
+(defn get-spa
+  [path-prefix]
+  (fn [_]
+    (-> (resp/resource-response (str path-prefix "public/admin/index.html"))
+        (assoc-in [:headers "Content-Type"] "text/html"))))
+
 (defn admin-ui-redirect
   "Handler function to redirect to the admin ui"
   [path-prefix]
   (fn [_]
-    (resp/redirect (str path-prefix "/admin/index.html"))))
+    (resp/redirect (str path-prefix "/admin"))))
 
 (defn get-env
   "Provide select config data to client upon request. Takes a map with static

--- a/src/main/lrsql/admin/interceptors/ui.clj
+++ b/src/main/lrsql/admin/interceptors/ui.clj
@@ -6,13 +6,13 @@
             [lrsql.init.localization :refer [custom-language-map]]))
 
 (defn get-spa
-  [path-prefix]
-  (fn [_]
-    (-> (resp/resource-response (str path-prefix "public/admin/index.html"))
-        (assoc-in [:headers "Content-Type"] "text/html"))))
+  "Handler function that returns the index.html file."
+  [_]
+  (-> (resp/resource-response "public/admin/index.html")
+      (assoc-in [:headers "Content-Type"] "text/html")))
 
 (defn admin-ui-redirect
-  "Handler function to redirect to the admin ui"
+  "Handler function to redirect to the admin UI."
   [path-prefix]
   (fn [_]
     (resp/redirect (str path-prefix "/admin/ui"))))

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -219,11 +219,11 @@
                              (ui/get-env inject-config))
      :route-name :lrsql.admin.ui/get-env]
     ;; SPA routes
-    ["/admin/ui" :get ui/get-spa
+    ["/admin/ui" :get (ui/get-spa proxy-path)
      :route-name :lrsql.admin.ui/main-path]
-    ["/admin/ui/" :get ui/get-spa
+    ["/admin/ui/" :get (ui/get-spa proxy-path)
      :route-name :lrsql.admin.ui/slash-path]
-    ["/admin/ui/*path" :get ui/get-spa
+    ["/admin/ui/*path" :get (ui/get-spa proxy-path)
      :route-name :lrsql.admin.ui/sub-paths]
     ;; SPA redirects
     ["/" :get (ui/admin-ui-redirect proxy-path)

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -219,11 +219,11 @@
                              (ui/get-env inject-config))
      :route-name :lrsql.admin.ui/get-env]
     ;; SPA routes
-    ["/admin/ui" :get (ui/get-spa proxy-path)
+    ["/admin/ui" :get ui/get-spa
      :route-name :lrsql.admin.ui/main-path]
-    ["/admin/ui/" :get (ui/get-spa proxy-path)
+    ["/admin/ui/" :get ui/get-spa
      :route-name :lrsql.admin.ui/slash-path]
-    ["/admin/ui/*path" :get (ui/get-spa proxy-path)
+    ["/admin/ui/*path" :get ui/get-spa
      :route-name :lrsql.admin.ui/sub-paths]
     ;; SPA redirects
     ["/" :get (ui/admin-ui-redirect proxy-path)

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -218,26 +218,20 @@
   #{["/admin/env" :get (conj common-interceptors
                              (ui/get-env inject-config))
      :route-name :lrsql.admin.ui/get-env]
-    ;; SPA index.html retirevals + redirects
-    ["/admin" :get (ui/get-spa proxy-path)
-     :route-name :lrsql.admin.ui/path-redirect]
+    ;; SPA routes
+    ["/admin/ui" :get (ui/get-spa proxy-path)
+     :route-name :lrsql.admin.ui/main-path]
+    ["/admin/ui/" :get (ui/get-spa proxy-path)
+     :route-name :lrsql.admin.ui/slash-path]
+    ["/admin/ui/*path" :get (ui/get-spa proxy-path)
+     :route-name :lrsql.admin.ui/sub-paths]
+    ;; SPA redirects
     ["/" :get (ui/admin-ui-redirect proxy-path)
      :route-name :lrsql.admin.ui/root-redirect]
-    ["/admin/" :get (ui/admin-ui-redirect proxy-path)
+    ["/admin" :get (ui/admin-ui-redirect proxy-path)
      :route-name :lrsql.admin.ui/slash-redirect]
-    ;; re-route routes
-    ["/admin/credentials" :get (ui/get-spa proxy-path)
-     :route-name :lrsql.admin.ui/admin-credentials-redirect]
-    ["/admin/accounts" :get (ui/get-spa proxy-path)
-     :route-name :lrsql.admin.ui/admin-accounts-redirect]
-    ["/admin/accounts/password" :get (ui/get-spa proxy-path)
-     :route-name :lrsql.admin.ui/admin-accounts-password-redirect]
-    ["/admin/data-management" :get (ui/get-spa proxy-path)
-     :route-name :lrsql.admin.ui/admin-data-management-redirect]
-    ["/admin/status" :get (ui/get-spa proxy-path)
-     :route-name :lrsql.admin.ui/admin-status-redirect]
-    ["/admin/reactions" :get (ui/get-spa proxy-path)
-     :route-name :lrsql.admin.ui/reactions-redirect]})
+    ["/admin/" :get (ui/admin-ui-redirect proxy-path)
+     :route-name :lrsql.admin.ui/slash-redirect-2]})
 
 (defn admin-reaction-routes
   [common-interceptors jwt-secret jwt-leeway no-val-opts]

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -215,18 +215,29 @@
 
 (defn admin-ui-routes
   [common-interceptors {:keys [proxy-path] :as inject-config}]
-  #{;; Redirect root to admin UI
+  #{["/admin/env" :get (conj common-interceptors
+                             (ui/get-env inject-config))
+     :route-name :lrsql.admin.ui/get-env]
+    ;; SPA index.html retirevals + redirects
+    ["/admin" :get (ui/get-spa proxy-path)
+     :route-name :lrsql.admin.ui/path-redirect]
     ["/" :get (ui/admin-ui-redirect proxy-path)
      :route-name :lrsql.admin.ui/root-redirect]
-    ;; Redirect admin w/o slash to admin UI
-    ["/admin" :get (ui/admin-ui-redirect proxy-path)
-     :route-name :lrsql.admin.ui/path-redirect]
-    ;; Redirect admin with slash to admin UI
     ["/admin/" :get (ui/admin-ui-redirect proxy-path)
      :route-name :lrsql.admin.ui/slash-redirect]
-    ["/admin/env" :get (conj common-interceptors
-                             (ui/get-env inject-config))
-     :route-name :lrsql.admin.ui/get-env]})
+    ;; re-route routes
+    ["/admin/credentials" :get (ui/get-spa proxy-path)
+     :route-name :lrsql.admin.ui/admin-credentials-redirect]
+    ["/admin/accounts" :get (ui/get-spa proxy-path)
+     :route-name :lrsql.admin.ui/admin-accounts-redirect]
+    ["/admin/accounts/password" :get (ui/get-spa proxy-path)
+     :route-name :lrsql.admin.ui/admin-accounts-password-redirect]
+    ["/admin/data-management" :get (ui/get-spa proxy-path)
+     :route-name :lrsql.admin.ui/admin-data-management-redirect]
+    ["/admin/status" :get (ui/get-spa proxy-path)
+     :route-name :lrsql.admin.ui/admin-status-redirect]
+    ["/admin/reactions" :get (ui/get-spa proxy-path)
+     :route-name :lrsql.admin.ui/reactions-redirect]})
 
 (defn admin-reaction-routes
   [common-interceptors jwt-secret jwt-leeway no-val-opts]


### PR DESCRIPTION
Update the base UI path to `/admin/ui`, and have it return the `index.html` directly rather than having it redirect to `/admin/index.html`. This will prevent clashing from other `/admin` endpoints, which is important for more detailed paths such as `/admin/ui/credentials` (which will be implemented using [re-route](https://github.com/yetanalytics/re-route) in the frontend).