### PR TITLE
Update Superset documentation and configuration to work with current images

### DIFF
--- a/dev-resources/superset_demo/superset/pythonpath_dev/superset_config.py
+++ b/dev-resources/superset_demo/superset/pythonpath_dev/superset_config.py
@@ -150,7 +150,6 @@ curr = os.path.abspath(os.getcwd())
 AUTH_TYPE = AUTH_OID
 OIDC_CLIENT_SECRETS = curr + '/docker/pythonpath_dev/client_secret.json'
 OIDC_ID_TOKEN_COOKIE_SECURE = False
-OIDC_REQUIRE_VERIFIED_EMAIL = False
 OIDC_OPENID_REALM = get_env_variable('OIDC_OPENID_REALM')
 OIDC_INTROSPECTION_AUTH_METHOD = 'client_secret_post'
 CUSTOM_SECURITY_MANAGER = OIDCSecurityManager

--- a/dev-resources/superset_demo/superset/requirements-local.txt
+++ b/dev-resources/superset_demo/superset/requirements-local.txt
@@ -1,3 +1,4 @@
 itsdangerous==2.0.1
 flask-oidc
 flask_openid
+psycopg2-binary

--- a/doc/superset.md
+++ b/doc/superset.md
@@ -37,12 +37,11 @@ docker run -v "$(pwd)"/dev-resources:/dev-resources  \
            -it \
            --rm \
            yetanalytics/datasim:latest \
+           generate post \
            -i /dev-resources/input/simple.json \
            -E http://host.docker.internal:8080/xapi \
            -U my_key \
-           -P my_secret \
-           generate post
-
+           -P my_secret
 ```
 
 ### Log In to Superset
@@ -89,6 +88,13 @@ Click "FINISH" and the database is ready to explore with Superset.
 Explore SQL LRS in SQL Lab:
 
 ![SQL lab](images/superset/6_sql_explorer.png)
+
+``` sql
+SELECT payload->'actor'->>'name' as actor_name,
+COUNT(DISTINCT id)
+FROM xapi_statement
+GROUP BY payload->'actor'->>'name'
+```
 
 Create a chart:
 


### PR DESCRIPTION
This PR updates the Superset documentation and configuration to maintain compatibility with latest dependencies. Changes include:

- Remove OIDC_REQUIRE_VERIFIED_EMAIL option as it was deprecated and removed in flask-oidc 2.0
- Update datasim command syntax in setup instructions to reflect current CLI format
- Add psycopg2-binary to requirements-local.txt for PostgreSQL support
- Add example SQL query to documentation showing xAPI statement analysis

These changes ensure the setup instructions remain current and functional with the latest versions of all dependencies.

ref: https://flask-oidc.readthedocs.io/en/latest/changelog.html#id21