### PR TITLE
[SQL-105] Editable API key labels

### DIFF
--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -203,6 +203,8 @@
     (insert-credential! tx input))
   (-insert-credential-scope! [_ tx input]
     (insert-credential-scope! tx input))
+  (-update-credential-label! [_ tx input]
+    (update-credential-label! tx input))
   (-delete-credential! [_ tx input]
     (delete-credential! tx input))
   (-delete-credential-scope! [_ tx input]

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -76,7 +76,8 @@
     (when (nil? (check-statement-to-actor-cascading-delete tx))
       (add-statement-to-actor-cascading-delete! tx))
     (when (some? (query-varchar-exists tx))
-      (convert-varchars-to-text! tx)))
+      (convert-varchars-to-text! tx))
+    (alter-lrs-credential-add-label! tx))
 
   bp/BackendUtil
   (-txn-retry? [_ ex]

--- a/src/db/postgres/lrsql/postgres/sql/ddl.sql
+++ b/src/db/postgres/lrsql/postgres/sql/ddl.sql
@@ -488,3 +488,10 @@ ALTER TABLE lrs_credential ALTER COLUMN secret_key TYPE TEXT;
 ALTER TABLE credential_to_scope ALTER COLUMN api_key TYPE TEXT;
 ALTER TABLE credential_to_scope ALTER COLUMN secret_key TYPE TEXT;
 ALTER TABLE reaction ALTER COLUMN title TYPE TEXT;
+
+/* Migration 2025-02-03 - Add label column to lrs_credential table */
+
+-- :name alter-lrs-credential-add-label!
+-- :command :execute
+-- :doc Add the `label` column to the `lrs_credential` table if it does not exist.
+ALTER TABLE lrs_credential ADD COLUMN IF NOT EXISTS label TEXT;

--- a/src/db/postgres/lrsql/postgres/sql/insert.sql
+++ b/src/db/postgres/lrsql/postgres/sql/insert.sql
@@ -135,9 +135,9 @@ INSERT INTO admin_account (
 -- :result :affected
 -- :doc Given API keys and `:account-id`, insert the credentials into the credential table.
 INSERT INTO lrs_credential (
-  id, api_key, secret_key, account_id
+  id, api_key, secret_key, account_id, label
 ) VALUES (
-  :primary-key, :api-key, :secret-key, :account-id
+  :primary-key, :api-key, :secret-key, :account-id, :label
 );
 
 -- :name insert-credential-scope!

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -286,7 +286,7 @@ WHERE oidc_issuer IS NULL;
 -- :command :query
 -- :result :many
 -- :doc Query all credentials associated with `:account-id`.
-SELECT api_key, secret_key FROM lrs_credential
+SELECT api_key, secret_key, label FROM lrs_credential
 WHERE account_id = :account-id;
 
 -- :name query-credential-ids

--- a/src/db/postgres/lrsql/postgres/sql/update.sql
+++ b/src/db/postgres/lrsql/postgres/sql/update.sql
@@ -68,6 +68,8 @@ SET
 WHERE profile_id = :profile-id
 AND activity_iri = :activity-iri;
 
+/* Admin Accounts + Credentials */
+
 -- :name update-admin-password!
 -- :command :execute
 -- :result :affected
@@ -76,6 +78,18 @@ UPDATE admin_account
 SET
   passhash = :new-passhash
 WHERE id = :account-id;
+
+-- :name update-credential-label!
+-- :command :execute
+-- :result :affected
+-- :doc Set the `label` column for the corresponding credential.
+UPDATE lrs_credential
+SET
+  label = :label
+WHERE api_key = :api-key
+AND secret_key = :secret-key;
+
+/* Reactions */
 
 -- :name update-reaction!
 -- :command :execute

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -244,6 +244,8 @@
     (insert-credential! tx input))
   (-insert-credential-scope! [_ tx input]
     (insert-credential-scope! tx input))
+  (-update-credential-label! [_ tx input]
+    (update-credential-label! tx input))
   (-delete-credential! [_ tx input]
     (delete-credential! tx input))
   (-delete-credential-scope! [_ tx input]

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -112,6 +112,8 @@
       (xapi-statement-add-trigger-id! tx))
     (when-not (some? (query-statement-to-actor-has-cascade-delete tx))
       (update-schema-simple! tx alter-statement-to-actor-add-cascade-delete!))
+    (when-not (some? (query-lrs-credential-label-exists tx))
+      (alter-lrs-credential-add-label! tx))
     (log/infof "sqlite schema_version: %d"
                (:schema_version (query-schema-version tx))))
 

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -523,4 +523,17 @@ SET sql = 'CREATE TABLE statement_to_actor (
     ON DELETE CASCADE,
   FOREIGN KEY (actor_ifi, actor_type) REFERENCES actor(actor_ifi, actor_type)
 )'
-WHERE type = 'table' AND name = 'statement_to_actor'
+WHERE type = 'table' AND name = 'statement_to_actor';
+
+/* Migration 2025-02-03 - Add label column to lrs_credential table */
+
+-- :name query-lrs-credential-label-exists
+-- :command :query
+-- :result :one
+-- :doc Query to see if `lrs_credential.label` exists.
+SELECT 1 FROM pragma_table_info('lrs_column') WHERE name = 'label'
+
+-- :name alter-lrs-credential-add-label!
+-- :command :execute
+-- :doc Add the `label` column to the `lrs_credential` table.
+ALTER TABLE lrs_credential ADD COLUMN label TEXT;

--- a/src/db/sqlite/lrsql/sqlite/sql/insert.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/insert.sql
@@ -135,9 +135,9 @@ INSERT INTO admin_account (
 -- :result :affected
 -- :doc Given API keys and `:account-id`, insert the credentials into the credential table.
 INSERT INTO lrs_credential (
-  id, api_key, secret_key, account_id
+  id, api_key, secret_key, account_id, label
 ) VALUES (
-  :primary-key, :api-key, :secret-key, :account-id
+  :primary-key, :api-key, :secret-key, :account-id, :label
 )
 
 -- :name insert-credential-scope!

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -262,7 +262,7 @@ WHERE oidc_issuer IS NULL
 -- :command :query
 -- :result :many
 -- :doc Query all credentials associated with `:account-id`.
-SELECT api_key, secret_key FROM lrs_credential
+SELECT api_key, secret_key, label FROM lrs_credential
 WHERE account_id = :account-id
 
 -- :name query-credential-ids

--- a/src/db/sqlite/lrsql/sqlite/sql/update.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/update.sql
@@ -63,6 +63,8 @@ SET
 WHERE profile_id = :profile-id
 AND activity_iri = :activity-iri
 
+/* Admin Accounts + Credentials */
+
 -- :name update-admin-password!
 -- :command :execute
 -- :result :affected
@@ -71,6 +73,18 @@ UPDATE admin_account
 SET
   passhash = :new-passhash
 WHERE id = :account-id
+
+-- :name update-credential-label!
+-- :command :execute
+-- :result :affected
+-- :doc Set the `label` column for the corresponding credential.
+UPDATE lrs_credential
+SET
+  label = :label
+WHERE api_key = :api-key
+AND secret_key = :secret-key
+
+/* Reactions */
 
 -- :name update-reaction!
 -- :command :execute

--- a/src/main/lrsql/admin/interceptors/credentials.clj
+++ b/src/main/lrsql/admin/interceptors/credentials.clj
@@ -21,7 +21,9 @@
        (if-some [err (or (when key-pair?
                            (s/explain-data as/key-pair-spec params))
                          (when scopes?
-                           (s/explain-data as/scopes-spec params)))]
+                           (s/explain-data as/scopes-spec params))
+                         (when (:label params)
+                           (s/explain-data as/label-spec params)))]
          ;; Invalid parameters - Bad Request
          (assoc (chain/terminate ctx)
                 :response
@@ -31,6 +33,7 @@
          ;; Valid parameters - continue
          (let [cred-info (select-keys params [:api-key
                                               :secret-key
+                                              :label
                                               :scopes])]
            (-> ctx
                (assoc ::data cred-info)

--- a/src/main/lrsql/admin/interceptors/credentials.clj
+++ b/src/main/lrsql/admin/interceptors/credentials.clj
@@ -48,11 +48,12 @@
     (fn create-api-keys [ctx]
       (let [{lrs :com.yetanalytics/lrs
              {:keys [account-id]} ::jwt/data
-             {:keys [scopes]} ::data}
+             {:keys [label scopes]} ::data}
             ctx
             api-key-res
             (adp/-create-api-keys lrs
                                   account-id
+                                  label
                                   (set scopes))]
         (assoc ctx
                :response
@@ -82,13 +83,14 @@
     (fn update-api-keys [ctx]
       (let [{lrs :com.yetanalytics/lrs
              {:keys [account-id]} ::jwt/data
-             {:keys [api-key secret-key scopes]} ::data}
+             {:keys [api-key secret-key label scopes]} ::data}
             ctx
             api-key-res
             (adp/-update-api-keys lrs
                                   account-id
                                   api-key
                                   secret-key
+                                  label
                                   (set scopes))]
         (assoc ctx
                :response

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -19,11 +19,11 @@
     "Update the password for an admin account given old and new passwords."))
 
 (defprotocol APIKeyManager
-  (-create-api-keys [this account-id scopes]
+  (-create-api-keys [this account-id label scopes]
     "Create a new API key pair with the associated scopes.")
   (-get-api-keys [this account-id]
     "Get all API key pairs associated with the account.")
-  (-update-api-keys [this account-id api-key secret-key scopes]
+  (-update-api-keys [this account-id api-key secret-key label scopes]
     "Update the key pair associated with the account with new scopes.")
   (-delete-api-keys [this account-id api-key secret-key]
     "Delete the key pair associated with the account."))

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -105,6 +105,7 @@
   ;; Commands
   (-insert-credential! [this tx input])
   (-insert-credential-scope! [this tx input])
+  (-update-credential-label! [this tx input])
   (-delete-credential! [this tx input])
   (-delete-credential-scope! [this tx input])
   ;; Queries

--- a/src/main/lrsql/init.clj
+++ b/src/main/lrsql/init.clj
@@ -51,12 +51,11 @@
         (when (and ?api-key ?secret-key)
           (let [key-pair {:api-key    ?api-key
                           :secret-key ?secret-key}
+                acc-id   (:primary-key admin-in)
                 cred-in  (auth-input/insert-credential-input
-                          (:primary-key admin-in)
-                          key-pair)
+                          acc-id nil key-pair)
                 scope-in (auth-input/insert-credential-scopes-input
-                          key-pair
-                          #{"all"})]
+                          key-pair #{"all"})]
             ;; Don't insert creds if reconnecting to a DB previously seeded
             ;; with a cred
             (when-not (auth-q/query-credential-scopes* backend tx cred-in)

--- a/src/main/lrsql/input/auth.clj
+++ b/src/main/lrsql/input/auth.clj
@@ -10,21 +10,24 @@
 
 (s/fdef insert-credential-input
   :args (s/cat :account-id ::ads/account-id
+               :label      ::as/label
                :key-pair   as/key-pair-args-spec)
   :ret as/insert-cred-input-spec)
 
 (defn insert-credential-input
   "Given `account-id` and either a `key-pair` map or separate `api-key` and
    `secret-key` args, construct the input param map for `insert-credential!`"
-  ([account-id key-pair]
+  ([account-id label key-pair]
    (assoc key-pair
           :primary-key (u/generate-squuid)
-          :account-id  account-id))
-  ([account-id api-key secret-key]
+          :account-id  account-id
+          :label       label))
+  ([account-id label api-key secret-key]
    {:primary-key (u/generate-squuid)
     :api-key     api-key
     :secret-key  secret-key
-    :account-id  account-id}))
+    :account-id  account-id
+    :label       label}))
 
 (s/fdef insert-credential-scopes-input
   :args (s/cat :key-pair as/key-pair-args-spec
@@ -43,6 +46,25 @@
    (let [key-pair {:api-key    api-key
                    :secret-key secret-key}]
      (insert-credential-scopes-input key-pair scopes))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Credentials Update
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(s/fdef update-credential-label-input
+  :args (s/cat :label    ::as/label
+               :key-pair as/key-pair-args-spec))
+
+(defn update-credential-label-input
+  "Given a `label` and either a `key-pair` map or seperate `api-key` and
+   `secret-key` args, construct the input param map for
+   `update-credential-label!`"
+  ([label key-pair]
+   (assoc key-pair :label label))
+  ([label api-key secret-key]
+   {:api-key    api-key
+    :secret-key secret-key
+    :label      label}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Credentials Deletion

--- a/src/main/lrsql/ops/command/auth.clj
+++ b/src/main/lrsql/ops/command/auth.clj
@@ -64,3 +64,19 @@
   [bk tx input]
   (bp/-delete-credential! bk tx input)
   nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Credential Label Update
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(s/fdef update-credential-label!
+  :args (s/cat :bk as/credential-backend?
+               :tx transaction?
+               :input as/update-cred-label-input-spec)
+  :ret nil?)
+
+(defn update-credential-label!
+  "Update the credential label. Returns `nil`."
+  [bk tx input]
+  (bp/-update-credential-label! bk tx input)
+  nil)

--- a/src/main/lrsql/ops/query/auth.clj
+++ b/src/main/lrsql/ops/query/auth.clj
@@ -79,8 +79,10 @@
   [bk tx input]
   (let [creds  (->> input
                     (bp/-query-credentials bk tx)
-                    (map (fn [{ak :api_key sk :secret_key}]
-                           {:api-key ak :secret-key sk})))
+                    (map (fn [{ak    :api_key
+                               sk    :secret_key
+                               label :label}]
+                           {:api-key ak :secret-key sk :label label})))
         scopes (doall (map (fn [cred]
                              (->> cred
                                   (bp/-query-credential-scopes bk tx)

--- a/src/main/lrsql/spec/auth.clj
+++ b/src/main/lrsql/spec/auth.clj
@@ -65,6 +65,8 @@
 (s/def ::api-key string?)
 (s/def ::secret-key string?)
 
+(s/def ::label (s/nilable string?))
+
 (s/def ::scope string-scopes)
 
 (s/def ::ids
@@ -110,6 +112,7 @@
   (s/keys :req-un [::c/primary-key
                    ::api-key
                    ::secret-key
+                   ::label
                    ::ads/account-id]))
 
 (def insert-cred-scope-input-spec
@@ -120,6 +123,15 @@
 
 (def insert-cred-scopes-input-spec
   (s/coll-of insert-cred-scope-input-spec :gen-max 5))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Update
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def update-cred-label-input-spec
+  (s/keys :req-un [::api-key
+                   ::secret-key
+                   ::label]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Delete

--- a/src/main/lrsql/spec/auth.clj
+++ b/src/main/lrsql/spec/auth.clj
@@ -88,6 +88,7 @@
 (def scoped-key-pair-spec
   (s/keys :req-un [::api-key
                    ::secret-key
+                   ::label
                    ::scopes]))
 
 (def key-pair-args-spec

--- a/src/main/lrsql/spec/auth.clj
+++ b/src/main/lrsql/spec/auth.clj
@@ -85,6 +85,9 @@
 (def scopes-spec
   (s/keys :req-un [::scopes]))
 
+(def label-spec
+  (s/keys :req-un [::label]))
+
 (def scoped-key-pair-spec
   (s/keys :req-un [::api-key
                    ::secret-key

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -307,11 +307,12 @@
 
   adp/APIKeyManager
   (-create-api-keys
-    [this account-id scopes]
+    [this account-id label scopes]
     (let [conn     (lrs-conn this)
           key-pair (auth-util/generate-key-pair)
           cred-in  (auth-input/insert-credential-input
                     account-id
+                    label
                     key-pair)
           scope-in (auth-input/insert-credential-scopes-input
                     key-pair
@@ -328,7 +329,7 @@
         (auth-q/query-credentials backend tx input))))
   (-update-api-keys
     ;; TODO: Verify the key pair is associated with the account ID
-    [this _account-id api-key secret-key scopes]
+    [this _account-id api-key secret-key label scopes]
     (let [conn  (lrs-conn this)
           input (auth-input/query-credential-scopes*-input api-key secret-key)]
       (jdbc/with-transaction [tx conn]
@@ -345,11 +346,17 @@
               del-inputs (auth-input/delete-credential-scopes-input
                           api-key
                           secret-key
-                          del-scopes)]
+                          del-scopes)
+              lab-inputs (auth-input/update-credential-label-input
+                          label
+                          api-key
+                          secret-key)]
+          (auth-cmd/update-credential-label! backend tx lab-inputs)
           (auth-cmd/insert-credential-scopes! backend tx add-inputs)
           (auth-cmd/delete-credential-scopes! backend tx del-inputs)
           {:api-key    api-key
            :secret-key secret-key
+           :label      label
            :scopes     scopes}))))
   (-delete-api-keys
     [this account-id api-key secret-key]

--- a/src/test/lrsql/admin/protocol_test.clj
+++ b/src/test/lrsql/admin/protocol_test.clj
@@ -284,6 +284,7 @@
           (testing "and credential retrieval"
             (is (= [{:api-key    api-key
                      :secret-key secret-key
+                     :label      nil
                      :scopes     #{"all" "all/read"}}]
                    (adp/-get-api-keys lrs acc-id))))
           (testing "and credential update"
@@ -302,6 +303,7 @@
                     #{"all/read" "statements/read" "statements/read/mine"})))
             (is (= [{:api-key    api-key
                      :secret-key secret-key
+                     :label      "My Label"
                      :scopes     #{"all/read"
                                    "statements/read"
                                    "statements/read/mine"}}]

--- a/src/test/lrsql/admin/protocol_test.clj
+++ b/src/test/lrsql/admin/protocol_test.clj
@@ -274,7 +274,7 @@
     (try
       (testing "Credential creation"
         (let [{:keys [api-key secret-key] :as key-pair}
-              (adp/-create-api-keys lrs acc-id #{"all" "all/read"})]
+              (adp/-create-api-keys lrs acc-id nil #{"all" "all/read"})]
           (is (re-matches Base64RegEx api-key))
           (is (re-matches Base64RegEx secret-key))
           (is (= {:api-key    api-key
@@ -289,6 +289,7 @@
           (testing "and credential update"
             (is (= {:api-key    api-key
                     :secret-key secret-key
+                    :label      "My Label"
                     :scopes     #{"all/read"
                                   "statements/read"
                                   "statements/read/mine"}}
@@ -297,6 +298,7 @@
                     acc-id
                     api-key
                     secret-key
+                    "My Label"
                     #{"all/read" "statements/read" "statements/read/mine"})))
             (is (= [{:api-key    api-key
                      :secret-key secret-key


### PR DESCRIPTION
Implement the backend functionality necessary for editable API key labels. Implement a new `label` column in `lrs_credential`, and add `label` as a parameter to API key objects.