### PR TITLE
url-param auth POC

### DIFF
--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -212,6 +212,8 @@
     (query-credential-ids tx input))
   (-query-credential-scopes [_ tx input]
     (query-credential-scopes tx input))
+  (-query-credential-by-id [_ tx input]
+    (query-credential-by-id tx input))
 
   bp/BackendIOSetter
   (-set-read! [_]

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -305,6 +305,13 @@ SELECT scope FROM credential_to_scope
 WHERE api_key = :api-key
 AND secret_key = :secret-key;
 
+-- :name query-credential-by-id
+-- :command :query
+-- :result :one
+-- :doc Get credential by id
+SELECT id, api_key, secret_key, account_id FROM lrs_credential
+WHERE id = :id;
+
 /* LRS Status */
 
 -- :name query-statement-count

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -252,6 +252,8 @@
     (query-credential-ids tx input))
   (-query-credential-scopes [_ tx input]
     (query-credential-scopes tx input))
+  (-query-credential-by-id [_ tx input]
+    (query-credential-by-id tx input))
 
   bp/BackendIOSetter
   (-set-read! [_]

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -281,6 +281,13 @@ SELECT scope FROM credential_to_scope
 WHERE api_key = :api-key
 AND secret_key = :secret-key
 
+-- :name query-credential-by-id
+-- :command :query
+-- :result :one
+-- :doc Get credential by id
+SELECT id, api_key, secret_key, account_id FROM lrs_credential
+WHERE id = :id
+
 /* LRS Status */
 
 -- :name query-statement-count

--- a/src/dev/lrsql/user.clj
+++ b/src/dev/lrsql/user.clj
@@ -8,7 +8,6 @@
             [lrsql.util :as u]
             [lrsql.util.actor :as a-util]))
 
-
 ;; SQLite
 (comment
   (require
@@ -204,3 +203,28 @@
 
   (component/stop sys')
   )
+
+
+(defn splice-into-statements-route [routes]
+  (let [f (fn [idx [path :as route]]
+            (if (= "statements"
+                   (last (clojure.string/split path #"/")))
+              idx))
+        idx (some (keep-indexed f routes))]
+    (update-in routes [idx 2] conj
+               {:name :auth-by-cred-id-interceptor
+                :enter (fn [ctx]
+                         (let [last-of-path (last (get-in ctx [:request :path-info]))
+                               cred-id (get-in ctx [:request :params :credentialID])]
+                           (if (and (= "statements" last-of-path)
+                                    cred-id)
+                             (let [cred-q-input (auth-input/query-credential-by-id-input cred-id)
+                                   {:keys [api-key secret-key]} (auth-q/query-credential-by-id cred-q-input)
+
+                                   base64 (util/str->base64encoded-str (str api-key ":" secret-key))]
+                               (-> ctx
+                                   (update-in [:request :params] dissoc :credentialID)
+                                        ;next spoof basic auth
+                                   (assoc-in [:request :headers "authorization"]
+                                             (str "Basic " base64))))
+                             ctx)))})))

--- a/src/dev/lrsql/user.clj
+++ b/src/dev/lrsql/user.clj
@@ -203,28 +203,3 @@
 
   (component/stop sys')
   )
-
-
-(defn splice-into-statements-route [routes]
-  (let [f (fn [idx [path :as route]]
-            (if (= "statements"
-                   (last (clojure.string/split path #"/")))
-              idx))
-        idx (some (keep-indexed f routes))]
-    (update-in routes [idx 2] conj
-               {:name :auth-by-cred-id-interceptor
-                :enter (fn [ctx]
-                         (let [last-of-path (last (get-in ctx [:request :path-info]))
-                               cred-id (get-in ctx [:request :params :credentialID])]
-                           (if (and (= "statements" last-of-path)
-                                    cred-id)
-                             (let [cred-q-input (auth-input/query-credential-by-id-input cred-id)
-                                   {:keys [api-key secret-key]} (auth-q/query-credential-by-id cred-q-input)
-
-                                   base64 (util/str->base64encoded-str (str api-key ":" secret-key))]
-                               (-> ctx
-                                   (update-in [:request :params] dissoc :credentialID)
-                                        ;next spoof basic auth
-                                   (assoc-in [:request :headers "authorization"]
-                                             (str "Basic " base64))))
-                             ctx)))})))

--- a/src/dev/lrsql/user.clj
+++ b/src/dev/lrsql/user.clj
@@ -203,3 +203,10 @@
 
   (component/stop sys')
   )
+
+(jdbc/execute! ds ["select * from lrs_credential"])
+(require '[lrsql.ops.query.auth :as auth-q])
+(def conn (-> lrs :connection :conn-pool))
+
+(jdbc/with-transaction [tx conn]
+  (auth-q/query-credential-by-id (:backend lrs) tx {:id "0194f6d2-a1fa-8779-821f-bc8d83fbb14f"}))

--- a/src/main/lrsql/auth/interceptor.clj
+++ b/src/main/lrsql/auth/interceptor.clj
@@ -1,0 +1,62 @@
+(ns lrsql.auth.interceptor
+  (:require
+   [lrsql.input.auth :as auth-input]
+   [lrsql.ops.query.auth :as auth-q]
+   [lrsql.util :as util]))
+
+(def holder (atom nil))
+(def h2 (atom nil))
+(def h3 (atom nil))
+
+(def auth-by-cred-id-interceptor
+  {:name :auth-by-cred-id-interceptor
+   :enter (fn auth-by-cred-id-interceptor [ctx]
+            (reset! h3 ctx)
+            (println "triggered")
+            (let [cred-id (get-in ctx [:request :params :credentialID])]
+              (if cred-id
+                (do
+                  (println "triggered statements")
+                  (-> ctx
+                      (update-in [:request :params] dissoc :credentialID)
+                                        ;next spoof basic auth
+                      (assoc-in [:request :com.yetanalytics.url-credential-ID] cred-id)))
+                ctx)))})
+
+
+(defn insert-id-auth-interceptor [routes]
+  (reset! holder routes)
+  (let [statements? (fn [[path method]]
+                      (and 
+                       (= "statements"
+                          (last (clojure.string/split path #"/")))
+                       (= method :get)))
+        map-fn (fn [route]
+                 (if (statements? route)
+                   (update-in route [2] (partial into [auth-by-cred-id-interceptor]))
+                   route))]
+    (reset! h2 (->> routes
+                    (map map-fn)
+                    (set)))))
+
+
+
+
+#_(let [routes @holder
+      statements?  (fn [[path method]]
+                     (and 
+                      (= "statements"
+                         (last (clojure.string/split path #"/")))
+                      (= method :get)))
+      map-fn (fn [route]
+               (if (vector? route) (println "vector") (println "not vector" ))
+               (if (statements? route)
+                 (do 
+                   (println route)
+                   (update-in route [2] (partial into [auth-by-cred-id-interceptor]))) 
+                 route))]
+  
+
+  (->> routes
+       (map map-fn)
+       (set)))

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -110,7 +110,8 @@
   ;; Queries
   (-query-credentials [this tx input])
   (-query-credential-ids [this tx input])
-  (-query-credential-scopes [this tx input]))
+  (-query-credential-scopes [this tx input])
+  (-query-credential-by-id [this tx input]))
 
 (defprotocol AdminStatusBackend
   ;; Queries

--- a/src/main/lrsql/input/auth.clj
+++ b/src/main/lrsql/input/auth.clj
@@ -125,3 +125,10 @@
     :secret-key    secret-key
     :authority-fn  authority-fn
     :authority-url authority-url}))
+
+(s/fdef query-credential-by-id-input
+  :args string?
+  :ret (s/keys :req-un [::id]))
+
+(defn query-credential-by-id-input [id]
+  {:id id})

--- a/src/main/lrsql/input/auth.clj
+++ b/src/main/lrsql/input/auth.clj
@@ -127,7 +127,7 @@
     :authority-url authority-url}))
 
 (s/fdef query-credential-by-id-input
-  :args string?
+  :args (s/cat :id string?)
   :ret (s/keys :req-un [::id]))
 
 (defn query-credential-by-id-input [id]

--- a/src/main/lrsql/ops/query/auth.clj
+++ b/src/main/lrsql/ops/query/auth.clj
@@ -103,4 +103,4 @@
 (defn query-credential-by-id
   "Given an input containing `:id`, return a map containing `:id`, `:api-key`, `:secret-key`, `:account-id`"
   [bk tx input]
-  (query-credential-by-id bk tx))
+  (bp/-query-credential-by-id bk tx input))

--- a/src/main/lrsql/ops/query/auth.clj
+++ b/src/main/lrsql/ops/query/auth.clj
@@ -91,7 +91,7 @@
           creds
           scopes)))
 
-(s/fdef query-credential-by-id
+#_(s/fdef query-credential-by-id
   :args (s/cat :bk as/credential-backend?
                :tx transaction?
                :input as/query-cred-by-id-input-spec)

--- a/src/main/lrsql/ops/query/auth.clj
+++ b/src/main/lrsql/ops/query/auth.clj
@@ -90,3 +90,17 @@
             (assoc cred :scopes (set cred-scopes)))
           creds
           scopes)))
+
+(s/fdef query-credential-by-id
+  :args (s/cat :bk as/credential-backend?
+               :tx transaction?
+               :input as/query-cred-by-id-input-spec)
+  :ret (s/keys :req-un [::id string?
+                        ::api-key string?
+                        ::secret-key string?
+                        ::account-id string?]))
+
+(defn query-credential-by-id
+  "Given an input containing `:id`, return a map containing `:id`, `:api-key`, `:secret-key`, `:account-id`"
+  [bk tx input]
+  (query-credential-by-id bk tx))

--- a/src/main/lrsql/spec/auth.clj
+++ b/src/main/lrsql/spec/auth.clj
@@ -154,3 +154,6 @@
                    ::secret-key
                    ::ats/authority-url
                    ::ats/authority-fn]))
+
+(def query-cred-by-id-input-spec
+  (s/keys :req-un [::id]))

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -46,6 +46,7 @@
       :conn-pool))
 
 (def holder (atom nil))
+(def after-transform (atom nil))
 
 (defrecord LearningRecordStore [connection
                                 backend
@@ -227,22 +228,22 @@
     [lrs ctx]
     (let [transform-from-url-auth
           (fn [ctx]
-            (let [last-of-path (last (get-in ctx [:request :path-info]))
-                  cred-id (get-in ctx [:request :com.yetanalytics.url-credential-ID])]
-              (if (and (= "statements" last-of-path)
-                       cred-id)
-                (let [conn (lrs-conn lrs)
-                      cred-q-input (auth-input/query-credential-by-id-input cred-id)
-                      {:keys [api-key secret-key]}
+            (let [cred-id (get-in ctx [:request :com.yetanalytics.url-credential-ID])]
+              (if cred-id
+                (let [_ (println "triggered in lrs auth")
+                      conn (lrs-conn lrs)
+                      input (auth-input/query-credential-by-id-input cred-id)
+                      _ (println "input:" input)
+                      {api-key :api_key secret-key :secret_key :as result}
                       (jdbc/with-transaction [tx conn]
-                        (auth-q/query-credential-by-id cred-q-input))
-
-
+                        (auth-q/query-credential-by-id backend tx input))
+                      _ (println "result:" result)
                       base64 (util/str->base64encoded-str (str api-key ":" secret-key))]
                   (assoc-in ctx [:request :headers "authorization"]
                             (str "Basic " base64)))
                 ctx)))
-          ctx (transform-from-url-auth ctx)]
+          ctx (transform-from-url-auth ctx)
+          _ (reset! after-transform ctx)]
       (or
        ;; Token Authentication
        (let [{:keys [oidc-scope-prefix]} config]

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -228,18 +228,19 @@
     (let [transform-from-url-auth
           (fn [ctx]
             (let [last-of-path (last (get-in ctx [:request :path-info]))
-                  cred-id (get-in ctx [:request :params :credentialID])]
+                  cred-id (get-in ctx [:request :com.yetanalytics.url-credential-ID])]
               (if (and (= "statements" last-of-path)
                        cred-id)
-                (let [cred-q-input (auth-input/query-credential-by-id-input cred-id)
-                      {:keys [api-key secret-key]} (auth-q/query-credential-by-id cred-q-input)
+                (let [conn (lrs-conn lrs)
+                      cred-q-input (auth-input/query-credential-by-id-input cred-id)
+                      {:keys [api-key secret-key]}
+                      (jdbc/with-transaction [tx conn]
+                        (auth-q/query-credential-by-id cred-q-input))
+
 
                       base64 (util/str->base64encoded-str (str api-key ":" secret-key))]
-                  (-> ctx
-                      (update-in [:request :params] dissoc :credentialID)
-                                        ;next spoof basic auth
-                      (assoc-in [:request :headers "authorization"]
-                                (str "Basic " base64))))
+                  (assoc-in ctx [:request :headers "authorization"]
+                            (str "Basic " base64)))
                 ctx)))
           ctx (transform-from-url-auth ctx)]
       (or
@@ -252,7 +253,6 @@
        ;; Basic Authentication
        (let [conn   (lrs-conn lrs)
              header (get-in ctx [:request :headers "authorization"])
-             credential-id (get-in ctx [:request :params :credentialID ])
              _ (reset! holder ctx)]
          (if-some [key-pair (auth-util/header->key-pair header)]
            (let [{:keys [authority-url]} config

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -45,6 +45,8 @@
       :connection
       :conn-pool))
 
+(def holder (atom nil))
+
 (defrecord LearningRecordStore [connection
                                 backend
                                 config
@@ -55,7 +57,7 @@
   (start
     [lrs]
     (assert-config ::cs/lrs "LRS" config)
-    (let [;; Destructuring
+    (let [ ;; Destructuring
           {conn :conn-pool}
           connection
           {uname        :admin-user-default
@@ -223,26 +225,45 @@
   lrsp/LRSAuth
   (-authenticate
     [lrs ctx]
-    (or
-     ;; Token Authentication
-     (let [{:keys [oidc-scope-prefix]} config]
-       (oidc-util/token-auth-identity
-        ctx
-        oidc-authority-fn
-        oidc-scope-prefix))
-     ;; Basic Authentication
-     (let [conn   (lrs-conn lrs)
-           header (get-in ctx [:request :headers "authorization"])]
-       (if-some [key-pair (auth-util/header->key-pair header)]
-         (let [{:keys [authority-url]} config
-               input (auth-input/query-credential-scopes-input
-                      authority-fn
-                      authority-url
-                      key-pair)]
-           (jdbc/with-transaction [tx conn]
-             (auth-q/query-credential-scopes backend tx input)))
-         ;; No authorization header = no entry
-         {:result :com.yetanalytics.lrs.auth/unauthorized}))))
+    (let [transform-from-url-auth
+          (fn [ctx]
+            (let [last-of-path (last (get-in ctx [:request :path-info]))
+                  cred-id (get-in ctx [:request :params :credentialID])]
+              (if (and (= "statements" last-of-path)
+                       cred-id)
+                (let [cred-q-input (auth-input/query-credential-by-id-input cred-id)
+                      {:keys [api-key secret-key]} (auth-q/query-credential-by-id cred-q-input)
+
+                      base64 (util/str->base64encoded-str (str api-key ":" secret-key))]
+                  (-> ctx
+                      (update-in [:request :params] dissoc :credentialID)
+                                        ;next spoof basic auth
+                      (assoc-in [:request :headers "authorization"]
+                                (str "Basic " base64))))
+                ctx)))
+          ctx (transform-from-url-auth ctx)]
+      (or
+       ;; Token Authentication
+       (let [{:keys [oidc-scope-prefix]} config]
+         (oidc-util/token-auth-identity
+          ctx
+          oidc-authority-fn
+          oidc-scope-prefix))
+       ;; Basic Authentication
+       (let [conn   (lrs-conn lrs)
+             header (get-in ctx [:request :headers "authorization"])
+             credential-id (get-in ctx [:request :params :credentialID ])
+             _ (reset! holder ctx)]
+         (if-some [key-pair (auth-util/header->key-pair header)]
+           (let [{:keys [authority-url]} config
+                 input (auth-input/query-credential-scopes-input
+                        authority-fn
+                        authority-url
+                        key-pair)]
+             (jdbc/with-transaction [tx conn]
+               (auth-q/query-credential-scopes backend tx input)))
+           ;; No authorization header = no entry
+           {:result :com.yetanalytics.lrs.auth/unauthorized})))))
   (-authorize
     [_lrs ctx auth-identity]
     ;; We need to wrap the boolean in a map or else the LRS lib will get

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -6,6 +6,7 @@
             [com.yetanalytics.lrs.pedestal.routes :refer [build]]
             [com.yetanalytics.lrs.pedestal.interceptor :as i]
             [lrsql.admin.routes :refer [add-admin-routes add-openapi-route]]
+            [lrsql.auth.interceptor :as auth-interceptor]
             [lrsql.init.oidc :as oidc]
             [lrsql.init.clamav :as clamav]
             [lrsql.init.git-data :refer [read-version]]
@@ -14,10 +15,12 @@
             [lrsql.util.cert :as cu]
             [lrsql.util.interceptor :refer [handle-json-parse-exn]]))
 
+(def holder (atom nil))
+
 (defn- service-map
   "Create a new service map for the webserver."
   [lrs config]
-  (let [;; Destructure webserver config
+  (let [ ;; Destructure webserver config
         {:keys [enable-http
                 enable-http2
                 http-host
@@ -81,9 +84,7 @@
         (->> (build {:lrs               lrs
                      :path-prefix       url-prefix
                      :wrap-interceptors (into
-                                         [:mythical-interceptor
-
-                                          i/error-interceptor
+                                         [i/error-interceptor
                                           (handle-json-parse-exn)]
                                          oidc-resource-interceptors)
                      :file-scanner      (when enable-clamav
@@ -115,7 +116,8 @@
              (add-openapi-route
               {:lrs lrs
                :head-opts head-opts
-               :version (read-version)}))
+               :version (read-version)})
+             (auth-interceptor/insert-id-auth-interceptor))
         
         ;; Build allowed-origins list. Add without ports as well for
         ;; default ports
@@ -128,7 +130,8 @@
               (= http-port 80) (conj (format "http://%s" http-host))
               (= ssl-port 443) (conj (format "https://%s" http-host))))]
     {:env                      :prod
-     ::http/routes             routes
+     ::http/routes             (do (reset! holder routes)
+                                   routes)
      ;; only serve assets if the admin ui is enabled
      ::http/resource-path      (when enable-admin-ui "/public")
      ::http/type               :jetty

--- a/src/main/lrsql/system/webserver.clj
+++ b/src/main/lrsql/system/webserver.clj
@@ -81,7 +81,9 @@
         (->> (build {:lrs               lrs
                      :path-prefix       url-prefix
                      :wrap-interceptors (into
-                                         [i/error-interceptor
+                                         [:mythical-interceptor
+
+                                          i/error-interceptor
                                           (handle-json-parse-exn)]
                                          oidc-resource-interceptors)
                      :file-scanner      (when enable-clamav

--- a/src/main/lrsql/util/auth.clj
+++ b/src/main/lrsql/util/auth.clj
@@ -6,7 +6,9 @@
             [buddy.core.codecs :refer [bytes->hex]]
             [buddy.core.nonce  :refer [random-bytes]]
             [lrsql.spec.auth :as as]
-            [lrsql.util :as u]))
+            [lrsql.util :as u]
+            [lrsql.input.auth :as auth-i]
+            [io.pedestal.interceptor :as i]))
 
 ;; NOTE: Additional scopes may be implemented in the future.
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fb44fa3c-79d6-46f6-bb7e-535dc7993c38)

the mechanism here is a bit convoluted:

 - an interceptor is injected into the chain *for the statements path specifically*, that removes  `:credentialID` from the `:params` map, and attaches it to  a new key in the `:request` map: `:com.yetanalytics.url-credential-ID`.  This has to be done here or else `lrs` will throw a fit `credentialID` not being in spec
 - LRS auth has a clause added that looks for `:com.yetanalytics.url-credential-ID` in the `:request` map, and, if it finds it, will query for the actual creds and modify the request so it passes Basic auth.   However, I now think I can move this functionality into the interceptor and avoid muddying `lrs.clj`