### PR TITLE
Allow Reactions with OIDC login

### DIFF
--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -329,7 +329,7 @@
                    common-interceptors-oidc secret leeway no-val-opts))
                 (when enable-reaction-routes
                   (admin-reaction-routes
-                   common-interceptors secret leeway no-val-opts))
+                   common-interceptors-oidc secret leeway no-val-opts))
                 (when enable-admin-delete-actor
                   (admin-lrs-management-routes
                    common-interceptors-oidc secret leeway no-val-opts)))))


### PR DESCRIPTION
Currently there is a bug where Reactions cannot be accessed when the user is logged in with OIDC/Keycloak.