### PR TITLE
[SQL-283] Authentication for CSV export

### DIFF
--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -80,7 +80,8 @@
       (add-statement-to-actor-cascading-delete! tx))
     (when (some? (query-varchar-exists tx))
       (convert-varchars-to-text! tx))
-    (create-blocked-jwt-table! tx))
+    (create-blocked-jwt-table! tx)
+    (alter-blocked-jwt-add-one-time-id! tx))
 
   bp/BackendUtil
   (-txn-retry? [_ ex]
@@ -210,10 +211,16 @@
   bp/JWTBlocklistBackend
   (-insert-blocked-jwt! [_ tx input]
     (insert-blocked-jwt! tx input))
+  (-insert-one-time-jwt! [_ tx input]
+    (insert-one-time-jwt! tx input))
+  (-update-one-time-jwt! [_ tx input]
+    (update-one-time-jwt! tx input))
   (-delete-blocked-jwt-by-time! [_ tx input]
     (delete-blocked-jwt-by-time! tx input))
   (-query-blocked-jwt [_ tx input]
     (query-blocked-jwt-exists tx input))
+  (-query-one-time-jwt [_ tx input]
+    (query-one-time-jwt-exists tx input))
 
   bp/CredentialBackend
   (-insert-credential! [_ tx input]

--- a/src/db/postgres/lrsql/postgres/sql/ddl.sql
+++ b/src/db/postgres/lrsql/postgres/sql/ddl.sql
@@ -505,4 +505,4 @@ CREATE INDEX IF NOT EXISTS blocked_jwt_evict_time_idx ON blocked_jwt(evict_time)
 -- :name alter-blocked-jwt-add-one-time-id!
 -- :command :execute
 -- :doc Add the column `blocked_jwt.one_time_id` for one-time JWTs; JWTs with one-time IDs are not considered blocked yet.
-ALTER TABLE IF EXISTS blocked_jwt ADD COLUMN IF NOT EXISTS one_time_id TYPE UUID UNIQUE;
+ALTER TABLE IF EXISTS blocked_jwt ADD COLUMN IF NOT EXISTS one_time_id UUID UNIQUE;

--- a/src/db/postgres/lrsql/postgres/sql/ddl.sql
+++ b/src/db/postgres/lrsql/postgres/sql/ddl.sql
@@ -499,3 +499,10 @@ CREATE TABLE IF NOT EXISTS blocked_jwt (
   evict_time TIMESTAMP WITH TIME ZONE
 );
 CREATE INDEX IF NOT EXISTS blocked_jwt_evict_time_idx ON blocked_jwt(evict_time);
+
+/* Migration 2025-03-05 - Add One-Time ID to Blocklist Table */
+
+-- :name alter-blocked-jwt-add-one-time-id!
+-- :command :execute
+-- :doc Add the column `blocked_jwt.one_time_id` for one-time JWTs; JWTs with one-time IDs are not considered blocked yet.
+ALTER TABLE IF EXISTS blocked_jwt ADD COLUMN IF NOT EXISTS one_time_id TYPE UUID UNIQUE;

--- a/src/db/postgres/lrsql/postgres/sql/insert.sql
+++ b/src/db/postgres/lrsql/postgres/sql/insert.sql
@@ -171,3 +171,13 @@ INSERT INTO blocked_jwt (
 ) VALUES (
   :jwt, :eviction-time
 );
+
+-- :name insert-one-time-jwt!
+-- :command :insert
+-- :result :affected
+-- :doc Insert a `:jwt` and a `:eviction-time` with `:one-time-id` into the blocklist.
+INSERT INTO blocked_jwt (
+  jwt, evict_time, one_time_id
+) VALUES (
+  :jwt, :eviction-time, :one-time-id
+);

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -433,6 +433,15 @@ WHERE reaction_id IS NOT NULL;
 -- :name query-blocked-jwt-exists
 -- :command :query
 -- :result :one
--- :doc Query that `:jwt` is in the blocklist.
+-- :doc Query that `:jwt` is in the blocklist. Excludes JWTs where `one_time_id` is not null.
 SELECT 1 FROM blocked_jwt
-WHERE jwt = :jwt;
+WHERE jwt = :jwt
+AND one_time_id IS NULL;
+
+-- :name query-one-time-jwt-exists
+-- :command :query
+-- :result :one
+-- :doc Query that `:jwt` with `:one-time-id` exists.
+SELECT 1 FROM blocked_jwt
+WHERE jwt = :jwt
+AND one_time_id = :one-time-id;

--- a/src/db/postgres/lrsql/postgres/sql/update.sql
+++ b/src/db/postgres/lrsql/postgres/sql/update.sql
@@ -77,6 +77,15 @@ SET
   passhash = :new-passhash
 WHERE id = :account-id;
 
+-- :name update-one-time-jwt!
+-- :command :execute
+-- :result :affected
+-- :doc Update `blocked_jwt.one_time_id` to be null, thus blocking the JWT.
+UPDATE blocked_jwt
+SET
+  one_time_id = NULL
+WHERE one_time_id = :one_time_id;
+
 -- :name update-reaction!
 -- :command :execute
 -- :result :affected

--- a/src/db/postgres/lrsql/postgres/sql/update.sql
+++ b/src/db/postgres/lrsql/postgres/sql/update.sql
@@ -84,7 +84,7 @@ WHERE id = :account-id;
 UPDATE blocked_jwt
 SET
   one_time_id = NULL
-WHERE one_time_id = :one_time_id;
+WHERE one_time_id = :one-time-id;
 
 -- :name update-reaction!
 -- :command :execute

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -117,6 +117,9 @@
       (update-schema-simple! tx alter-statement-to-actor-add-cascade-delete!))
     (create-blocked-jwt-table! tx)
     (create-blocked-jwt-evict-time-idx! tx)
+    (when-not (some? (query-blocked-jwt-one-time-id-exists tx))
+      (alter-blocked-jwt-add-one-time-id! tx)
+      (alter-blocked-jwt-add-one-time-id-idx! tx))
     (log/infof "sqlite schema_version: %d"
                (:schema_version (query-schema-version tx))))
 
@@ -247,10 +250,16 @@
   bp/JWTBlocklistBackend
   (-insert-blocked-jwt! [_ tx input]
     (insert-blocked-jwt! tx input))
+  (-insert-one-time-jwt! [_ tx input]
+    (insert-one-time-jwt! tx input))
+  (-update-one-time-jwt! [_ tx input]
+    (update-one-time-jwt! tx input))
   (-delete-blocked-jwt-by-time! [_ tx input]
     (delete-blocked-jwt-by-time! tx input))
   (-query-blocked-jwt [_ tx input]
     (query-blocked-jwt-exists tx input))
+  (-query-one-time-jwt [_ tx input]
+    (query-one-time-jwt-exists tx input))
 
   bp/CredentialBackend
   (-insert-credential! [_ tx input]

--- a/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/ddl.sql
@@ -538,3 +538,23 @@ CREATE TABLE IF NOT EXISTS blocked_jwt (
 -- :command :execute
 -- :doc Create the `blocked_jwt_evict_time_idx` table if it does not exist yet.
 CREATE INDEX IF NOT EXISTS blocked_jwt_evict_time_idx ON blocked_jwt(evict_time);
+
+/* Migration 2025-03-05 - Add One-Time ID to Blocklist Table */
+
+-- :name query-blocked-jwt-one-time-id-exists
+-- :command :query
+-- :result :one
+-- :doc Query to see if `blocked_jwt.one_time_id` exists.
+SELECT 1 FROM pragma_table_info('blocked_jwt') WHERE name = 'one_time_id';
+
+-- :name alter-blocked-jwt-add-one-time-id!
+-- :command :execute
+-- :result :one
+-- :doc Add the column `blocked_jwt.one_time_id` for one-time JWTs; JWTs with one-time IDs are not considered blocked yet.
+ALTER TABLE blocked_jwt ADD COLUMN one_time_id TEXT;
+
+-- :name alter-blocked-jwt-add-one-time-id-idx!
+-- :command :execute
+-- :result :one
+-- :doc Add a unique index on `blocked_jwt.one_time_id` (since SQLite does not allow directly adding unique columns).
+CREATE UNIQUE INDEX IF NOT EXISTS blocked_jwt_one_time_id_idx ON blocked_jwt(one_time_id);

--- a/src/db/sqlite/lrsql/sqlite/sql/insert.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/insert.sql
@@ -171,3 +171,13 @@ INSERT INTO blocked_jwt (
 ) VALUES (
   :jwt, :eviction-time
 );
+
+-- :name insert-one-time-jwt!
+-- :command :insert
+-- :result :affected
+-- :doc Insert a `:jwt` and a `:eviction-time` with `:one-time-id` into the blocklist.
+INSERT INTO blocked_jwt (
+  jwt, evict_time, one_time_id
+) VALUES (
+  :jwt, :eviction-time, :one-time-id
+);

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -400,6 +400,15 @@ WHERE reaction_id IS NOT NULL;
 -- :name query-blocked-jwt-exists
 -- :command :query
 -- :result :one
--- :doc Query that `:jwt` is in the blocklist.
+-- :doc Query that `:jwt` is in the blocklist. Excludes JWTs where `one_time_id` is not null.
 SELECT 1 FROM blocked_jwt
 WHERE jwt = :jwt
+AND one_time_id IS NULL;
+
+-- :name query-one-time-jwt-exists
+-- :command :query
+-- :result :one
+-- :doc Query that `:jwt` with `:one-time-id` exists.
+SELECT 1 FROM blocked_jwt
+WHERE jwt = :jwt
+AND one_time_id = :one-time-id;

--- a/src/db/sqlite/lrsql/sqlite/sql/update.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/update.sql
@@ -72,6 +72,16 @@ SET
   passhash = :new-passhash
 WHERE id = :account-id
 
+-- :name update-one-time-jwt!
+-- :command :execute
+-- :result :affected
+-- :doc Update `blocked_jwt.one_time_id` to be null, thus blocking the JWT.
+UPDATE blocked_jwt
+SET
+  one_time_id = NULL
+WHERE jwt = :jwt
+AND one_time_id = :one-time-id;
+
 -- :name update-reaction!
 -- :command :execute
 -- :result :affected

--- a/src/main/lrsql/admin/interceptors/account.clj
+++ b/src/main/lrsql/admin/interceptors/account.clj
@@ -316,7 +316,7 @@
     (fn add-jwt-to-blocklist [ctx]
       (if-not no-val?
         (let [{lrs :com.yetanalytics/lrs
-               {:keys [jwt account-id]} :lrsql.admin.interceptors.jwt/data}
+               {:keys [jwt account-id]} ::jwt/data}
               ctx]
           (adp/-purge-blocklist lrs leeway) ; Update blocklist upon logout
           (adp/-block-jwt lrs jwt exp)

--- a/src/main/lrsql/admin/interceptors/account.clj
+++ b/src/main/lrsql/admin/interceptors/account.clj
@@ -261,6 +261,7 @@
 
 ;; JWT interceptors for admin
 
+;; See also: `admin.interceptors.lrs-management/generate-one-time-jwt`
 (defn generate-jwt
   "Upon account login, generate a new JSON web token."
   [secret exp ref leeway]

--- a/src/main/lrsql/admin/interceptors/jwt.clj
+++ b/src/main/lrsql/admin/interceptors/jwt.clj
@@ -47,7 +47,7 @@
 
 (defn validate-jwt
   "Validate that the header JWT is valid (e.g. not expired and signed properly).
-   If no-val? is true run an entirely separate decoding that gets the username
+   If `no-val?` is true run an entirely separate decoding that gets the username
    and issuer claims, verifies a role and ensures the account if necessary."
   [secret leeway {:keys [no-val?] :as no-val-opts}]
   (interceptor
@@ -81,6 +81,8 @@
                   :body   {:error "Unauthorized JSON Web Token!"}}))))}))
 
 (defn validate-one-time-jwt
+  "Validate one-time JWTs. Checks that they are not expired and are signed
+   properly just like regular JWTs, then automatically revoke them."
   [secret leeway]
   (interceptor
    {:name ::validate-one-time-jwt

--- a/src/main/lrsql/admin/interceptors/jwt.clj
+++ b/src/main/lrsql/admin/interceptors/jwt.clj
@@ -80,6 +80,39 @@
                  {:status 401
                   :body   {:error "Unauthorized JSON Web Token!"}}))))}))
 
+(defn validate-one-time-jwt
+  [secret leeway]
+  (interceptor
+   {:name ::validate-one-time-jwt
+    :enter
+    (fn validate-one-time-jwt [ctx]
+      (let [{lrs :com.yetanalytics/lrs} ctx
+            token  (get-in ctx [:request :params :token])
+            result (validate-jwt* lrs token secret leeway)]
+        (cond
+          (or (= :lrsql.admin/unauthorized-token-error result)
+              (nil? (:one-time-id result)))
+          (assoc (chain/terminate ctx)
+                 :response
+                 {:status 401
+                  :body   {:error "Unauthorized JSON Web Token!"}})
+          (map? result)
+          (let [{:keys [one-time-id]} result
+                block-result
+                (adp/-block-one-time-jwt lrs token one-time-id)]
+            (if-some [_ (:error block-result)]
+              (assoc (chain/terminate ctx)
+                     :response
+                     {:status 401
+                      :body   {:error "Unauthorized, JSON Web Token was not issued!"}})
+              ;; Success!
+              (-> ctx ; So far :form-params and :edn-params are not implemented
+                  (update-in [:request :params] dissoc :token)
+                  (update-in [:request :query-params] dissoc :token)
+                  (update-in [:request :json-params] dissoc :token)
+                  (assoc-in [::data] result)
+                  (assoc-in [:request :session ::data] result)))))))}))
+
 (def validate-jwt-account
   "Check that the account ID stored in the JWT exists in the account table.
    This should go after `validate-jwt`, and MUST be present if `account-id`

--- a/src/main/lrsql/admin/protocol.clj
+++ b/src/main/lrsql/admin/protocol.clj
@@ -21,8 +21,12 @@
 (defprotocol AdminJWTManager
   (-purge-blocklist [this leeway]
     "Purge the blocklist of any JWTs that have expired since they were added.")
+  (-create-one-time-jwt [this jwt exp one-time-id]
+    "Add a one-time JWT that will be blocked after it is validated.")
   (-block-jwt [this jwt expiration]
     "Block `jwt` and apply an associated `expiration` number of seconds. Returns an error if `jwt` is already in the blocklist.")
+  (-block-one-time-jwt [this jwt one-time-id]
+    "Similar to `-block-jwt` but specific to blocking one-time JWTs. Returns an error if `jwt` and `one-time-id` cannot be found or updated.")
   (-jwt-blocked? [this jwt]
     "Is `jwt` on the blocklist?"))
 

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -309,18 +309,23 @@
      :route-name :lrsql.admin.reaction/delete]})
 
 (defn admin-lrs-management-routes
-  [common-interceptors jwt-secret jwt-leeway no-val-opts]
+  [common-interceptors jwt-secret jwt-exp jwt-leeway no-val-opts]
   #{["/admin/agents" :delete (conj common-interceptors
                                    lm/validate-delete-actor-params
                                    (ji/validate-jwt jwt-secret jwt-leeway no-val-opts)
                                    ji/validate-jwt-account
                                    lm/delete-actor)
      :route-name :lrsql.lrs-management/delete-actor]
+    ["/admin/csv/auth" :get (conj common-interceptors
+                                  (ji/validate-jwt
+                                   jwt-secret jwt-leeway no-val-opts)
+                                  ji/validate-jwt-account
+                                  (lm/generate-one-time-jwt jwt-secret jwt-exp))
+     :route-name :lrsql.lrs-management/download-csv-auth]
     ["/admin/csv" :get (conj common-interceptors
                              lm/validate-property-paths
                              lm/validate-query-params
-                             #_(ji/validate-jwt jwt-secret jwt-leeway no-val-opts)
-                             #_ji/validate-jwt-account
+                             (ji/validate-one-time-jwt jwt-secret jwt-leeway)
                              lm/download-statement-csv)
      :route-name :lrsql.lrs-management/download-csv]})
 
@@ -391,7 +396,7 @@
                    common-interceptors-oidc secret leeway no-val-opts))
                 (when enable-admin-delete-actor
                   (admin-lrs-management-routes
-                   common-interceptors-oidc secret leeway no-val-opts)))))
+                   common-interceptors-oidc secret exp leeway no-val-opts)))))
 
 (defn add-openapi-route [{:keys [lrs head-opts version]} routes]
   (let [common-interceptors (make-common-interceptors lrs head-opts)]

--- a/src/main/lrsql/admin/routes.clj
+++ b/src/main/lrsql/admin/routes.clj
@@ -150,7 +150,8 @@
                                  (ji/validate-jwt
                                   jwt-secret jwt-leeway no-val-opts)
                                  ji/validate-jwt-account
-                                 ai/no-content)]
+                                 ai/no-content)
+      :route-name :lrsql.admin.verify/get]
      {:description "Verify that querying account is logged in"
       :operationId :verify-own-account
       :security [{:bearerAuth []}]

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -105,9 +105,12 @@
 (defprotocol JWTBlocklistBackend
   ;; Commands
   (-insert-blocked-jwt! [this tx input])
+  (-insert-one-time-jwt! [this tx input])
+  (-update-one-time-jwt! [this tx input])
   (-delete-blocked-jwt-by-time! [this tx input])
   ;; Queries
-  (-query-blocked-jwt [this tx input]))
+  (-query-blocked-jwt [this tx input])
+  (-query-one-time-jwt [this tx input]))
 
 (defprotocol CredentialBackend
   ;; Commands

--- a/src/main/lrsql/input/admin/jwt.clj
+++ b/src/main/lrsql/input/admin/jwt.clj
@@ -42,3 +42,26 @@
 (defn purge-blocklist-input
   [leeway]
   {:current-time (current-time leeway)})
+
+;; One-time JWTs
+
+(s/fdef insert-one-time-jwt-input
+  :args (s/cat :jwt ::jwts/jwt
+               :exp ::jwts/exp
+               :oti ::jwts/one-time-id)
+  :ret jwts/insert-one-time-jwt-input-spec)
+
+(defn insert-one-time-jwt-input
+  [jwt exp oti]
+  {:jwt           jwt
+   :eviction-time (eviction-time exp)
+   :one-time-id   oti})
+
+(s/fdef update-one-time-jwt-input
+  :args (s/cat :jwt ::jwts/jwt
+               :oti ::jwts/one-time-id))
+
+(defn update-one-time-jwt-input
+  [jwt oti]
+  {:jwt         jwt
+   :one-time-id oti})

--- a/src/main/lrsql/ops/query/admin.clj
+++ b/src/main/lrsql/ops/query/admin.clj
@@ -127,6 +127,6 @@
   :ret jwts/blocked-jwt-query-result-spec)
 
 (defn query-blocked-jwt-exists
-  "Query whether an unexpired JWT for the account exists."
+  "Query whether an unexpired but blocked JWT exists."
   [bk tx input]
   (boolean (bp/-query-blocked-jwt bk tx input)))

--- a/src/main/lrsql/spec/admin/jwt.clj
+++ b/src/main/lrsql/spec/admin/jwt.clj
@@ -21,6 +21,9 @@
 (s/def ::leeway ::config/jwt-exp-leeway)
 (s/def ::eviction-time c/instant-spec)
 (s/def ::current-time c/instant-spec)
+(s/def ::one-time-id uuid?)
+
+;; Blocked JWTs
 
 (def query-blocked-jwt-input-spec
   (s/keys :req-un [::jwt]))
@@ -30,6 +33,17 @@
 
 (def purge-blocklist-input-spec
   (s/keys :req-un [::current-time]))
+
+;; One-time JWTs
+
+(def query-one-time-jwt-input-spec
+  (s/keys :req-un [::jwt ::one-time-id]))
+
+(def insert-one-time-jwt-input-spec
+  (s/keys :req-un [::jwt ::eviction-time ::one-time-id]))
+
+(def update-one-time-jwt-input-spec
+  (s/keys :req-un [::jwt ::one-time-id]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Results

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -312,12 +312,24 @@
          input (admin-jwt-input/purge-blocklist-input leeway)]
      (jdbc/with-transaction [tx conn]
        (admin-cmd/purge-blocklist! backend tx input))))
+  (-create-one-time-jwt
+   [this jwt exp one-time-id]
+   (let [conn  (lrs-conn this)
+         input (admin-jwt-input/insert-one-time-jwt-input jwt exp one-time-id)]
+     (jdbc/with-transaction [tx conn]
+       (admin-cmd/insert-one-time-jwt! backend tx input))))
   (-block-jwt
    [this jwt exp]
    (let [conn      (lrs-conn this)
          jwt-input (admin-jwt-input/insert-blocked-jwt-input jwt exp)]
      (jdbc/with-transaction [tx conn]
        (admin-cmd/insert-blocked-jwt! backend tx jwt-input))))
+  (-block-one-time-jwt
+   [this jwt one-time-id]
+   (let [conn      (lrs-conn this)
+         jwt-input (admin-jwt-input/update-one-time-jwt-input jwt one-time-id)]
+     (jdbc/with-transaction [tx conn]
+       (admin-cmd/update-one-time-jwt! backend tx jwt-input))))
   (-jwt-blocked?
    [this jwt]
    (let [conn      (lrs-conn this)

--- a/src/test/lrsql/admin/protocol_test.clj
+++ b/src/test/lrsql/admin/protocol_test.clj
@@ -12,7 +12,8 @@
             [lrsql.test-support   :as support]
             [lrsql.util           :as u]
             [lrsql.test-constants :as tc]
-            [lrsql.util.actor     :as ua]))
+            [lrsql.util.actor     :as ua]
+            [lrsql.util.admin     :as uadm]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Init
@@ -159,6 +160,15 @@
                    (adp/-purge-blocklist lrs leeway)))
             (is (false?
                  (adp/-jwt-blocked? lrs jwt))))))
+      (testing "Admin one-time JWTs"
+        (let [{:keys [jwt exp oti]}
+              (uadm/one-time-jwt {} "MySecret" 100)]
+          (testing "- can be added"
+            (is (adp/-create-one-time-jwt lrs jwt exp oti))
+            (is (false? (adp/-jwt-blocked? lrs jwt))))
+          (testing "- can be blocked"
+            (is (adp/-block-one-time-jwt lrs jwt oti))
+            (is (true? (adp/-jwt-blocked? lrs jwt))))))
       (testing "Admin password update"
         (let [account-id   (-> (adp/-authenticate-account lrs
                                                           test-username

--- a/src/test/lrsql/bench_test.clj
+++ b/src/test/lrsql/bench_test.clj
@@ -110,7 +110,7 @@
             (format "http://localhost:8080/admin/csv?token=%s&property-paths=%s"
                     json-web-token*
                     (u/url-encode [["id"] ["verb" "id"]]))
-              ;; Download CSV
+            ;; Download CSV
             start
             (jt/instant)
             {:keys [status] input-stream :body}
@@ -123,4 +123,5 @@
                        num-statements
                        t-diff)
             (is (= 200 status))
-            (is (= (inc num-statements) res-count))))))))
+            (is (= (inc num-statements) res-count))))))
+    (component/stop sys')))

--- a/src/test/lrsql/input/input_test.clj
+++ b/src/test/lrsql/input/input_test.clj
@@ -61,7 +61,9 @@
 (deftest test-admin-jwt
   (testing "admin JWT inputs"
     (is (nil? (check-validate `i-adm-jwt/query-blocked-jwt-input)))
-    (is (nil? (check-validate `i-adm-jwt/insert-blocked-jwt-input)))))
+    (is (nil? (check-validate `i-adm-jwt/insert-blocked-jwt-input)))
+    (is (nil? (check-validate `i-adm-jwt/insert-one-time-jwt-input)))
+    (is (nil? (check-validate `i-adm-jwt/update-one-time-jwt-input)))))
 
 (deftest test-admin-status
   (testing "admin status inputs"


### PR DESCRIPTION
Implement authentication for the `GET /admin/csv` endpoint, as HTML `download` attributes cannot have headers, thus making the usual JWT authentication impossible.

We introduce the concept of "one-time JWTs" that have "one-time IDs." These one-time JWTs are stored in the `jwt_blocklist` SQL table (added in v0.8.0), where if the `one_time_id` column is not null then they are ignored during the query for blocked JWTs. Thus, these JWTs can easily be blocked/revoked by updating `one_time_id` to be null, which happens once they are validated. These one-time JWTs can be added as a `token` parameter for any GET endpoint, this case the CSV download endpoint.