### PR TITLE
Skip setting payload type if already correct

### DIFF
--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -73,9 +73,10 @@
       (xapi-statement-add-reaction-id! tx))
     (when-not (some? (query-xapi-statement-trigger-id-exists tx))
       (xapi-statement-add-trigger-id! tx))
-    (if (-> tuning :config :enable-jsonb)
-      (migrate-to-jsonb! tx)
-      (migrate-to-json! tx))
+    (let [is-json? (some? (query-payload-json tx))
+          enable-b (-> tuning :config :enable-jsonb)]
+      (when (and is-json? enable-b) (migrate-to-jsonb! tx)) 
+      (when (not (or is-json? enable-b)) (migrate-to-json! tx)))
     (when (nil? (check-statement-to-actor-cascading-delete tx))
       (add-statement-to-actor-cascading-delete! tx))
     (when (some? (query-varchar-exists tx))

--- a/src/db/postgres/lrsql/postgres/sql/ddl.sql
+++ b/src/db/postgres/lrsql/postgres/sql/ddl.sql
@@ -379,6 +379,13 @@ USING last_modified AT TIME ZONE :sql:tz-id;
 ALTER TABLE agent_profile_document ALTER COLUMN last_modified TYPE TIMESTAMP WITH TIME ZONE
 USING last_modified AT TIME ZONE :sql:tz-id;
 
+-- :name query-payload-json
+-- :command :query
+-- :result :one
+-- :doc Query to see if any of 'xapi_statement.payload', 'actor.payload', or 'activity.payload' is json
+SELECT 1 FROM information_schema.columns
+WHERE column_name = 'payload' AND data_type = 'json' AND table_name in ('xapi_statement', 'actor', 'activity');
+
 -- :name migrate-to-jsonb!
 -- :command :execute
 -- :doc Convert all JSON payloads to JSONB to allow for faster reads and advanced indexing


### PR DESCRIPTION
- added a check to resolve[ issue #476](https://github.com/yetanalytics/lrsql/issues/476), where startup could be slow when the reapplication of jsonb triggered rebuild of custom B-tree indexes, even after conversion