### PR TITLE
Speed Up Tests with Singleton TestContainer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ resources/public/admin:
 # All other phony targets run lrsql instances that can be used and tested
 # during development. All start up with fixed DB properties and seed creds.
 
-.phony: clean-dev, ci, ephemeral, ephemeral-prod, sqlite, postgres, bench, bench-async, keycloak-demo, ephemeral-oidc, superset-demo, clamav-demo, test-sqlite, test-postgres, test-postgres-11, test-postgres-12, test-postgres-13, test-postgres-14, test-postgres-15
+.phony: clean-dev, ci, ephemeral, ephemeral-prod, sqlite, postgres, bench, bench-async, keycloak-demo, ephemeral-oidc, superset-demo, clamav-demo, test-sqlite, test-postgres, test-postgres-11, test-postgres-12, test-postgres-13, test-postgres-14, test-postgres-15, test-mariadb
 
 clean-dev:
 	rm -rf *.db *.log resources/public tmp
@@ -57,10 +57,10 @@ test-postgres-15:
 test-postgres-16:
 	LRSQL_TEST_DB_VERSION=16 $(TEST_PG_COMMAND)
 
-test-maria:
-	clojure -M:test -m lrsql.test-runner --database maria $(if $(ns),--ns $(ns))
+test-mariadb:
+	clojure -M:test -m lrsql.test-runner --database mariadb $(if $(ns),--ns $(ns))
 
-ci: test-sqlite test-postgres test-maria
+ci: test-sqlite test-postgres test-mariadb
 
 
 # Dev
@@ -212,7 +212,7 @@ target/bundle/admin: resources/public/admin
 BUNDLE_RUNTIMES ?= true
 
 ifeq ($(BUNDLE_RUNTIMES),true)
-target/bundle: target/bundle/config target/bundle/doc target/bundle/bin target/bundle/lrsql.jar target/bundle/admin target/bundle/lrsql.exe target/bundle/lrsql_pg.exe target/bundle/LICENSE target/bundle/NOTICE target/bundle/customization target/bundle/bench.jar target/bundle/bench target/bundle/runtimes 
+target/bundle: target/bundle/config target/bundle/doc target/bundle/bin target/bundle/lrsql.jar target/bundle/admin target/bundle/lrsql.exe target/bundle/lrsql_pg.exe target/bundle/LICENSE target/bundle/NOTICE target/bundle/customization target/bundle/bench.jar target/bundle/bench target/bundle/runtimes
 else
 target/bundle: target/bundle/config target/bundle/doc target/bundle/bin target/bundle/lrsql.jar target/bundle/admin target/bundle/lrsql.exe target/bundle/lrsql_pg.exe target/bundle/LICENSE target/bundle/NOTICE target/bundle/customization target/bundle/bench.jar target/bundle/bench
 endif

--- a/deps.edn
+++ b/deps.edn
@@ -112,7 +112,9 @@
    :extra-deps  {;; DB deps
                  org.xerial/sqlite-jdbc        {:mvn/version "3.42.0.0"}
                  org.postgresql/postgresql     {:mvn/version "42.6.1"}
-                 org.testcontainers/postgresql {:mvn/version "1.19.8"}
+                 clj-test-containers/clj-test-containers
+                 {:mvn/version "0.7.3"}
+                 ;; org.testcontainers/postgresql {:mvn/version "1.19.8"}
                  com.kohlschutter.junixsocket/junixsocket-common
                  {:mvn/version "2.6.1"}
                  com.kohlschutter.junixsocket/junixsocket-native-common

--- a/resources/lrsql/config/config.edn
+++ b/resources/lrsql/config/config.edn
@@ -23,13 +23,12 @@
                :db-name       "lrsql_db"
                :db-host       "0.0.0.0"
                :db-port       3306
-               :db-user       "root"
-               :db-password   "pass"
+               :db-user       "lrsql_user"
+               :db-password   "lrsql_password"
                :db-properties "allowMultiQueries=true"
 
                ;; Testing Only! Specify the version used with testcontainers
-               ;;:test-db-version #or [#env LRSQL_TEST_DB_VERSION "11.7.2"]
-               }
+               :test-db-version #or [#env LRSQL_TEST_DB_VERSION "11.7.2"]}
   :test-oidc {:db-type "sqlite"
               :db-name ":memory:"}
 

--- a/resources/lrsql/config/test/maria/connection.edn
+++ b/resources/lrsql/config/test/maria/connection.edn
@@ -1,4 +1,6 @@
 #merge
  [#include "test/default/connection.edn"
   {:pool-minimum-idle 10
-   :pool-maximum-size 10}]
+   :pool-maximum-size 10
+   ;; This is required for TestContainers MariaDB
+   :pool-initialization-fail-timeout 0}]

--- a/src/dev/lrsql/user.clj
+++ b/src/dev/lrsql/user.clj
@@ -320,3 +320,17 @@
   ;; Stop the container
   (tc/stop! container)
   )
+
+;; Use containers in individual tests from the REPL!
+(comment
+
+  (require '[lrsql.test-support :as ts])
+
+  ;; Setting one of these fixture modes will result in automatically
+  ;; bootstrapping fixtures so you can use things like cider-test-run-test
+  (ts/set-db-fixture-mode! :postgres)
+
+  (ts/set-db-fixture-mode! :mariadb)
+
+
+  )

--- a/src/dev/lrsql/user.clj
+++ b/src/dev/lrsql/user.clj
@@ -23,7 +23,7 @@
   (def ds (-> sys' :lrs :connection :conn-pool))
 
 
-  
+
   (lrsp/-store-statements lrs auth-ident [stmt-1] [])
   (lrsp/-store-statements lrs auth-ident-oauth [stmt-2] [])
 
@@ -76,7 +76,7 @@
        FROM pragma_table_info('admin_account')
        WHERE name = 'passhash'
        AND \"notnull\" = 1"])
-    
+
     (jdbc/execute!
      ds
      ["SELECT 1
@@ -84,7 +84,7 @@
        WHERE \"table\" = 'xapi_statement'
        AND on_delete = 'CASCADE'
       "])
-    
+
     (jdbc/execute!
      ds
      ["SELECT 1
@@ -176,10 +176,10 @@
           (adp/-create-api-keys lrs account-id ["agents_profile"])
           (adp/-create-api-keys lrs account-id ["agents_profile/read"]))
         (range 0 100000))
-  
+
   ;; Note: deletes initial username + password API keys
   (jdbc/execute! ds ["DELETE FROM credential_to_scope"])
-  
+
   ;; Query enums
 
   (jdbc/execute!
@@ -220,7 +220,7 @@
    '[lrsql.backend.protocol :aps bp]
    '[clojure.data.json :as json]
    '[lrsql.maria.data :as md])
-  
+
 
   (do (require '[clojure.tools.namespace.repl :refer [refresh]])
       (refresh)
@@ -231,30 +231,28 @@
           (def lrs (:lrs sys'))
           (def bk (:backend lrs))
           (def ds (-> sys' :lrs :connection :conn-pool))))
-  
-  #_(lrsql.init.log/set-log-level! "DEBUG")
+
   (def sys (system/system (rm/map->MariaBackend {}) :test-maria))
   (def sys' (component/start sys))
 
   (def lrs (:lrs sys'))
   (def bk (:backend lrs))
-    
+
   (def ds (-> sys' :lrs :connection :conn-pool))
-  @stmt-cmd/holder
 
 
-  
+
   (lrsp/-store-statements lrs auth-ident [stmt-0 stmt-1 stmt-2] [])
   (lrsp/-store-statements lrs auth-ident [stmt-2] [])
   (lrsp/-store-statements lrs auth-ident-oauth [stmt-2] [])
 
 
 
-  
-  
+
+
   (do (require '[lrsql.test-runner :as tr])
       (tr/-main {"--database" "maria"}))
-  
+
   ;; Sanity check queries
   (jdbc/execute! ds
                  ["SELECT stmt.payload FROM xapi_statement stmt LIMIT 1"])
@@ -269,248 +267,56 @@
   (component/stop sys')
   )
 
-
-(with-open [writer (java.io.StringWriter.)]
-              (adp/-get-statements-csv lrs writer  [["id"] ["actor" "mbox"] ["verb" "id"] ["object" "id"]] {})
-              (str writer)
-)
-
-
-(require '[next.jdbc.result-set :as jrs])
-
-(require '[lrsql.ops.query.statement :as qs])
-(require '[com.yetanalytics.pathetic :as pa])
-
-(println  (lrsp/-get-statements lrs auth-ident {} []))
-
-(def res  (lrsp/-get-statements lrs auth-ident {} []))
-
-
-
-(stmt-input/query-statement-input {:ascending true} auth-ident )
-
- (get-ss lrs auth-ident {:limit 2 :ascending true} #{})
-
-
-;;;;single test harness
+;; Maria with containers
 (comment
   (require
+   '[lrsql.maria.record :as rm]
+   '[hugsql.core :as hug]
+   '[lrsql.init.log]
    '[lrsql.test-support :as ts]
-   '[clojure.test :as test])
+   '[lrsql.lrs-test :refer [stmt-0 stmt-1 stmt-2 auth-ident auth-ident-oauth]]
+   '[lrsql.ops.command.statement :as stmt-cmd]
+   '[lrsql.backend.protocol :aps bp]
+   '[clojure.data.json :as json]
+   '[lrsql.maria.data :as md]
+   '[clj-test-containers.core :as tc]
+   '[lrsql.init.config :as cfg]
+   )
 
-  (def implementation
-    #_ts/fresh-sqlite-fixture
-    #_ts/fresh-postgres-fixture
-    ts/fresh-maria-fixture)
+  ;; start a container
+  (def container (tc/start! ts/mariadb-container))
 
-(defn test-test [test]
-  (implementation #(test)))
+  ;; Make a system pointing at it
+  (let [{{{:keys [db-port]}
+          :database}
+         :connection
+         :as raw-cfg} (cfg/read-config :test-maria)
+        mapped-port   (get (:mapped-ports container) db-port)
+        mapped-host   (get container :host)]
+    (def sys
+      (system/system (rm/map->MariaBackend {}) :test-maria
+                     :conf-overrides
+                     {[:connection :database :db-port] mapped-port
+                      [:connection :database :db-host] mapped-host})))
 
-(defn test-ns [ns]
   (do
-    (require ns)
-    (alter-meta! (find-ns ns)
-                 assoc
-                 ::test/each-fixtures
-                 [implementation])
-    (test/run-tests ns)))
+    (def sys' (component/start sys))
+    (def lrs (:lrs sys'))
+    (def bk (:backend lrs))
+    (def ds (-> sys' :lrs :connection :conn-pool)))
 
-(defmacro with-fixtures [& forms]
-  `(implementation
-    (fn []
-      (do ~@forms)))))
+  ;; Sanity check queries
+  (jdbc/execute! ds
+                 ["SELECT stmt.payload FROM xapi_statement stmt LIMIT 1"])
 
-(comment
-;using cognitect's test runner
-  (require '[cognitect.test-runner.api :as runner]
-           '[lrsql.test-support :as support])
-  
-  (with-redefs [support/fresh-db-fixture support/fresh-maria-fixture]
-    (runner/test {
-                  #_#_:patterns [#"lrsql.lrs-test"]
-                  :nses ['lrsql.lrs-test]
-                  :dirs ["src/test"]})))
+  (jdbc/execute! ds
+                 ["SELECT COUNT(*) FROM xapi_statement"])
 
 
 
+  ;; Stop system
+  (component/stop sys')
 
-(require '[lrsql.util.statement :as us])
-
-
-
-
-(+ 2 2)
-(defn stdin-works? []
-  (try
-    ;; Try to read a line without blocking
-    (when (.ready *in*)
-      (.readLine (java.io.BufferedReader. *in*)))
-    true
-    (catch Exception _
-      false)))
-
-(defn safe-repl []
-  (if (stdin-works?)
-    (try
-      (println "🛠️  Starting fallback REPL. Ctrl-D to exit.")
-      (clojure.main/repl)
-      (catch Throwable e
-        (println "⚠️  Could not start fallback REPL:" (.getMessage e))))
-    (println "⚠️  Input stream is not available (probably CIDER). Skipping REPL.")))
-
-(safe-repl)
-
-
-
-
-
-
-
-(defmacro test-macro [& body]
-  `(do
-     (println "test-macro!")
-     ~@body))
-
-(alter-var-root #'test-macro
-                (fn [_]
-                  (fn [& form]
-                    `(do
-                       (println "rebound!")
-                       ~@(rest form)))))
-
-(alter-meta! #'test-macro assoc :macro true)
-
-(def v)
-
-(alter-meta! #'v assoc :macro true)
-
-(alter-var-root #'v (fn [_]
-                      (fn [_ & form]
-                        `(do
-                           (println "vvvvv!!")
-                           ~@form))))
-
-(def holder (atom nil))
-(defmacro env-macro [& form]
-  (reset! holder  &env)
-  `(do ~@form)
-  )
-
-
-  (require '[cognitect.test-runner.api :as runner]
-           '[lrsql.test-support :as support])
-(in-ns 'cognitect.test-runner)
-
-(def unfiltered (->>  ["src/test"] 
-                     (map io/file)
-                     (mapcat find/find-namespaces-in-dir)
-                     ))
-
-(filter (ns-filter {:namespace [#{'lrsql.lrs-test}] :namespace-regex [#"lrs-test"]}) unfiltered)
-
-((ns-filter {:namespace #{'lrsql.lrs-test} :namespace-regex [#"lrs-test"]}) 'lrsql.lrs-test)
-
-
-
-(in-ns 'cognitect.test-runner)
-
-(defn- ns-filter
-  [{:keys [namespace namespace-regex] :as opts}]
-  (println "opts:" opts)
-  (let [regexes (or namespace-regex [#".*\-test$"])]
-    (fn [ns]
-      (or
-       (get namespace ns)
-       (some #(re-matches % (name ns)) regexes)))))
-
-(require 'clojure.repl)
-(clojure.repl/source test)
-
-(defn test
-  [options]
-  (let [dirs (or (:dir options)
-                 #{"test"})
-        nses (->> dirs
-                  (map io/file)
-                  (mapcat find/find-namespaces-in-dir))
-        nses (filter (ns-filter options) nses)]
-    (println "nses:" nses)
-    (println (format "\nRunning tests in %s" dirs))
-    #_#_(dorun (map require nses))
-    (try
-      (filter-vars! nses (var-filter options))
-      (filter-fixtures! nses)
-      (apply test/run-tests nses)
-      (finally
-        (restore-vars! nses)
-        (restore-fixtures! nses)))))
-
-
-(defmacro capture-args []
-                    (let [locals (keys &env)
-                          syms (mapv (comp symbol name) locals)
-                          vals (vec locals)]
-                      `(let [syms# '~syms
-                             vals# (vector ~@locals)]
-                      (def holder (atom (zipmap syms# vals#))))))
-
-(require '[clojure.walk :as walk])
-
-(defmacro with-holder [form]
-  (let [params (mapv (comp symbol gensym name) (keys @holder))
-        mapping (zipmap (keys @holder) params)
-        rewritten (walk/postwalk-replace mapping form)
-        fn-form (list 'fn params rewritten)]
-    `(apply (eval ~fn-form) (vals @holder))))
-
-
-(defmacro do-print [& forms]
-  `(do
-     ~@(apply concat
-              (for [form forms]
-                [`(println ~(str form))
-                 form]))
-     (println "all done!")))
-
-
-(comment
-  (in-ns 'clojure.test)
-  (require '[clojure.main :as m])
-
-  (defmacro try-expr [msg form]
-    (let [locals (keys &env)
-          ctx-map (into {} (map (fn [s] [`'~s s]) locals))]
-
-      `(try ~(assert-expr msg form)
-            (catch Throwable t#
-              (do-report {:type :error, :message ~msg,
-                          :expected '~form, :actual t#})
-              (let [__locals__# ~ctx-map]
-                (println "🔎 Entering debug eval REPL with locals:" (keys __locals__#))
-                (m/repl :eval (fn [form#]
-                                (eval
-                                 `(let [~@(mapcat (fn [[sym# val#]] [`~sym# val#])
-                                                  __locals__#)]
-                                    ~form#)))))))))
-
-                                        ;dynamic, so can probably do that rather than alter-var-root
-  (defn test-var [v]
-    (when-let [t (:test (meta v))]
-      (binding [*testing-vars* (conj *testing-vars* v)]
-        (do-report {:type :begin-test-var, :var v})
-        (inc-report-counter :test)
-        (try (t)
-             (catch Throwable e
-               (do-report {:type :error, :message "Uncaught exception, not in assertion."
-                           :expected nil, :actual e})
-               (m/repl)             ;no locals so we can do it like so
-               ))
-        (do-report {:type :end-test-var, :var v}))))
-
-  (comment
-    (println "💥 Test failure:" ~test-name)
-    (println "🧵 Message:" (.getMessage t#)))
-
-
-  
+  ;; Stop the container
+  (tc/stop! container)
   )

--- a/src/test/logback-test.xml
+++ b/src/test/logback-test.xml
@@ -12,4 +12,6 @@
   <logger name="lrsql.ops.query.reaction" level="off" />
   <!-- allow logs for bench tests -->
   <logger name="lrsql.bench-test" level="info" />
+  <!-- allow logs for test runner -->
+  <logger name="lrsql.test-runner" level="info" />
 </configuration>

--- a/src/test/logback-test.xml
+++ b/src/test/logback-test.xml
@@ -14,4 +14,5 @@
   <logger name="lrsql.bench-test" level="info" />
   <!-- allow logs for test runner -->
   <logger name="lrsql.test-runner" level="info" />
+  <logger name="lrsql.test-support" level="info" />
 </configuration>

--- a/src/test/lrsql/test_runner.clj
+++ b/src/test/lrsql/test_runner.clj
@@ -26,7 +26,10 @@
                     "sqlite" support/*postgres-container*
                     "postgres" support/*postgres-container*
                     "mariadb" (tc/start! support/*mariadb-container*))]
-          (runner/test {:dirs ["src/test"]}))
+          (runner/test (merge
+                        {:dirs ["src/test"]}
+                        (when ns
+                          {:nses [(symbol ns)]}))))
         (finally
           (when (= "postgres" db)
             (tc/stop! support/*postgres-container*))

--- a/src/test/lrsql/test_runner.clj
+++ b/src/test/lrsql/test_runner.clj
@@ -10,44 +10,33 @@
          ns "--ns"
          :or {db "sqlite"
               ns nil}} args]
-
+    (when (contains? #{"postgres"
+                       "mariadb"}
+                     db)
+      (log/infof "Starting container for %s..." db))
     (with-redefs [support/fresh-db-fixture
                   (case db
                     "sqlite"   support/fresh-sqlite-fixture
                     "postgres" support/fresh-postgres-fixture
-                    "mariadb"  support/fresh-mariadb-fixture)]
+                    "mariadb"  support/fresh-mariadb-fixture)
+                  support/*container*
+                  (case db
+                    "sqlite"   nil
+                    "postgres" (tc/start! support/postgres-container)
+                    "mariadb"  (tc/start! support/mariadb-container))]
       (try
-        (when (contains? #{"postgres"
-                           "mariadb"}
-                         db)
-          (log/infof "Starting container for %s..." db))
-        (binding [support/*postgres-container*
-                  (case db
-                    "sqlite" support/*postgres-container*
-                    "postgres" (tc/start! support/*postgres-container*)
-                    "mariadb" support/*mariadb-container*)
-                  support/*mariadb-container*
-                  (case db
-                    "sqlite" support/*postgres-container*
-                    "postgres" support/*postgres-container*
-                    "mariadb" (tc/start! support/*mariadb-container*))]
-          (when (contains? #{"postgres"
-                             "mariadb"}
-                           db)
-            (log/infof "Container for %s started!" db))
-          (runner/test (merge
-                        {:dirs ["src/test"]}
-                        (when ns
-                          {:nses [(symbol ns)]}))))
+        (when support/*container*
+          (log/infof "Container for %s started!" db))
+        ;; Run tests
+        (runner/test (merge
+                      {:dirs ["src/test"]}
+                      (when ns
+                        {:nses [(symbol ns)]})))
+        ;; Cleanup
         (finally
-          (when (contains? #{"postgres"
-                             "mariadb"}
-                           db)
+          (when support/*container*
             (log/infof "Stopping container for %s..." db)
-            (when (= "postgres" db)
-              (tc/stop! support/*postgres-container*))
-            (when (= "mariadb" db)
-              (tc/stop! support/*mariadb-container*))
+            (tc/stop! support/*container*)
             (log/infof "%s container stopped. Cleaning up..." db)
             (tc/perform-cleanup!)
             (log/info "tc cleanup complete."))

--- a/src/test/lrsql/test_runner.clj
+++ b/src/test/lrsql/test_runner.clj
@@ -1,6 +1,7 @@
 (ns lrsql.test-runner
-  (:require[cognitect.test-runner.api :as runner]
-           [lrsql.test-support :as support]))
+  (:require [cognitect.test-runner.api :as runner]
+            [lrsql.test-support :as support]
+            [clj-test-containers.core :as tc]))
 
 (defn -main
   [& args]
@@ -10,10 +11,15 @@
               ns nil}} args]
 
     (with-redefs [support/fresh-db-fixture
-                    (case db
-                      "sqlite"   support/fresh-sqlite-fixture
-                      "postgres" support/fresh-postgres-fixture
-                      "maria" support/fresh-maria-fixture)]
-      (runner/test (merge {:dirs ["src/test"]}
-                          (when ns {:nses [(symbol ns)]
-                                    #_#_:patterns [#"nonsensestring"]}))))))
+                  (case db
+                    "sqlite"   support/fresh-sqlite-fixture
+                    "postgres" support/fresh-postgres-fixture)]
+      (try
+        (binding [support/*postgres-container*
+                  (case db
+                    "sqlite" support/*postgres-container*
+                    "postgres" (tc/start! support/*postgres-container*))]
+          (runner/test {:dirs ["src/test"]}))
+        (finally
+          (when (= "postgres" db)
+            (tc/stop! support/*postgres-container*)))))))

--- a/src/test/lrsql/test_runner.clj
+++ b/src/test/lrsql/test_runner.clj
@@ -13,13 +13,22 @@
     (with-redefs [support/fresh-db-fixture
                   (case db
                     "sqlite"   support/fresh-sqlite-fixture
-                    "postgres" support/fresh-postgres-fixture)]
+                    "postgres" support/fresh-postgres-fixture
+                    "mariadb"  support/fresh-mariadb-fixture)]
       (try
         (binding [support/*postgres-container*
                   (case db
                     "sqlite" support/*postgres-container*
-                    "postgres" (tc/start! support/*postgres-container*))]
+                    "postgres" (tc/start! support/*postgres-container*)
+                    "mariadb" support/*mariadb-container*)
+                  support/*mariadb-container*
+                  (case db
+                    "sqlite" support/*postgres-container*
+                    "postgres" support/*postgres-container*
+                    "mariadb" (tc/start! support/*mariadb-container*))]
           (runner/test {:dirs ["src/test"]}))
         (finally
           (when (= "postgres" db)
-            (tc/stop! support/*postgres-container*)))))))
+            (tc/stop! support/*postgres-container*))
+          (when (= "mariadb" db)
+            (tc/stop! support/*mariadb-container*)))))))

--- a/src/test/lrsql/test_runner.clj
+++ b/src/test/lrsql/test_runner.clj
@@ -50,4 +50,5 @@
               (tc/stop! support/*mariadb-container*))
             (log/infof "%s container stopped. Cleaning up..." db)
             (tc/perform-cleanup!)
-            (log/info "tc cleanup complete.")))))))
+            (log/info "tc cleanup complete."))
+          (shutdown-agents))))))

--- a/src/test/lrsql/test_support.clj
+++ b/src/test/lrsql/test_support.clj
@@ -54,7 +54,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Container spec, derived from settings
-(def ^:dynamic *postgres-container*
+(def postgres-container
   (let [{{{:keys [db-type
                   db-port
                   db-name
@@ -71,7 +71,7 @@
                       "POSTGRES_PASSWORD" db-password}
       :wait-for      {:wait-strategy :port}})))
 
-(def ^:dynamic *mariadb-container*
+(def mariadb-container
   (let [{{{:keys [db-type
                   db-port
                   db-name
@@ -90,6 +90,8 @@
       :wait-for      {:wait-strategy :log
                       :message       "ready for connections"
                       :times         1}})))
+
+(def ^:dynamic *container* nil)
 
 (def table-names
   ["credential_to_scope"
@@ -154,9 +156,6 @@
     (let [profile-kw    (case dbtype
                           :postgres :test-postgres
                           :mariadb  :test-maria)
-          container     (case dbtype
-                          :postgres *postgres-container*
-                          :mariadb  *mariadb-container*)
           {{{:keys [db-type
                     db-port
                     db-name
@@ -165,8 +164,8 @@
             :database}
            :connection
            :as raw-cfg} (read-config profile-kw)
-          mapped-port   (get (:mapped-ports container) db-port)
-          mapped-host   (get container :host)
+          mapped-port   (get (:mapped-ports *container*) db-port)
+          mapped-host   (get *container* :host)
           pg-cfg        (update-in
                          raw-cfg
                          [:connection :database]

--- a/src/test/lrsql/test_support.clj
+++ b/src/test/lrsql/test_support.clj
@@ -1,9 +1,7 @@
 (ns lrsql.test-support
   (:require [clojure.spec.test.alpha :as stest]
-            [clojure.string :as cstr]
             [orchestra.spec.test :as otest]
             [next.jdbc :as jdbc]
-            [next.jdbc.connection :refer [jdbc-url]]
             [com.yetanalytics.datasim :as ds]
             [lrsql.init.config :refer [read-config]]
             [lrsql.system :as system]
@@ -39,7 +37,7 @@
    (let [opts {:clojure.spec.test.check/opts
                {:num-tests num-tests
                 :seed      (rand-int Integer/MAX_VALUE)}}
-         res (stest/check fname opts)]
+         res  (stest/check fname opts)]
      (when-not (true? (-> res first :clojure.spec.test.check/ret :pass?))
        res))))
 
@@ -58,7 +56,6 @@
 ;; Container spec, derived from settings
 (def ^:dynamic *postgres-container*
   (let [{{{:keys [db-type
-                  db-host
                   db-port
                   db-name
                   db-user
@@ -67,12 +64,12 @@
           :database}
          :connection} (read-config :test-postgres)]
     (tc/create
-     {:image-name (format "%s:%s" db-type test-db-version)
+     {:image-name    (format "%s:%s" db-type test-db-version)
       :exposed-ports [db-port]
-      :env-vars {"POSTGRES_DB" db-name
-                 "POSTGRES_USER" db-user
-                 "POSTGRES_PASSWORD" db-password}
-      :wait-for {:wait-strategy :port}})))
+      :env-vars      {"POSTGRES_DB"       db-name
+                      "POSTGRES_USER"     db-user
+                      "POSTGRES_PASSWORD" db-password}
+      :wait-for      {:wait-strategy :port}})))
 
 (def table-names
   ["credential_to_scope"
@@ -125,14 +122,14 @@
                    (assoc-in [:connection :database :db-name]
                              ":memory:?cache=shared"))]
     (with-redefs
-     [read-config (constantly sl-cfg)
-      test-system (fn [& {:keys [conf-overrides]}]
-                    (system/system (sr/map->SQLiteBackend {}) :test-sqlite
-                                   :conf-overrides conf-overrides))]
+      [read-config (constantly sl-cfg)
+       test-system (fn [& {:keys [conf-overrides]}]
+                     (system/system (sr/map->SQLiteBackend {}) :test-sqlite
+                                    :conf-overrides conf-overrides))]
       (let [ret (f)]
         ;; Wrapped in a try for fixture test
         (try (truncate-all-sqlite!)
-             (catch Exception ex_
+             (catch Exception _
                ))
         ret))))
 
@@ -145,8 +142,7 @@
                   db-port
                   db-name
                   db-user
-                  db-password
-                  test-db-version]}
+                  db-password]}
           :database}
          :connection
          :as raw-cfg} (read-config :test-postgres)
@@ -155,11 +151,11 @@
                        raw-cfg
                        [:connection :database :db-port]
                        mapped-port)
-        db            {:dbtype db-type
-                       :dbname db-name
-                       :host db-host
-                       :port mapped-port
-                       :user db-user
+        db            {:dbtype   db-type
+                       :dbname   db-name
+                       :host     db-host
+                       :port     mapped-port
+                       :user     db-user
                        :password db-password}
         ds            (jdbc/get-datasource db)]
     (with-redefs
@@ -195,9 +191,9 @@
    (fn splode [{:keys [_title
                        _status
                        tests]
-                :as test}
+                :as   test}
                & {:keys [depth]
-                  :or {depth 0}}]
+                  :or   {depth 0}}]
      (cons (-> test
                (assoc :depth depth))
            (mapcat #(splode % :depth (inc depth))

--- a/src/test/lrsql/test_support.clj
+++ b/src/test/lrsql/test_support.clj
@@ -125,7 +125,6 @@
       (jdbc/execute! tx [(format "TRUNCATE TABLE `%s`" t)]))
     (jdbc/execute! tx ["SET FOREIGN_KEY_CHECKS=1"])))
 
-
 ;; Returns `{}` as default - need to be used in a fixture
 (defn test-system
   "Create a lrsql system specifically for tests. Optional kwarg `conf-overrides`

--- a/src/test/lrsql/test_support_test.clj
+++ b/src/test/lrsql/test_support_test.clj
@@ -8,9 +8,9 @@
   (get-in config [:connection :database :db-name]))
 
 (deftest fresh-db-fixture-test
-  (testing "sets the db name to a random uuid"
+  (testing "sets the db name for shared memory db"
     (is
-     (= ":memory:"
+     (= ":memory:?cache=shared"
         (get-db-name
          (fresh-sqlite-fixture
           #(read-config :test-sqlite-mem)))))))

--- a/src/test/lrsql/test_support_test.clj
+++ b/src/test/lrsql/test_support_test.clj
@@ -10,7 +10,7 @@
 (deftest fresh-db-fixture-test
   (testing "sets the db name for shared memory db"
     (is
-     (= ":memory:?cache=shared"
+     (= ":memory:"
         (get-db-name
          (fresh-sqlite-fixture
           #(read-config :test-sqlite-mem)))))))


### PR DESCRIPTION
Rather than running containers per-test, run a single container and clear it after every test.

To run individual tests in the repl, use set-db-fixture-mode! to set your desired backend first and then containers will be created on-demand.