### PR TITLE
bump docker jdk to 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN apk update \
         && apk upgrade \
         && apk add ca-certificates \
         && update-ca-certificates \
-        && apk add --no-cache openjdk11 \
+        && apk add --no-cache openjdk21 \
         && mkdir -p /lrsql/runtimes \
         && jlink --output /lrsql/runtimes/linux/ --add-modules $(cat /lrsql/.java_modules) \
-        && apk del openjdk11 \
+        && apk del openjdk21 \
         && rm -rf /var/cache/apk/*
 
 # delete bench utils for leaner container


### PR DESCRIPTION
We updated the build env to 21 but did not update the jdk in the image itself, causing an npe. See https://github.com/yetanalytics/lrsql/issues/509