### PR TITLE
ETag Compare-and-Swap

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -59,7 +59,9 @@
   com.fasterxml.jackson.core/jackson-core       {:mvn/version "2.21.5"}
   ;; Yet Analytics deps
   com.yetanalytics/lrs
-  {:mvn/version "1.5.0"
+  {;; :mvn/version "1.5.0"
+   :git/url "https://github.com/yetanalytics/lrs.git"
+   :git/sha "d2795e35cdf9584ab6f0feab9e70e6d1589d052e"
    :exclusions  [org.clojure/clojure
                  org.clojure/clojurescript
                  com.yetanalytics/xapi-schema]}

--- a/deps.edn
+++ b/deps.edn
@@ -61,7 +61,7 @@
   com.yetanalytics/lrs
   {;; :mvn/version "1.5.0"
    :git/url "https://github.com/yetanalytics/lrs.git"
-   :git/sha "d2795e35cdf9584ab6f0feab9e70e6d1589d052e"
+   :git/sha "237a01282a1600d3ac6fac7a139d46cbe6294f8c"
    :exclusions  [org.clojure/clojure
                  org.clojure/clojurescript
                  com.yetanalytics/xapi-schema]}

--- a/deps.edn
+++ b/deps.edn
@@ -59,9 +59,7 @@
   com.fasterxml.jackson.core/jackson-core       {:mvn/version "2.21.5"}
   ;; Yet Analytics deps
   com.yetanalytics/lrs
-  {;; :mvn/version "1.5.0"
-   :git/url "https://github.com/yetanalytics/lrs.git"
-   :git/sha "237a01282a1600d3ac6fac7a139d46cbe6294f8c"
+  {:mvn/version "1.5.1"
    :exclusions  [org.clojure/clojure
                  org.clojure/clojurescript
                  com.yetanalytics/xapi-schema]}

--- a/src/db/mariadb/lrsql/mariadb/record.clj
+++ b/src/db/mariadb/lrsql/mariadb/record.clj
@@ -7,14 +7,15 @@
             [lrsql.backend.result :as br]
             [lrsql.init :refer [init-hugsql-adapter!]]
             [lrsql.mariadb.data :as md]
-            [clojure.string :refer [includes?]])
-  (:import [java.security MessageDigest]))
+            [clojure.string :as cstr])
+  (:import [java.security MessageDigest]
+           [java.sql SQLException]))
 
 (defn make-path-str [p]
   (as-> p path
     (map #(format "\"%s\"" %) path)
     (into [\$] path)
-    (clojure.string/join \. path)
+    (cstr/join \. path)
     (format "'%s'" path)))
 
 (defn sha256-bytes [^String s]
@@ -27,7 +28,7 @@
 (defn emit-binary-hashes [ifis]
   (->> ifis
        (map (comp bytes->sql-hex sha256-bytes))
-       (clojure.string/join ", "))) ;; emits: X'...', X'...', ...
+       (cstr/join ", "))) ;; emits: X'...', X'...', ...
 
 ;; Init HugSql functions
 
@@ -75,10 +76,13 @@
 
   bp/BackendUtil
   (-txn-retry? [_ ex]
-    (and (instance? java.sql.SQLException ex)
-         (let [msg (.getMessage ex)]
-           (or (includes? msg "Record has changed since last read")
-               (includes? msg "Deadlock found when trying to get lock")))))
+    (and (instance? SQLException ex)
+         (let [sql-ex ^SQLException ex]
+           (or (= "40001" (.getSQLState sql-ex))
+               (contains? #{1020  ; record changed since last read
+                            1205  ; lock wait timeout
+                            1213} ; deadlock / serialization conflict
+                          (.getErrorCode sql-ex))))))
 
   bp/StatementBackend
   (-insert-statement! [_ tx input]
@@ -145,6 +149,8 @@
     (br/affected->applied? (delete-state-document-if-contents! tx input)))
   (-delete-state-documents! [_ tx input]
     (delete-state-documents! tx input))
+  (-delete-state-documents-by-primary-keys! [_ tx input]
+    (delete-state-documents-by-primary-keys! tx input))
   (-query-state-document [_ tx input]
     (query-state-document tx input))
   (-query-state-document-ids [_ tx input]

--- a/src/db/mariadb/lrsql/mariadb/record.clj
+++ b/src/db/mariadb/lrsql/mariadb/record.clj
@@ -4,6 +4,7 @@
             [next.jdbc :as jdbc]
             [lrsql.backend.data :as bd]
             [lrsql.backend.protocol :as bp]
+            [lrsql.backend.result :as br]
             [lrsql.init :refer [init-hugsql-adapter!]]
             [lrsql.mariadb.data :as md]
             [clojure.string :refer [includes?]])
@@ -132,10 +133,16 @@
   bp/StateDocumentBackend
   (-insert-state-document! [_ tx input]
     (insert-state-document! tx input))
+  (-insert-state-document-if-absent! [_ tx input]
+    (br/affected->applied? (insert-state-document-if-absent! tx input)))
   (-update-state-document! [_ tx input]
     (update-state-document! tx input))
+  (-update-state-document-if-contents! [_ tx input]
+    (br/affected->applied? (update-state-document-if-contents! tx input)))
   (-delete-state-document! [_ tx input]
     (delete-state-document! tx input))
+  (-delete-state-document-if-contents! [_ tx input]
+    (br/affected->applied? (delete-state-document-if-contents! tx input)))
   (-delete-state-documents! [_ tx input]
     (delete-state-documents! tx input))
   (-query-state-document [_ tx input]
@@ -148,10 +155,16 @@
   bp/AgentProfileDocumentBackend
   (-insert-agent-profile-document! [_ tx input]
     (insert-agent-profile-document! tx input))
+  (-insert-agent-profile-document-if-absent! [_ tx input]
+    (br/affected->applied? (insert-agent-profile-document-if-absent! tx input)))
   (-update-agent-profile-document! [_ tx input]
     (update-agent-profile-document! tx input))
+  (-update-agent-profile-document-if-contents! [_ tx input]
+    (br/affected->applied? (update-agent-profile-document-if-contents! tx input)))
   (-delete-agent-profile-document! [_ tx input]
     (delete-agent-profile-document! tx input))
+  (-delete-agent-profile-document-if-contents! [_ tx input]
+    (br/affected->applied? (delete-agent-profile-document-if-contents! tx input)))
   (-query-agent-profile-document [_ tx input]
     (query-agent-profile-document tx input))
   (-query-agent-profile-document-ids [_ tx input]
@@ -162,10 +175,16 @@
   bp/ActivityProfileDocumentBackend
   (-insert-activity-profile-document! [_ tx input]
     (insert-activity-profile-document! tx input))
+  (-insert-activity-profile-document-if-absent! [_ tx input]
+    (br/affected->applied? (insert-activity-profile-document-if-absent! tx input)))
   (-update-activity-profile-document! [_ tx input]
     (update-activity-profile-document! tx input))
+  (-update-activity-profile-document-if-contents! [_ tx input]
+    (br/affected->applied? (update-activity-profile-document-if-contents! tx input)))
   (-delete-activity-profile-document! [_ tx input]
     (delete-activity-profile-document! tx input))
+  (-delete-activity-profile-document-if-contents! [_ tx input]
+    (br/affected->applied? (delete-activity-profile-document-if-contents! tx input)))
   (-query-activity-profile-document [_ tx input]
     (query-activity-profile-document tx input))
   (-query-activity-profile-document-ids [_ tx input]

--- a/src/db/mariadb/lrsql/mariadb/sql/delete.sql
+++ b/src/db/mariadb/lrsql/mariadb/sql/delete.sql
@@ -20,6 +20,19 @@ AND agent_ifi = :agent-ifi
 --~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
 ;
 
+-- :name delete-state-documents-by-primary-keys!
+-- :command :execute
+-- :result :affected
+-- :doc Delete observed State documents by physical primary key, retaining collection scoping predicates.
+DELETE FROM state_document
+WHERE activity_hash = UNHEX(SHA2(:activity-iri,256))
+AND agent_hash = UNHEX(SHA2(:agent-ifi,256))
+AND activity_iri = :activity-iri
+AND agent_ifi = :agent-ifi
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
+AND id IN (:v*:primary-keys)
+;
+
 -- :name delete-agent-profile-document!
 -- :command :execute
 -- :result :affected

--- a/src/db/mariadb/lrsql/mariadb/sql/delete.sql
+++ b/src/db/mariadb/lrsql/mariadb/sql/delete.sql
@@ -38,6 +38,40 @@ WHERE profile_hash = UNHEX(SHA2(:profile-id,256))
 AND profile_id = :profile-id
 AND activity_iri = :activity-iri;
 
+/* Conditional Document Deletion */
+
+-- :name delete-state-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Delete a state document only when its contents equal the observed contents.
+DELETE FROM state_document
+WHERE activity_iri = :activity-iri
+AND agent_ifi = :agent-ifi
+AND state_hash = UNHEX(SHA2(:state-id,256))
+AND state_id = :state-id
+--~ (when (:registration params) "AND registration = :registration" "AND registration IS NULL")
+AND contents = :expected-contents;
+
+-- :name delete-agent-profile-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Delete an agent profile document only when its contents equal the observed contents.
+DELETE FROM agent_profile_document
+WHERE profile_hash = UNHEX(SHA2(:profile-id,256))
+AND profile_id = :profile-id
+AND agent_ifi = :agent-ifi
+AND contents = :expected-contents;
+
+-- :name delete-activity-profile-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Delete an activity profile document only when its contents equal the observed contents.
+DELETE FROM activity_profile_document
+WHERE profile_hash = UNHEX(SHA2(:profile-id,256))
+AND profile_id = :profile-id
+AND activity_iri = :activity-iri
+AND contents = :expected-contents;
+
 /* Admin Accounts + Credentials */
 
 -- :name delete-admin-account!

--- a/src/db/mariadb/lrsql/mariadb/sql/delete.sql
+++ b/src/db/mariadb/lrsql/mariadb/sql/delete.sql
@@ -49,7 +49,7 @@ WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
 AND state_hash = UNHEX(SHA2(:state-id,256))
 AND state_id = :state-id
---~ (when (:registration params) "AND registration = :registration" "AND registration IS NULL")
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
 AND contents = :expected-contents;
 
 -- :name delete-agent-profile-document-if-contents!

--- a/src/db/mariadb/lrsql/mariadb/sql/insert.sql
+++ b/src/db/mariadb/lrsql/mariadb/sql/insert.sql
@@ -108,6 +108,70 @@ INSERT INTO activity_profile_document (
   :last-modified, :content-type, :content-length, :contents
 ) ON DUPLICATE KEY UPDATE id = id;
 
+/* Conditional Document Insertion */
+
+-- :name insert-state-document-if-absent!
+-- :command :execute
+-- :result :affected
+-- :doc Insert a state document only when its logical key is absent.
+INSERT INTO state_document (
+  id, state_id, activity_iri, agent_ifi, registration,
+  last_modified, content_type, content_length, contents
+)
+SELECT
+  :primary-key, :state-id, :activity-iri, :agent-ifi, :registration,
+  :last-modified, :content-type, :content-length, :contents
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM state_document
+  WHERE state_hash = UNHEX(SHA2(:state-id,256))
+  AND state_id = :state-id
+  AND activity_hash = UNHEX(SHA2(:activity-iri,256))
+  AND agent_hash = UNHEX(SHA2(:agent-ifi,256))
+  --~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
+)
+ON DUPLICATE KEY UPDATE id = id;
+
+-- :name insert-agent-profile-document-if-absent!
+-- :command :execute
+-- :result :affected
+-- :doc Insert an agent profile document only when its logical key is absent.
+INSERT INTO agent_profile_document (
+  id, profile_id, agent_ifi,
+  last_modified, content_type, content_length, contents
+)
+SELECT
+  :primary-key, :profile-id, :agent-ifi,
+  :last-modified, :content-type, :content-length, :contents
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM agent_profile_document
+  WHERE profile_hash = UNHEX(SHA2(:profile-id,256))
+  AND profile_id = :profile-id
+  AND agent_hash = UNHEX(SHA2(:agent-ifi,256))
+)
+ON DUPLICATE KEY UPDATE id = id;
+
+-- :name insert-activity-profile-document-if-absent!
+-- :command :execute
+-- :result :affected
+-- :doc Insert an activity profile document only when its logical key is absent.
+INSERT INTO activity_profile_document (
+  id, profile_id, activity_iri,
+  last_modified, content_type, content_length, contents
+)
+SELECT
+  :primary-key, :profile-id, :activity-iri,
+  :last-modified, :content-type, :content-length, :contents
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM activity_profile_document
+  WHERE profile_hash = UNHEX(SHA2(:profile-id,256))
+  AND profile_id = :profile-id
+  AND activity_hash = UNHEX(SHA2(:activity-iri,256))
+)
+ON DUPLICATE KEY UPDATE id = id;
+
 /* Accounts */
 
 -- :name insert-admin-account!

--- a/src/db/mariadb/lrsql/mariadb/sql/query.sql
+++ b/src/db/mariadb/lrsql/mariadb/sql/query.sql
@@ -217,7 +217,7 @@ AND profile_id = :profile-id;
 -- :command :query
 -- :result :many
 -- :doc Query for one or more state document IDs using resource params. If `:registration` is missing then `registration` must be NULL.
-SELECT state_id FROM state_document
+SELECT id, state_id FROM state_document
 WHERE activity_hash = UNHEX(SHA2(:activity-iri,256))
 AND agent_hash = UNHEX(SHA2(:agent-ifi,256))
 --~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")

--- a/src/db/mariadb/lrsql/mariadb/sql/update.sql
+++ b/src/db/mariadb/lrsql/mariadb/sql/update.sql
@@ -71,6 +71,52 @@ WHERE profile_hash = UNHEX(SHA2(:profile-id,256))
 AND profile_id = :profile-id
 AND activity_hash = UNHEX(SHA2(:activity-iri,256));
 
+/* Conditional Document Updates */
+
+-- :name update-state-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Update a state document only when its contents equal the observed contents.
+UPDATE state_document
+SET
+  content_length = :content-length,
+  contents = :contents,
+  last_modified = :last-modified
+WHERE state_hash = UNHEX(SHA2(:state-id,256))
+AND state_id = :state-id
+AND activity_hash = UNHEX(SHA2(:activity-iri,256))
+AND agent_hash = UNHEX(SHA2(:agent-ifi,256))
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
+AND contents = :expected-contents;
+
+-- :name update-agent-profile-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Update an agent profile document only when its contents equal the observed contents.
+UPDATE agent_profile_document
+SET
+  content_length = :content-length,
+  contents = :contents,
+  last_modified = :last-modified
+WHERE profile_hash = UNHEX(SHA2(:profile-id,256))
+AND profile_id = :profile-id
+AND agent_hash = UNHEX(SHA2(:agent-ifi,256))
+AND contents = :expected-contents;
+
+-- :name update-activity-profile-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Update an activity profile document only when its contents equal the observed contents.
+UPDATE activity_profile_document
+SET
+  content_length = :content-length,
+  contents = :contents,
+  last_modified = :last-modified
+WHERE profile_hash = UNHEX(SHA2(:profile-id,256))
+AND profile_id = :profile-id
+AND activity_hash = UNHEX(SHA2(:activity-iri,256))
+AND contents = :expected-contents;
+
 /* Admin Accounts + Credentials */
 
 -- :name update-admin-password!

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -4,6 +4,7 @@
             [next.jdbc :as jdbc]
             [lrsql.backend.data :as bd]
             [lrsql.backend.protocol :as bp]
+            [lrsql.backend.result :as br]
             [lrsql.init :refer [init-hugsql-adapter!]]
             [lrsql.postgres.data :as pd]
             [clojure.string :refer [includes?]])
@@ -150,10 +151,16 @@
   bp/StateDocumentBackend
   (-insert-state-document! [_ tx input]
     (insert-state-document! tx input))
+  (-insert-state-document-if-absent! [_ tx input]
+    (br/affected->applied? (insert-state-document-if-absent! tx input)))
   (-update-state-document! [_ tx input]
     (update-state-document! tx input))
+  (-update-state-document-if-contents! [_ tx input]
+    (br/affected->applied? (update-state-document-if-contents! tx input)))
   (-delete-state-document! [_ tx input]
     (delete-state-document! tx input))
+  (-delete-state-document-if-contents! [_ tx input]
+    (br/affected->applied? (delete-state-document-if-contents! tx input)))
   (-delete-state-documents! [_ tx input]
     (delete-state-documents! tx input))
   (-query-state-document [_ tx input]
@@ -166,10 +173,16 @@
   bp/AgentProfileDocumentBackend
   (-insert-agent-profile-document! [_ tx input]
     (insert-agent-profile-document! tx input))
+  (-insert-agent-profile-document-if-absent! [_ tx input]
+    (br/affected->applied? (insert-agent-profile-document-if-absent! tx input)))
   (-update-agent-profile-document! [_ tx input]
     (update-agent-profile-document! tx input))
+  (-update-agent-profile-document-if-contents! [_ tx input]
+    (br/affected->applied? (update-agent-profile-document-if-contents! tx input)))
   (-delete-agent-profile-document! [_ tx input]
     (delete-agent-profile-document! tx input))
+  (-delete-agent-profile-document-if-contents! [_ tx input]
+    (br/affected->applied? (delete-agent-profile-document-if-contents! tx input)))
   (-query-agent-profile-document [_ tx input]
     (query-agent-profile-document tx input))
   (-query-agent-profile-document-ids [_ tx input]
@@ -180,10 +193,16 @@
   bp/ActivityProfileDocumentBackend
   (-insert-activity-profile-document! [_ tx input]
     (insert-activity-profile-document! tx input))
+  (-insert-activity-profile-document-if-absent! [_ tx input]
+    (br/affected->applied? (insert-activity-profile-document-if-absent! tx input)))
   (-update-activity-profile-document! [_ tx input]
     (update-activity-profile-document! tx input))
+  (-update-activity-profile-document-if-contents! [_ tx input]
+    (br/affected->applied? (update-activity-profile-document-if-contents! tx input)))
   (-delete-activity-profile-document! [_ tx input]
     (delete-activity-profile-document! tx input))
+  (-delete-activity-profile-document-if-contents! [_ tx input]
+    (br/affected->applied? (delete-activity-profile-document-if-contents! tx input)))
   (-query-activity-profile-document [_ tx input]
     (query-activity-profile-document tx input))
   (-query-activity-profile-document-ids [_ tx input]

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -91,12 +91,17 @@
 
   bp/BackendUtil
   (-txn-retry? [_ ex]
-    ;; only retry PGExceptions with a specified phrase
     (and (instance? PSQLException ex)
-         (let [msg (.getMessage ^PSQLException ex)]
-           (or (includes? msg "ERROR: deadlock detected")
-               (includes? msg "ERROR: could not serialize access due to concurrent update")
-               (includes? msg "ERROR: could not serialize access due to read/write dependencies among transactions")))))
+         (or
+          ;; PostgreSQL reports transaction rollbacks by SQLSTATE.
+          (contains? #{"40001" ; serialization_failure
+                       "40P01"} ; deadlock_detected
+                     (.getSQLState ^PSQLException ex))
+          ;; In the past we have seen scenarios where PG does not properly set SQLSTATE
+          (let [msg (.getMessage ^PSQLException ex)]
+            (or (includes? msg "ERROR: deadlock detected")
+                (includes? msg "ERROR: could not serialize access due to concurrent update")
+                (includes? msg "ERROR: could not serialize access due to read/write dependencies among transactions"))))))
 
   bp/StatementBackend
   (-insert-statement! [_ tx input]
@@ -163,6 +168,8 @@
     (br/affected->applied? (delete-state-document-if-contents! tx input)))
   (-delete-state-documents! [_ tx input]
     (delete-state-documents! tx input))
+  (-delete-state-documents-by-primary-keys! [_ tx input]
+    (delete-state-documents-by-primary-keys! tx input))
   (-query-state-document [_ tx input]
     (query-state-document tx input))
   (-query-state-document-ids [_ tx input]

--- a/src/db/postgres/lrsql/postgres/sql/delete.sql
+++ b/src/db/postgres/lrsql/postgres/sql/delete.sql
@@ -45,7 +45,7 @@ DELETE FROM state_document
 WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
 AND state_id = :state-id
---~ (when (:registration params) "AND registration = :registration" "AND registration IS NULL")
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
 AND contents = :expected-contents;
 
 -- :name delete-agent-profile-document-if-contents!

--- a/src/db/postgres/lrsql/postgres/sql/delete.sql
+++ b/src/db/postgres/lrsql/postgres/sql/delete.sql
@@ -35,6 +35,37 @@ DELETE FROM activity_profile_document
 WHERE profile_id = :profile-id
 AND activity_iri = :activity-iri;
 
+/* Conditional Document Deletion */
+
+-- :name delete-state-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Delete a state document only when its contents equal the observed contents.
+DELETE FROM state_document
+WHERE activity_iri = :activity-iri
+AND agent_ifi = :agent-ifi
+AND state_id = :state-id
+--~ (when (:registration params) "AND registration = :registration" "AND registration IS NULL")
+AND contents = :expected-contents;
+
+-- :name delete-agent-profile-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Delete an agent profile document only when its contents equal the observed contents.
+DELETE FROM agent_profile_document
+WHERE profile_id = :profile-id
+AND agent_ifi = :agent-ifi
+AND contents = :expected-contents;
+
+-- :name delete-activity-profile-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Delete an activity profile document only when its contents equal the observed contents.
+DELETE FROM activity_profile_document
+WHERE profile_id = :profile-id
+AND activity_iri = :activity-iri
+AND contents = :expected-contents;
+
 /* Admin Accounts + Credentials */
 
 -- :name delete-admin-account!

--- a/src/db/postgres/lrsql/postgres/sql/delete.sql
+++ b/src/db/postgres/lrsql/postgres/sql/delete.sql
@@ -19,6 +19,17 @@ AND agent_ifi = :agent-ifi
 --~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
 ;
 
+-- :name delete-state-documents-by-primary-keys!
+-- :command :execute
+-- :result :affected
+-- :doc Delete observed State documents by physical primary key, retaining collection scoping predicates.
+DELETE FROM state_document
+WHERE activity_iri = :activity-iri
+AND agent_ifi = :agent-ifi
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
+AND id IN (:v*:primary-keys)
+;
+
 -- :name delete-agent-profile-document!
 -- :command :execute
 -- :result :affected

--- a/src/db/postgres/lrsql/postgres/sql/insert.sql
+++ b/src/db/postgres/lrsql/postgres/sql/insert.sql
@@ -108,6 +108,67 @@ INSERT INTO activity_profile_document (
   :last-modified, :content-type, :content-length, :contents
 ) ON CONFLICT ON CONSTRAINT activity_profile_doc_idx DO NOTHING;
 
+/* Conditional Document Insertion */
+
+-- :name insert-state-document-if-absent!
+-- :command :execute
+-- :result :affected
+-- :doc Insert a state document only when its logical key is absent.
+INSERT INTO state_document (
+  id, state_id, activity_iri, agent_ifi, registration,
+  last_modified, content_type, content_length, contents
+)
+SELECT
+  :primary-key, :state-id, :activity-iri, :agent-ifi, :registration,
+  :last-modified, :content-type, :content-length, :contents
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM state_document
+  WHERE state_id = :state-id
+  AND activity_iri = :activity-iri
+  AND agent_ifi = :agent-ifi
+  --~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
+)
+ON CONFLICT ON CONSTRAINT state_doc_idx DO NOTHING;
+
+-- :name insert-agent-profile-document-if-absent!
+-- :command :execute
+-- :result :affected
+-- :doc Insert an agent profile document only when its logical key is absent.
+INSERT INTO agent_profile_document (
+  id, profile_id, agent_ifi,
+  last_modified, content_type, content_length, contents
+)
+SELECT
+  :primary-key, :profile-id, :agent-ifi,
+  :last-modified, :content-type, :content-length, :contents
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM agent_profile_document
+  WHERE profile_id = :profile-id
+  AND agent_ifi = :agent-ifi
+)
+ON CONFLICT ON CONSTRAINT agent_profile_doc_idx DO NOTHING;
+
+-- :name insert-activity-profile-document-if-absent!
+-- :command :execute
+-- :result :affected
+-- :doc Insert an activity profile document only when its logical key is absent.
+INSERT INTO activity_profile_document (
+  id, profile_id, activity_iri,
+  last_modified, content_type, content_length, contents
+)
+SELECT
+  :primary-key, :profile-id, :activity-iri,
+  :last-modified, :content-type, :content-length, :contents
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM activity_profile_document
+  WHERE profile_id = :profile-id
+  AND activity_iri = :activity-iri
+)
+ON CONFLICT ON CONSTRAINT activity_profile_doc_idx DO NOTHING;
+
 /* Accounts */
 
 -- :name insert-admin-account!

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -207,7 +207,7 @@ AND profile_id = :profile-id;
 -- :command :query
 -- :result :many
 -- :doc Query for one or more state document IDs using resource params. If `:registration` is missing then `registration` must be NULL.
-SELECT state_id FROM state_document
+SELECT id, state_id FROM state_document
 WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
 --~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")

--- a/src/db/postgres/lrsql/postgres/sql/update.sql
+++ b/src/db/postgres/lrsql/postgres/sql/update.sql
@@ -68,6 +68,49 @@ SET
 WHERE profile_id = :profile-id
 AND activity_iri = :activity-iri;
 
+/* Conditional Document Updates */
+
+-- :name update-state-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Update a state document only when its contents equal the observed contents.
+UPDATE state_document
+SET
+  content_length = :content-length,
+  contents = :contents,
+  last_modified = :last-modified
+WHERE state_id = :state-id
+AND activity_iri = :activity-iri
+AND agent_ifi = :agent-ifi
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
+AND contents = :expected-contents;
+
+-- :name update-agent-profile-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Update an agent profile document only when its contents equal the observed contents.
+UPDATE agent_profile_document
+SET
+  content_length = :content-length,
+  contents = :contents,
+  last_modified = :last-modified
+WHERE profile_id = :profile-id
+AND agent_ifi = :agent-ifi
+AND contents = :expected-contents;
+
+-- :name update-activity-profile-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Update an activity profile document only when its contents equal the observed contents.
+UPDATE activity_profile_document
+SET
+  content_length = :content-length,
+  contents = :contents,
+  last_modified = :last-modified
+WHERE profile_id = :profile-id
+AND activity_iri = :activity-iri
+AND contents = :expected-contents;
+
 /* Admin Accounts + Credentials */
 
 -- :name update-admin-password!

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -131,9 +131,14 @@
                (:schema_version (query-schema-version tx))))
 
   bp/BackendUtil
-  (-txn-retry? [_ _ex]
-    ;; No known retry cases for SQLite
-    false)
+  (-txn-retry? [_ ex]
+    (and (instance? SQLiteException ex)
+         ;; Extended BUSY and LOCKED codes retain their primary result code in
+         ;; the low byte (e.g. SQLITE_BUSY_SNAPSHOT is 0x205).
+         (contains? #{5 6}
+                    (bit-and 0xff
+                             (.-code (.getResultCode
+                                      ^SQLiteException ex))))))
 
   bp/StatementBackend
   (-insert-statement! [_ tx input]
@@ -203,6 +208,8 @@
     (br/affected->applied? (delete-state-document-if-contents! tx input)))
   (-delete-state-documents! [_ tx input]
     (delete-state-documents! tx input))
+  (-delete-state-documents-by-primary-keys! [_ tx input]
+    (delete-state-documents-by-primary-keys! tx input))
   (-query-state-document [_ tx input]
     (query-state-document tx input))
   (-query-state-document-ids [_ tx input]

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -5,6 +5,7 @@
             [next.jdbc :as jdbc]
             [lrsql.backend.protocol :as bp]
             [lrsql.backend.data :as bd]
+            [lrsql.backend.result :as br]
             [lrsql.init :refer [init-hugsql-adapter!]]
             [lrsql.sqlite.data :as sd]
             [lrsql.util.path :refer [path->sqlpath-string]])
@@ -190,10 +191,16 @@
   bp/StateDocumentBackend
   (-insert-state-document! [_ tx input]
     (insert-state-document! tx input))
+  (-insert-state-document-if-absent! [_ tx input]
+    (br/affected->applied? (insert-state-document-if-absent! tx input)))
   (-update-state-document! [_ tx input]
     (update-state-document! tx input))
+  (-update-state-document-if-contents! [_ tx input]
+    (br/affected->applied? (update-state-document-if-contents! tx input)))
   (-delete-state-document! [_ tx input]
     (delete-state-document! tx input))
+  (-delete-state-document-if-contents! [_ tx input]
+    (br/affected->applied? (delete-state-document-if-contents! tx input)))
   (-delete-state-documents! [_ tx input]
     (delete-state-documents! tx input))
   (-query-state-document [_ tx input]
@@ -206,10 +213,16 @@
   bp/AgentProfileDocumentBackend
   (-insert-agent-profile-document! [_ tx input]
     (insert-agent-profile-document! tx input))
+  (-insert-agent-profile-document-if-absent! [_ tx input]
+    (br/affected->applied? (insert-agent-profile-document-if-absent! tx input)))
   (-update-agent-profile-document! [_ tx input]
     (update-agent-profile-document! tx input))
+  (-update-agent-profile-document-if-contents! [_ tx input]
+    (br/affected->applied? (update-agent-profile-document-if-contents! tx input)))
   (-delete-agent-profile-document! [_ tx input]
     (delete-agent-profile-document! tx input))
+  (-delete-agent-profile-document-if-contents! [_ tx input]
+    (br/affected->applied? (delete-agent-profile-document-if-contents! tx input)))
   (-query-agent-profile-document [_ tx input]
     (query-agent-profile-document tx input))
   (-query-agent-profile-document-ids [_ tx input]
@@ -220,10 +233,16 @@
   bp/ActivityProfileDocumentBackend
   (-insert-activity-profile-document! [_ tx input]
     (insert-activity-profile-document! tx input))
+  (-insert-activity-profile-document-if-absent! [_ tx input]
+    (br/affected->applied? (insert-activity-profile-document-if-absent! tx input)))
   (-update-activity-profile-document! [_ tx input]
     (update-activity-profile-document! tx input))
+  (-update-activity-profile-document-if-contents! [_ tx input]
+    (br/affected->applied? (update-activity-profile-document-if-contents! tx input)))
   (-delete-activity-profile-document! [_ tx input]
     (delete-activity-profile-document! tx input))
+  (-delete-activity-profile-document-if-contents! [_ tx input]
+    (br/affected->applied? (delete-activity-profile-document-if-contents! tx input)))
   (-query-activity-profile-document [_ tx input]
     (query-activity-profile-document tx input))
   (-query-activity-profile-document-ids [_ tx input]

--- a/src/db/sqlite/lrsql/sqlite/sql/delete.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/delete.sql
@@ -33,6 +33,37 @@ DELETE FROM activity_profile_document
 WHERE profile_id = :profile-id
 AND activity_iri = :activity-iri
 
+/* Conditional Document Deletion */
+
+-- :name delete-state-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Delete a state document only when its contents equal the observed contents.
+DELETE FROM state_document
+WHERE activity_iri = :activity-iri
+AND agent_ifi = :agent-ifi
+AND state_id = :state-id
+--~ (when (:registration params) "AND registration = :registration" "AND registration ISNULL")
+AND contents = :expected-contents
+
+-- :name delete-agent-profile-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Delete an agent profile document only when its contents equal the observed contents.
+DELETE FROM agent_profile_document
+WHERE profile_id = :profile-id
+AND agent_ifi = :agent-ifi
+AND contents = :expected-contents
+
+-- :name delete-activity-profile-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Delete an activity profile document only when its contents equal the observed contents.
+DELETE FROM activity_profile_document
+WHERE profile_id = :profile-id
+AND activity_iri = :activity-iri
+AND contents = :expected-contents
+
 /* Admin Accounts + Credentials */
 
 -- :name delete-admin-account!

--- a/src/db/sqlite/lrsql/sqlite/sql/delete.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/delete.sql
@@ -17,6 +17,16 @@ WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
 --~ (if (:registration params) "AND registration = :registration" "AND registration ISNULL")
 
+-- :name delete-state-documents-by-primary-keys!
+-- :command :execute
+-- :result :affected
+-- :doc Delete observed State documents by physical primary key, retaining collection scoping predicates.
+DELETE FROM state_document
+WHERE activity_iri = :activity-iri
+AND agent_ifi = :agent-ifi
+--~ (if (:registration params) "AND registration = :registration" "AND registration ISNULL")
+AND id IN (:v*:primary-keys)
+
 -- :name delete-agent-profile-document!
 -- :command :execute
 -- :result :affected

--- a/src/db/sqlite/lrsql/sqlite/sql/delete.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/delete.sql
@@ -43,7 +43,7 @@ DELETE FROM state_document
 WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
 AND state_id = :state-id
---~ (when (:registration params) "AND registration = :registration" "AND registration ISNULL")
+--~ (if (:registration params) "AND registration = :registration" "AND registration ISNULL")
 AND contents = :expected-contents
 
 -- :name delete-agent-profile-document-if-contents!

--- a/src/db/sqlite/lrsql/sqlite/sql/insert.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/insert.sql
@@ -108,6 +108,64 @@ INSERT INTO activity_profile_document (
   :last-modified, :content-type, :content-length, :contents
 )
 
+/* Conditional Document Insertion */
+
+-- :name insert-state-document-if-absent!
+-- :command :execute
+-- :result :affected
+-- :doc Insert a state document only when its logical key is absent.
+INSERT INTO state_document (
+  id, state_id, activity_iri, agent_ifi, registration,
+  last_modified, content_type, content_length, contents
+)
+SELECT
+  :primary-key, :state-id, :activity-iri, :agent-ifi, :registration,
+  :last-modified, :content-type, :content-length, :contents
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM state_document
+  WHERE state_id = :state-id
+  AND activity_iri = :activity-iri
+  AND agent_ifi = :agent-ifi
+  --~ (if (:registration params) "AND registration = :registration" "AND registration ISNULL")
+)
+
+-- :name insert-agent-profile-document-if-absent!
+-- :command :execute
+-- :result :affected
+-- :doc Insert an agent profile document only when its logical key is absent.
+INSERT INTO agent_profile_document (
+  id, profile_id, agent_ifi,
+  last_modified, content_type, content_length, contents
+)
+SELECT
+  :primary-key, :profile-id, :agent-ifi,
+  :last-modified, :content-type, :content-length, :contents
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM agent_profile_document
+  WHERE profile_id = :profile-id
+  AND agent_ifi = :agent-ifi
+)
+
+-- :name insert-activity-profile-document-if-absent!
+-- :command :execute
+-- :result :affected
+-- :doc Insert an activity profile document only when its logical key is absent.
+INSERT INTO activity_profile_document (
+  id, profile_id, activity_iri,
+  last_modified, content_type, content_length, contents
+)
+SELECT
+  :primary-key, :profile-id, :activity-iri,
+  :last-modified, :content-type, :content-length, :contents
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM activity_profile_document
+  WHERE profile_id = :profile-id
+  AND activity_iri = :activity-iri
+)
+
 /* Accounts */
 
 -- :name insert-admin-account!

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -187,7 +187,7 @@ AND profile_id = :profile-id
 -- :command :query
 -- :result :many
 -- :doc Query for one or more state document IDs using resource params. If `:registration` is missing then `registration` must be NULL.
-SELECT state_id FROM state_document
+SELECT id, state_id FROM state_document
 WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
 --~ (if (:registration params) "AND registration = :registration" "AND registration ISNULL")

--- a/src/db/sqlite/lrsql/sqlite/sql/update.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/update.sql
@@ -63,6 +63,49 @@ SET
 WHERE profile_id = :profile-id
 AND activity_iri = :activity-iri
 
+/* Conditional Document Updates */
+
+-- :name update-state-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Update a state document only when its contents equal the observed contents.
+UPDATE state_document
+SET
+  content_length = :content-length,
+  contents = :contents,
+  last_modified = :last-modified
+WHERE state_id = :state-id
+AND activity_iri = :activity-iri
+AND agent_ifi = :agent-ifi
+--~ (if (:registration params) "AND registration = :registration" "AND registration ISNULL")
+AND contents = :expected-contents
+
+-- :name update-agent-profile-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Update an agent profile document only when its contents equal the observed contents.
+UPDATE agent_profile_document
+SET
+  content_length = :content-length,
+  contents = :contents,
+  last_modified = :last-modified
+WHERE profile_id = :profile-id
+AND agent_ifi = :agent-ifi
+AND contents = :expected-contents
+
+-- :name update-activity-profile-document-if-contents!
+-- :command :execute
+-- :result :affected
+-- :doc Update an activity profile document only when its contents equal the observed contents.
+UPDATE activity_profile_document
+SET
+  content_length = :content-length,
+  contents = :contents,
+  last_modified = :last-modified
+WHERE profile_id = :profile-id
+AND activity_iri = :activity-iri
+AND contents = :expected-contents
+
 /* Admin Accounts + Credentials */
 
 -- :name update-admin-password!

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -69,6 +69,9 @@
   (-delete-state-document-if-contents! [this tx input]
     "Delete a state document only when its contents equal :expected-contents. Returns a boolean indicating whether the delete was applied.")
   (-delete-state-documents! [this tx input])
+  (-delete-state-documents-by-primary-keys! [this tx input]
+    "Delete State documents in the requested collection whose physical IDs
+     are present in :primary-keys. Returns the backend affected-row result.")
   ;; Queries
   (-query-state-document [this tx input])
   (-query-state-document-ids [this tx input])

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -60,8 +60,14 @@
 (defprotocol StateDocumentBackend
   ;; Commands
   (-insert-state-document! [this tx input])
+  (-insert-state-document-if-absent! [this tx input]
+    "Insert a state document only when its logical key is absent. Returns a boolean indicating whether the insert was applied.")
   (-update-state-document! [this tx input])
+  (-update-state-document-if-contents! [this tx input]
+    "Update a state document only when its contents equal :expected-contents. Returns a boolean indicating whether the update was applied.")
   (-delete-state-document! [this tx input])
+  (-delete-state-document-if-contents! [this tx input]
+    "Delete a state document only when its contents equal :expected-contents. Returns a boolean indicating whether the delete was applied.")
   (-delete-state-documents! [this tx input])
   ;; Queries
   (-query-state-document [this tx input])
@@ -71,8 +77,14 @@
 (defprotocol AgentProfileDocumentBackend
   ;; Commands
   (-insert-agent-profile-document! [this tx input])
+  (-insert-agent-profile-document-if-absent! [this tx input]
+    "Insert an agent profile document only when its logical key is absent. Returns a boolean indicating whether the insert was applied.")
   (-update-agent-profile-document! [this tx input])
+  (-update-agent-profile-document-if-contents! [this tx input]
+    "Update an agent profile document only when its contents equal :expected-contents. Returns a boolean indicating whether the update was applied.")
   (-delete-agent-profile-document! [this tx input])
+  (-delete-agent-profile-document-if-contents! [this tx input]
+    "Delete an agent profile document only when its contents equal :expected-contents. Returns a boolean indicating whether the delete was applied.")
   ;; Queries
   (-query-agent-profile-document [this tx input])
   (-query-agent-profile-document-ids [this tx input])
@@ -81,8 +93,14 @@
 (defprotocol ActivityProfileDocumentBackend
   ;; Commands
   (-insert-activity-profile-document! [this tx input])
+  (-insert-activity-profile-document-if-absent! [this tx input]
+    "Insert an activity profile document only when its logical key is absent. Returns a boolean indicating whether the insert was applied.")
   (-update-activity-profile-document! [this tx input])
+  (-update-activity-profile-document-if-contents! [this tx input]
+    "Update an activity profile document only when its contents equal :expected-contents. Returns a boolean indicating whether the update was applied.")
   (-delete-activity-profile-document! [this tx input])
+  (-delete-activity-profile-document-if-contents! [this tx input]
+    "Delete an activity profile document only when its contents equal :expected-contents. Returns a boolean indicating whether the delete was applied.")
   ;; Queries
   (-query-activity-profile-document [this tx input])
   (-query-activity-profile-document-ids [this tx input])

--- a/src/main/lrsql/backend/result.clj
+++ b/src/main/lrsql/backend/result.clj
@@ -1,0 +1,16 @@
+(ns lrsql.backend.result)
+
+(defn affected->applied?
+  "Normalize the affected-row result of a single-row CAS command to a boolean.
+   Throws if the backend reports more than one affected row, since that would
+   violate the logical document-key invariant."
+  [result]
+  (let [affected (if (map? result)
+                   (:next.jdbc/update-count result)
+                   result)]
+    (case affected
+      0 false
+      1 true
+      (throw (ex-info "Unexpected affected-row count for document CAS"
+                      {:type     ::unexpected-affected-count
+                       :affected affected})))))

--- a/src/main/lrsql/ops/command/document.clj
+++ b/src/main/lrsql/ops/command/document.clj
@@ -9,23 +9,26 @@
             [lrsql.ops.util :refer [throw-invalid-table-ex]]))
 
 (defn- document-cas-ops
-  "Return the backend operations used for a document CAS write."
+  "Return the backend operations used for a document CAS mutation."
   [table]
   (case table
     :state-document
     {:query  bp/-query-state-document
      :insert bp/-insert-state-document-if-absent!
-     :update bp/-update-state-document-if-contents!}
+     :update bp/-update-state-document-if-contents!
+     :delete bp/-delete-state-document-if-contents!}
 
     :agent-profile-document
     {:query  bp/-query-agent-profile-document
      :insert bp/-insert-agent-profile-document-if-absent!
-     :update bp/-update-agent-profile-document-if-contents!}
+     :update bp/-update-agent-profile-document-if-contents!
+     :delete bp/-delete-agent-profile-document-if-contents!}
 
     :activity-profile-document
     {:query  bp/-query-activity-profile-document
      :insert bp/-insert-activity-profile-document-if-absent!
-     :update bp/-update-activity-profile-document-if-contents!}
+     :update bp/-update-activity-profile-document-if-contents!
+     :delete bp/-delete-activity-profile-document-if-contents!}
 
     (throw-invalid-table-ex "document-cas-ops" {:table table})))
 
@@ -263,6 +266,33 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Document Deletion
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(s/fdef delete-document-cas!
+  :args (s/cat :bk ds/document-backend?
+               :tx transaction?
+               :ctx map?
+               :input ds/document-input-spec)
+  :ret ds/document-command-res-spec)
+
+(defn delete-document-cas!
+  "Atomically delete a single document after validating the normalized ETag
+   preconditions in `ctx` against the contents read in this transaction.
+   A missed database CAS predicate throws an internal retryable conflict."
+  [bk tx ctx {:keys [table] :as input}]
+  (let [{:keys [query delete]} (document-cas-ops table)
+        old-doc (query bk tx input)]
+    (if-some [error-result
+              (du/precondition-error ctx old-doc {:operation :delete
+                                                  :table     table})]
+      error-result
+      (do
+        (when old-doc
+          (ensure-cas-applied!
+           (delete bk tx (assoc input
+                                :expected-contents (:contents old-doc)))
+           :delete
+           table))
+        {}))))
 
 (s/fdef delete-document!
   :args (s/cat :bk ds/document-backend?

--- a/src/main/lrsql/ops/command/document.clj
+++ b/src/main/lrsql/ops/command/document.clj
@@ -329,3 +329,50 @@
     ;; Else
     (throw-invalid-table-ex "delete-documents!" input))
   {})
+
+(def ^:private state-document-delete-batch-size 500)
+
+(defn- observed-primary-keys
+  [rows]
+  (->> rows
+       (map :id)
+       (sort-by str)
+       vec))
+
+(s/fdef delete-documents-cas!
+  :args (s/cat :bk ds/document-backend?
+               :tx transaction?
+               :ctx map?
+               :input ds/state-doc-multi-input-spec)
+  :ret ds/document-command-res-spec)
+
+(defn delete-documents-cas!
+  "Validate a State collection against the rows observed in this transaction,
+   then delete only those rows by immutable physical primary key. Rows added or
+   recreated after the observation are outside this operation's ordering point
+   and are not deleted."
+  [bk tx ctx {:keys [table] :as input}]
+  (case table
+    :state-document
+    (let [rows (bp/-query-state-document-ids bk tx input)
+          ids  (->> rows
+                    (map :state_id)
+                    du/canonical-state-document-ids)
+          collection-document
+          {:contents (du/state-document-ids-contents ids)}]
+      (if-some [error-result
+                (du/precondition-error ctx
+                                       collection-document
+                                       {:operation   :delete
+                                        :table       table
+                                        :collection? true})]
+        error-result
+        (do
+          (doseq [primary-keys (partition-all
+                                state-document-delete-batch-size
+                                (observed-primary-keys rows))]
+            (bp/-delete-state-documents-by-primary-keys!
+             bk tx (assoc input :primary-keys (vec primary-keys))))
+          {})))
+
+    (throw-invalid-table-ex "delete-documents-cas!" input)))

--- a/src/main/lrsql/ops/command/document.clj
+++ b/src/main/lrsql/ops/command/document.clj
@@ -5,7 +5,35 @@
             [lrsql.spec.common :refer [transaction?]]
             [lrsql.spec.document :as ds]
             [lrsql.util :as u]
+            [lrsql.util.document :as du]
             [lrsql.ops.util :refer [throw-invalid-table-ex]]))
+
+(defn- document-cas-ops
+  "Return the backend operations used for a document CAS write."
+  [table]
+  (case table
+    :state-document
+    {:query  bp/-query-state-document
+     :insert bp/-insert-state-document-if-absent!
+     :update bp/-update-state-document-if-contents!}
+
+    :agent-profile-document
+    {:query  bp/-query-agent-profile-document
+     :insert bp/-insert-agent-profile-document-if-absent!
+     :update bp/-update-agent-profile-document-if-contents!}
+
+    :activity-profile-document
+    {:query  bp/-query-activity-profile-document
+     :insert bp/-insert-activity-profile-document-if-absent!
+     :update bp/-update-activity-profile-document-if-contents!}
+
+    (throw-invalid-table-ex "document-cas-ops" {:table table})))
+
+(defn- ensure-cas-applied!
+  [applied? operation table]
+  (when-not applied?
+    (du/throw-cas-conflict! {:operation operation
+                             :table     table})))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Document Insertion
@@ -165,6 +193,72 @@
                        bp/-update-activity-profile-document!)
     ;; Else
     (throw-invalid-table-ex "upsert-document!" input)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Atomic Document Setting
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- put-document-cas!
+  [bk tx input old-doc insert-fn! update-fn!]
+  (let [{:keys [table]} input]
+    (ensure-cas-applied!
+     (if old-doc
+       (update-fn! bk tx (assoc input
+                                :expected-contents (:contents old-doc)))
+       (insert-fn! bk tx input))
+     :put
+     table)
+    {}))
+
+(defn- post-document-cas!
+  [bk tx input old-doc insert-fn! update-fn!]
+  (let [{:keys [table]} input]
+    (if old-doc
+      (upsert-update-document!
+       bk
+       tx
+       input
+       old-doc
+       (fn [bk' tx' merged-input]
+         (ensure-cas-applied!
+          (update-fn! bk'
+                      tx'
+                      (assoc merged-input
+                             :expected-contents (:contents old-doc)))
+          :post
+          table)))
+      (upsert-insert-document!
+       bk
+       tx
+       input
+       (fn [bk' tx' new-input]
+         (ensure-cas-applied! (insert-fn! bk' tx' new-input)
+                              :post
+                              table))))))
+
+(s/fdef set-document-cas!
+  :args (s/cat :bk ds/document-backend?
+               :tx transaction?
+               :ctx map?
+               :input ds/insert-document-spec
+               :merge? boolean?)
+  :ret ds/document-command-res-spec)
+
+(defn set-document-cas!
+  "Atomically PUT or POST a document after validating the normalized ETag
+   preconditions in `ctx` against the contents read in this transaction.
+   A missed database CAS predicate throws an internal retryable conflict."
+  [bk tx ctx {:keys [table] :as input} merge?]
+  (let [{:keys [query insert update]} (document-cas-ops table)
+        old-doc (query bk tx input)
+        operation (if merge? :post :put)]
+    (if-some [error-result
+              (du/precondition-error ctx old-doc {:operation operation
+                                                  :table     table})]
+      error-result
+      (if merge?
+        (post-document-cas! bk tx input old-doc insert update)
+        (put-document-cas! bk tx input old-doc insert update)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Document Deletion

--- a/src/main/lrsql/ops/query/document.clj
+++ b/src/main/lrsql/ops/query/document.clj
@@ -5,6 +5,7 @@
             [lrsql.spec.common :refer [transaction?]]
             [lrsql.spec.document :as ds]
             [lrsql.util :as u]
+            [lrsql.util.document :as du]
             [lrsql.ops.util :refer [throw-invalid-table-ex]]))
 
 (s/fdef query-document
@@ -59,7 +60,8 @@
               :state-document
               (->> input
                    (bp/-query-state-document-ids bk tx)
-                   (map :state_id))
+                   (map :state_id)
+                   du/canonical-state-document-ids)
               :agent-profile-document
               (->> input
                    (bp/-query-agent-profile-document-ids bk tx)

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -187,6 +187,11 @@
     [_lrs _ctx _auth-identity]
     (str (util/current-time)))
 
+  lrsp/AtomicDocumentPreconditions
+  (-atomic-document-preconditions?
+    [_lrs]
+    true)
+
   lrsp/DocumentResource
   (-set-document
     [lrs ctx _auth-identity params document merge?]

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -208,11 +208,12 @@
      (jdbc/with-transaction [tx conn]
        (doc-q/query-document-ids backend tx input))))
   (-delete-document
-    [lrs _ctx _auth-identity params]
+    [lrs ctx _auth-identity params]
     (let [conn  (lrs-conn lrs)
-          input (doc-input/document-input params)]
-      (jdbc/with-transaction [tx conn]
-        (doc-cmd/delete-document! backend tx input))))
+          input (doc-input/document-input params)
+          retry-opts (doc-util/document-retry-opts backend config)]
+      (with-rerunable-txn [tx conn retry-opts]
+        (doc-cmd/delete-document-cas! backend tx ctx input))))
   (-delete-documents
     [lrs _ctx _auth-identity params]
     (let [conn  (lrs-conn lrs)

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -33,6 +33,7 @@
             [lrsql.ops.query.statement     :as stmt-q]
             [lrsql.spec.config             :as cs]
             [lrsql.util.auth               :as auth-util]
+            [lrsql.util.document           :as doc-util]
             [lrsql.util.oidc               :as oidc-util]
             [lrsql.util.statement          :as stmt-util]
             [lrsql.util                    :as util]
@@ -188,13 +189,12 @@
 
   lrsp/DocumentResource
   (-set-document
-    [lrs _ctx _auth-identity params document merge?]
+    [lrs ctx _auth-identity params document merge?]
     (let [conn  (lrs-conn lrs)
-          input (doc-input/insert-document-input params document)]
-      (jdbc/with-transaction [tx conn]
-        (if merge?
-          (doc-cmd/upsert-document! backend tx input)
-          (doc-cmd/insert-document! backend tx input)))))
+          input (doc-input/insert-document-input params document)
+          retry-opts (doc-util/document-retry-opts backend config)]
+      (with-rerunable-txn [tx conn retry-opts]
+        (doc-cmd/set-document-cas! backend tx ctx input merge?))))
   (-get-document
     [lrs _ctx _auth-identity params]
     (let [conn  (lrs-conn lrs)

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -215,11 +215,12 @@
       (with-rerunable-txn [tx conn retry-opts]
         (doc-cmd/delete-document-cas! backend tx ctx input))))
   (-delete-documents
-    [lrs _ctx _auth-identity params]
+    [lrs ctx _auth-identity params]
     (let [conn  (lrs-conn lrs)
-          input (doc-input/document-multi-input params)]
-      (jdbc/with-transaction [tx conn]
-        (doc-cmd/delete-documents! backend tx input))))
+          input (doc-input/document-multi-input params)
+          retry-opts (doc-util/document-retry-opts backend config)]
+      (with-rerunable-txn [tx conn retry-opts]
+        (doc-cmd/delete-documents-cas! backend tx ctx input))))
 
   lrsp/AgentInfoResource
   (-get-person

--- a/src/main/lrsql/util/document.clj
+++ b/src/main/lrsql/util/document.clj
@@ -1,7 +1,25 @@
 (ns lrsql.util.document
   (:require [com.yetanalytics.lrs.util.hash :as hash]
             [com.yetanalytics.lrs.xapi.document :as lrs-doc]
-            [lrsql.backend.protocol :as bp]))
+            [lrsql.backend.protocol :as bp]
+            [lrsql.util :as u]))
+
+(defn canonical-state-document-ids
+  "Return State document IDs in the canonical order used by collection GET
+   responses and collection precondition validation."
+  [ids]
+  (->> ids sort vec))
+
+(defn state-document-ids-contents
+  "Canonicalize and serialize State document IDs exactly as the LRS document
+   route serializes its JSON response body."
+  [ids]
+  (u/write-json (canonical-state-document-ids ids)))
+
+(defn state-document-ids-etag
+  "Return the unquoted SHA-1 ETag for a canonical State document ID vector."
+  [ids]
+  (hash/sha-1 (state-document-ids-contents ids)))
 
 (defn preconditions
   "Return the normalized ETag preconditions supplied by the LRS library.

--- a/src/main/lrsql/util/document.clj
+++ b/src/main/lrsql/util/document.clj
@@ -1,4 +1,74 @@
-(ns lrsql.util.document)
+(ns lrsql.util.document
+  (:require [com.yetanalytics.lrs.util.hash :as hash]
+            [com.yetanalytics.lrs.xapi.document :as lrs-doc]
+            [lrsql.backend.protocol :as bp]))
+
+(defn preconditions
+  "Return the normalized ETag preconditions supplied by the LRS library.
+   An absent key represents a request without preconditions."
+  [ctx]
+  (get ctx ::lrs-doc/preconditions {}))
+
+(defn current-document-state
+  "Return the existence and unquoted ETag state for an observed database
+   document. The ETag is the SHA-1 hash of the exact stored contents."
+  [document]
+  (if-some [contents (:contents document)]
+    {:exists? true
+     :etag    (hash/sha-1 contents)}
+    {:exists? false}))
+
+(defn preconditions-met?
+  "Return true when the normalized context preconditions are met by the
+   observed database document."
+  [ctx document]
+  (lrs-doc/etag-preconditions-met? (preconditions ctx)
+                                   (current-document-state document)))
+
+(defn precondition-error
+  "Return the standard LRS document precondition error when the normalized
+   context preconditions fail for the observed document, otherwise nil."
+  ([ctx document]
+   (precondition-error ctx document {}))
+  ([ctx document data]
+   (when-not (preconditions-met? ctx document)
+     (lrs-doc/precondition-failed-error data))))
+
+(defn cas-conflict-ex
+  "Create an internal exception indicating that a document CAS operation did
+   not apply and its transaction must be retried with a fresh snapshot."
+  ([]
+   (cas-conflict-ex {}))
+  ([data]
+   (ex-info "Document compare-and-swap conflict"
+            (assoc data :type ::cas-conflict))))
+
+(defn cas-conflict?
+  "Return true when `ex` represents an internal document CAS conflict."
+  [ex]
+  (= ::cas-conflict (:type (ex-data ex))))
+
+(defn throw-cas-conflict!
+  "Throw an internal document CAS conflict exception."
+  ([]
+   (throw-cas-conflict! {}))
+  ([data]
+   (throw (cas-conflict-ex data))))
+
+(defn document-txn-retry?
+  "Return true when a document transaction should be retried, either because
+   its CAS predicate missed or the backend recognizes the database error."
+  [backend ex]
+  (or (cas-conflict? ex)
+      (bp/-txn-retry? backend ex)))
+
+(defn document-retry-opts
+  "Build document transaction retry options from the existing statement retry
+   limit and budget configuration."
+  [backend config]
+  {:retry-test  (partial document-txn-retry? backend)
+   :max-attempt (:stmt-retry-limit config)
+   :budget      (:stmt-retry-budget config)})
 
 (defn document-dispatch
   "Return either `:state-document`, `:agent-profile-document`, or

--- a/src/test/lrsql/backend/document_cas_test.clj
+++ b/src/test/lrsql/backend/document_cas_test.clj
@@ -1,10 +1,13 @@
 (ns lrsql.backend.document-cas-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [com.stuartsierra.component :as component]
+            [com.yetanalytics.lrs.xapi.document :as lrs-doc]
             [lrsql.backend.protocol :as bp]
             [lrsql.backend.result :as br]
+            [lrsql.ops.command.document :as command]
             [lrsql.test-support :as support]
             [lrsql.util :as u]
+            [lrsql.util.document :as document-util]
             [next.jdbc :as jdbc])
   (:import [java.nio.charset StandardCharsets]
            [java.util UUID]))
@@ -145,5 +148,79 @@
                     "a delete with current observed contents is applied")
                 (is (nil? (query bk tx initial-input))
                     "the matching delete removes the document"))))))
+      (finally
+        (component/stop sys)))))
+
+(defn- state-document-input
+  [collection-input state-id]
+  (merge collection-input
+         {:table          :state-document
+          :primary-key    (UUID/randomUUID)
+          :state-id       state-id
+          :last-modified  (u/current-time)
+          :content-type   "application/json"
+          :content-length 2
+          :contents       (utf8-bytes "{}")}))
+
+(deftest state-collection-observed-primary-key-primitives-test
+  (let [sys (component/start (support/test-system))]
+    (try
+      (let [bk         (:backend sys)
+            ds         (get-in sys [:lrs :connection :conn-pool])
+            collection {:activity-iri "https://example.org/observed-keys"
+                        :agent-ifi    "mbox::mailto:observed@example.org"
+                        :registration nil}]
+        (testing "the backend primitive deletes only observed, in-scope keys"
+          (let [observed   (state-document-input collection "observed")
+                unobserved (state-document-input collection "unobserved")
+                other      (state-document-input
+                            (assoc collection
+                                   :activity-iri
+                                   "https://example.org/other-collection")
+                            "other")]
+            (jdbc/with-transaction [tx ds]
+              (doseq [input [observed unobserved other]]
+                (bp/-insert-state-document! bk tx input))
+              (bp/-delete-state-documents-by-primary-keys!
+               bk tx
+               (assoc collection
+                      :primary-keys [(:primary-key observed)
+                                     (:primary-key other)
+                                     (UUID/randomUUID)]))
+              (is (nil? (bp/-query-state-document bk tx observed)))
+              (is (some? (bp/-query-state-document bk tx unobserved))
+                  "an unobserved row in the collection survives")
+              (is (some? (bp/-query-state-document bk tx other))
+                  "a supplied key outside the collection scope survives"))))
+
+        (testing "more than 500 observed keys are batched atomically"
+          (let [batch-collection
+                (assoc collection
+                       :activity-iri "https://example.org/batched-keys")
+                inputs (mapv #(state-document-input
+                               batch-collection
+                               (format "state-%03d" %))
+                             (range 501))
+                ids    (mapv :state-id inputs)
+                ctx    {::lrs-doc/preconditions
+                        {:if-match
+                         #{(document-util/state-document-ids-etag ids)}}}]
+            (jdbc/with-transaction [tx ds]
+              (doseq [input inputs]
+                (bp/-insert-state-document! bk tx input))
+              (is (= 501
+                     (count (bp/-query-state-document-ids
+                             bk tx
+                             (assoc batch-collection
+                                    :table :state-document))))
+                  "all rows are visible at the collection ordering point")
+              (is (= {}
+                     (command/delete-documents-cas!
+                      bk tx ctx
+                      (assoc batch-collection :table :state-document))))
+              (is (empty? (bp/-query-state-document-ids
+                           bk tx
+                           (assoc batch-collection
+                                  :table :state-document))))))))
       (finally
         (component/stop sys)))))

--- a/src/test/lrsql/backend/document_cas_test.clj
+++ b/src/test/lrsql/backend/document_cas_test.clj
@@ -1,0 +1,149 @@
+(ns lrsql.backend.document-cas-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [com.stuartsierra.component :as component]
+            [lrsql.backend.protocol :as bp]
+            [lrsql.backend.result :as br]
+            [lrsql.test-support :as support]
+            [lrsql.util :as u]
+            [next.jdbc :as jdbc])
+  (:import [java.nio.charset StandardCharsets]
+           [java.util UUID]))
+
+(use-fixtures :once support/instrumentation-fixture)
+(use-fixtures :each support/fresh-db-fixture)
+
+(defn- utf8-bytes
+  [s]
+  (.getBytes ^String s StandardCharsets/UTF_8))
+
+(defn- document-input
+  [table contents]
+  (merge
+   {:table          table
+    :primary-key    (UUID/randomUUID)
+    :last-modified  (u/current-time)
+    :content-type   "application/json"
+    :content-length (count contents)
+    :contents       contents}
+   (case table
+     :state-document
+     {:state-id     "state-id"
+      :activity-iri "https://example.org/activity"
+      :agent-ifi    "mbox::mailto:test@example.org"
+      :registration nil}
+
+     :agent-profile-document
+     {:profile-id "agent-profile-id"
+      :agent-ifi  "mbox::mailto:test@example.org"}
+
+     :activity-profile-document
+     {:profile-id   "activity-profile-id"
+      :activity-iri "https://example.org/activity"})))
+
+(defn- document-ops
+  [table]
+  (case table
+    :state-document
+    {:insert bp/-insert-state-document-if-absent!
+     :update bp/-update-state-document-if-contents!
+     :delete bp/-delete-state-document-if-contents!
+     :query  bp/-query-state-document}
+
+    :agent-profile-document
+    {:insert bp/-insert-agent-profile-document-if-absent!
+     :update bp/-update-agent-profile-document-if-contents!
+     :delete bp/-delete-agent-profile-document-if-contents!
+     :query  bp/-query-agent-profile-document}
+
+    :activity-profile-document
+    {:insert bp/-insert-activity-profile-document-if-absent!
+     :update bp/-update-activity-profile-document-if-contents!
+     :delete bp/-delete-activity-profile-document-if-contents!
+     :query  bp/-query-activity-profile-document}))
+
+(defn- missing-document-input
+  [{:keys [table] :as input}]
+  (case table
+    :state-document            (assoc input :state-id "missing-state-id")
+    :agent-profile-document    (assoc input :profile-id "missing-agent-profile-id")
+    :activity-profile-document (assoc input :profile-id "missing-activity-profile-id")))
+
+(deftest document-content-cas-primitives-test
+  (let [sys (component/start (support/test-system))]
+    (try
+      (testing "affected-row normalization"
+        (is (false? (br/affected->applied? 0)))
+        (is (true? (br/affected->applied? 1)))
+        (is (true? (br/affected->applied? {:next.jdbc/update-count 1})))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Unexpected affected-row count"
+                              (br/affected->applied? 2))))
+      (let [bk (:backend sys)
+            ds (get-in sys [:lrs :connection :conn-pool])]
+        (doseq [table [:state-document
+                       :agent-profile-document
+                       :activity-profile-document]]
+          (testing (name table)
+            (let [{:keys [insert update delete query]} (document-ops table)
+                  initial-contents (utf8-bytes "{\"value\":\"initial\"}")
+                  stale-contents   (utf8-bytes "{\"value\":\"stale\"}")
+                  winner-contents  (utf8-bytes "{\"value\":\"winner\"}")
+                  initial-input    (document-input table initial-contents)
+                  duplicate-input  (assoc initial-input
+                                          :primary-key (UUID/randomUUID)
+                                          :contents stale-contents
+                                          :content-length (count stale-contents))
+                  winner-input     (assoc initial-input
+                                          :contents winner-contents
+                                          :content-length (count winner-contents)
+                                          :last-modified
+                                          (u/millis->time
+                                           (+ 1000
+                                              (u/time->millis
+                                               (:last-modified initial-input)))))]
+              (jdbc/with-transaction [tx ds]
+                (is (true? (insert bk tx initial-input))
+                    "the absent logical key is inserted")
+                (is (false? (insert bk tx duplicate-input))
+                    "a duplicate logical key is not inserted")
+                (is (= (seq initial-contents)
+                       (seq (:contents (query bk tx initial-input))))
+                    "the duplicate insert leaves the original contents")
+
+                (is (false? (update bk tx
+                                    (assoc winner-input
+                                           :expected-contents stale-contents)))
+                    "an update with stale observed contents is not applied")
+                (is (false? (update bk tx
+                                    (-> winner-input
+                                        missing-document-input
+                                        (assoc :expected-contents
+                                               initial-contents))))
+                    "an update for a missing logical key is not applied")
+                (is (true? (update bk tx
+                                   (assoc winner-input
+                                          :expected-contents initial-contents)))
+                    "an update with current observed contents is applied")
+                (is (true? (update bk tx
+                                   (assoc winner-input
+                                          :expected-contents winner-contents)))
+                    "a same-content update still matches the observed contents")
+
+                (is (false? (delete bk tx
+                                    (assoc winner-input
+                                           :expected-contents initial-contents)))
+                    "a delete with stale observed contents is not applied")
+                (is (false? (delete bk tx
+                                    (-> winner-input
+                                        missing-document-input
+                                        (assoc :expected-contents
+                                               winner-contents))))
+                    "a delete for a missing logical key is not applied")
+                (is (true? (delete bk tx
+                                   (assoc winner-input
+                                          :expected-contents winner-contents)))
+                    "a delete with current observed contents is applied")
+                (is (nil? (query bk tx initial-input))
+                    "the matching delete removes the document"))))))
+      (finally
+        (component/stop sys)))))

--- a/src/test/lrsql/backend/retry_test.clj
+++ b/src/test/lrsql/backend/retry_test.clj
@@ -1,0 +1,50 @@
+(ns lrsql.backend.retry-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [lrsql.backend.protocol :as bp]
+            [lrsql.mariadb.record :as mariadb]
+            [lrsql.postgres.record :as postgres]
+            [lrsql.sqlite.record :as sqlite])
+  (:import [java.sql SQLException]
+           [org.postgresql.util PSQLException PSQLState]
+           [org.sqlite SQLiteErrorCode SQLiteException]))
+
+(deftest postgres-transaction-retry-classification-test
+  (let [backend (postgres/map->PostgresBackend {})]
+    (is (bp/-txn-retry?
+         backend
+         (PSQLException. "serialization" PSQLState/SERIALIZATION_FAILURE)))
+    (is (bp/-txn-retry?
+         backend
+         (PSQLException. "deadlock" PSQLState/DEADLOCK_DETECTED)))
+    (is (not (bp/-txn-retry?
+              backend
+              (PSQLException. "unique" PSQLState/UNIQUE_VIOLATION))))))
+
+(deftest mariadb-and-mysql-transaction-retry-classification-test
+  (let [backend (mariadb/map->MariadbBackend {})]
+    (testing "SQLSTATE transaction rollbacks"
+      (is (bp/-txn-retry?
+           backend
+           (SQLException. "serialization" "40001" 0))))
+    (testing "vendor lock and concurrency error codes"
+      (doseq [code [1020 1205 1213]]
+        (is (bp/-txn-retry?
+             backend
+             (SQLException. "retryable" "HY000" code)))))
+    (is (not (bp/-txn-retry?
+              backend
+              (SQLException. "unique" "23000" 1062))))))
+
+(deftest sqlite-transaction-retry-classification-test
+  (let [backend (sqlite/map->SQLiteBackend {})]
+    (doseq [code [SQLiteErrorCode/SQLITE_BUSY
+                  SQLiteErrorCode/SQLITE_BUSY_SNAPSHOT
+                  SQLiteErrorCode/SQLITE_LOCKED
+                  SQLiteErrorCode/SQLITE_LOCKED_SHAREDCACHE]]
+      (is (bp/-txn-retry?
+           backend
+           (SQLiteException. "retryable" code))))
+    (is (not (bp/-txn-retry?
+              backend
+              (SQLiteException. "constraint"
+                                SQLiteErrorCode/SQLITE_CONSTRAINT))))))

--- a/src/test/lrsql/document_etag_race_test.clj
+++ b/src/test/lrsql/document_etag_race_test.clj
@@ -4,7 +4,9 @@
             [com.stuartsierra.component :as component]
             [com.yetanalytics.lrs :as lrs]
             [com.yetanalytics.lrs.util.hash :as hash]
-            [lrsql.test-support :as support]))
+            [lrsql.test-support :as support]
+            [lrsql.util :as u]
+            [lrsql.util.document :as doc-util]))
 
 (use-fixtures :once support/instrumentation-fixture)
 (use-fixtures :each support/fresh-db-fixture)
@@ -52,6 +54,17 @@
      :get    curl/get)
    endpoint
    (request-options resource document-id header body)))
+
+(defn- state-collection-request
+  [{:keys [endpoint query-params]} method header]
+  ((case method
+     :delete curl/delete
+     :get    curl/get)
+   endpoint
+   {:basic-auth   ["username" "password"]
+    :headers      (cond-> base-headers header (merge header))
+    :query-params query-params
+    :throw        false}))
 
 (defn- await!
   [pending label]
@@ -143,5 +156,136 @@
                                          "-"
                                          (name precondition))
                       :precondition precondition})))
+      (finally
+        (component/stop sys)))))
+
+(defn- run-state-collection-race!
+  [membership-change]
+  (let [suffix   (name membership-change)
+        resource (-> (first resource-cases)
+                     (assoc-in [:query-params "activityId"]
+                               (str "https://example.org/etag-race/collection/"
+                                    suffix)))
+        initial-ids ["alpha" "zeta"]]
+    (doseq [state-id initial-ids]
+      (ensure-status! 204
+                      (document-request resource
+                                        :put
+                                        state-id
+                                        {"If-None-Match" "*"}
+                                        initial-body)
+                      "initial State document PUT"))
+    (let [header {"If-Match"
+                  (str "\""
+                       (doc-util/state-document-ids-etag initial-ids)
+                       "\"")}
+          original-preconditions-met? doc-util/preconditions-met?
+          collection-read             (promise)
+          release-read                (promise)
+          read-count                  (atom 0)]
+      (with-redefs [doc-util/preconditions-met?
+                    (fn [& args]
+                      (let [result (apply original-preconditions-met? args)]
+                        ;; This hook is used only by LRSQL's authoritative
+                        ;; validation, not by the preliminary LRS interceptor.
+                        (when (= 1 (swap! read-count inc))
+                          (deliver collection-read true)
+                          (await! release-read "collection DELETE release"))
+                        result))]
+        (let [collection-delete
+              (future (state-collection-request resource :delete header))]
+          (try
+            (await! collection-read "collection DELETE validation")
+            (let [membership-request
+                  (future
+                    (case membership-change
+                      :addition
+                      [(document-request resource
+                                         :put
+                                         "new"
+                                         nil
+                                         winner-body)]
+
+                      :removal
+                      [(document-request resource
+                                         :delete
+                                         "zeta"
+                                         nil
+                                         nil)]
+
+                      :recreation
+                      [(document-request resource
+                                         :delete
+                                         "zeta"
+                                         nil
+                                         nil)
+                       (document-request resource
+                                         :put
+                                         "zeta"
+                                         nil
+                                         winner-body)]))]
+              (try
+                ;; Let the membership operation and the collection deletion
+                ;; establish whichever ordering the backend permits.
+                (deliver release-read true)
+                (let [delete-response (await! collection-delete
+                                              "collection DELETE")
+                      membership-responses
+                      (await! membership-request "membership change")
+                      final-response (state-collection-request resource
+                                                               :get
+                                                               nil)
+                      final-ids      (u/parse-json (:body final-response)
+                                                   :object? false)]
+                  (is (every? #(= 204 (:status %)) membership-responses))
+                  (is (contains? #{204 412} (:status delete-response))
+                      "a backend retry may expose the membership change and return 412")
+                  (is (= 200 (:status final-response)))
+                  (case membership-change
+                    :addition
+                    (do
+                      (is (some #{"new"} final-ids)
+                          "a concurrent addition is never deleted")
+                      (is (= (if (= 412 (:status delete-response))
+                               ["alpha" "new" "zeta"]
+                               ["new"])
+                             final-ids)))
+
+                    :removal
+                    (do
+                      (is (not-any? #{"zeta"} final-ids)
+                          "a concurrent removal remains absent")
+                      (is (= (if (= 412 (:status delete-response))
+                               ["alpha"]
+                               [])
+                             final-ids)))
+
+                    :recreation
+                    (do
+                      (is (some #{"zeta"} final-ids)
+                          "a recreated logical document has a new physical key and survives")
+                      (is (= winner-body
+                             (:body (document-request resource
+                                                      :get
+                                                      "zeta"
+                                                      nil
+                                                      nil))))
+                      (is (= (if (= 412 (:status delete-response))
+                               ["alpha" "zeta"]
+                               ["zeta"])
+                             final-ids)))))
+                (finally
+                  (future-cancel membership-request))))
+            (finally
+              (deliver release-read true)
+              (future-cancel collection-delete))))))))
+
+(deftest state-collection-etag-precondition-is-atomic-test
+  (let [sys (component/start (support/test-system))]
+    (try
+      (doseq [membership-change [:addition :removal :recreation]]
+        (testing (str "concurrent State document "
+                      (name membership-change))
+          (run-state-collection-race! membership-change)))
       (finally
         (component/stop sys)))))

--- a/src/test/lrsql/document_etag_race_test.clj
+++ b/src/test/lrsql/document_etag_race_test.clj
@@ -1,0 +1,123 @@
+(ns lrsql.document-etag-race-test
+  (:require [babashka.curl :as curl]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [com.stuartsierra.component :as component]
+            [com.yetanalytics.lrs :as lrs]
+            [com.yetanalytics.lrs.util.hash :as hash]
+            [lrsql.test-support :as support]))
+
+(use-fixtures :once support/instrumentation-fixture)
+(use-fixtures :each support/fresh-db-fixture)
+
+(def endpoint
+  "http://localhost:8080/xapi/activities/profile")
+
+(def base-headers
+  {"Content-Type"             "application/json"
+   "X-Experience-API-Version" "1.0.3"})
+
+(def initial-body "{\"value\":\"initial\"}")
+(def winner-body  "{\"value\":\"winner\"}")
+(def stale-body   "{\"value\":\"stale\"}")
+
+(defn- request-options
+  [document-id header body]
+  (cond-> {:basic-auth  ["username" "password"]
+           :headers     (cond-> base-headers header (merge header))
+           :query-params
+           {"activityId" "https://example.org/etag-race"
+            "profileId"  document-id}
+           :throw       false}
+    body (assoc :body body)))
+
+(defn- document-request
+  [method document-id header body]
+  ((case method
+     :put    curl/put
+     :post   curl/post
+     :delete curl/delete
+     :get    curl/get)
+   endpoint
+   (request-options document-id header body)))
+
+(defn- await!
+  [pending label]
+  (let [result (deref pending 10000 ::timeout)]
+    (when (= ::timeout result)
+      (throw (ex-info (str "Timed out waiting for " label) {:label label})))
+    result))
+
+(defn- ensure-status!
+  [expected response label]
+  (when-not (= expected (:status response))
+    (throw (ex-info (str "Unexpected response from " label)
+                    {:expected expected
+                     :actual   response}))))
+
+(defn- run-race!
+  [{:keys [action document-id precondition]}]
+  (let [if-match? (= :if-match precondition)
+        header    (if if-match?
+                    {"If-Match" (str "\"" (hash/sha-1 initial-body) "\"")}
+                    {"If-None-Match" "*"})]
+    (when if-match?
+      (ensure-status! 204
+                      (document-request :put
+                                        document-id
+                                        {"If-None-Match" "*"}
+                                        initial-body)
+                      "initial document PUT"))
+    (let [original-get lrs/get-document
+          read-done    (promise)
+          release-read (promise)
+          read-count   (atom 0)]
+      (with-redefs [lrs/get-document
+                    (fn [& args]
+                      (let [result (apply original-get args)]
+                        ;; Pause only the stale request, after its database read
+                        ;; has completed but before its precondition is applied.
+                        (when (= 1 (swap! read-count inc))
+                          (deliver read-done true)
+                          (await! release-read "stale request release"))
+                        result))]
+        (let [stale-request
+              (future
+                (document-request action
+                                  document-id
+                                  header
+                                  (when-not (= :delete action) stale-body)))]
+          (try
+            (await! read-done "stale request precondition read")
+            ;; This request legitimately wins using the same precondition.
+            (ensure-status! 204
+                            (document-request :put
+                                              document-id
+                                              header
+                                              winner-body)
+                            "winning document PUT")
+            (deliver release-read true)
+            (is (= 412 (:status (await! stale-request "stale request")))
+                "the stale request must be rejected")
+            (finally
+              (deliver release-read true)
+              (future-cancel stale-request))))))
+    (is (= {:status 200 :body winner-body}
+           (select-keys (document-request :get document-id nil nil)
+                        [:status :body]))
+        "the stale request must not modify the winning representation")))
+
+(deftest document-etag-precondition-is-atomic-test
+  (let [sys (component/start (support/test-system))]
+    (try
+      (doseq [[action precondition]
+              [[:put    :if-match]
+               [:post   :if-match]
+               [:delete :if-match]
+               [:put    :if-none-match]
+               [:post   :if-none-match]]]
+        (testing (str (name action) " with " (name precondition))
+          (run-race! {:action       action
+                      :document-id  (str (name action) "-" (name precondition))
+                      :precondition precondition})))
+      (finally
+        (component/stop sys)))))

--- a/src/test/lrsql/document_etag_race_test.clj
+++ b/src/test/lrsql/document_etag_race_test.clj
@@ -3,10 +3,13 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [com.stuartsierra.component :as component]
             [com.yetanalytics.lrs :as lrs]
+            [com.yetanalytics.lrs.protocol :as lrsp]
             [com.yetanalytics.lrs.util.hash :as hash]
             [lrsql.test-support :as support]
             [lrsql.util :as u]
-            [lrsql.util.document :as doc-util]))
+            [lrsql.util.document :as doc-util])
+  (:import [java.io File]
+           [java.sql DriverManager]))
 
 (use-fixtures :once support/instrumentation-fixture)
 (use-fixtures :each support/fresh-db-fixture)
@@ -36,6 +39,46 @@
 (def initial-body "{\"value\":\"initial\"}")
 (def winner-body  "{\"value\":\"winner\"}")
 (def stale-body   "{\"value\":\"stale\"}")
+
+(defn- delete-sqlite-files!
+  [^File db-file]
+  (doseq [path [(.getAbsolutePath db-file)
+                (str (.getAbsolutePath db-file) "-wal")
+                (str (.getAbsolutePath db-file) "-shm")]]
+    (let [file (File. path)]
+      (when (and (.exists file) (not (.delete file)))
+        (.deleteOnExit file)))))
+
+(defn- start-race-system!
+  "Start the configured test system with enough independent connections for a
+   transaction-level race. SQLite additionally needs a file-backed WAL database
+   so a winner can commit while the observed transaction remains open."
+  []
+  (let [base-system (support/test-system)]
+    (if (= "sqlite"
+           (get-in base-system [:connection :config :database :db-type]))
+      (let [db-file (doto (File/createTempFile "lrsql-etag-race-" ".db")
+                      (.deleteOnExit))
+            jdbc-url (str "jdbc:sqlite:" (.getAbsolutePath db-file))]
+        (with-open [conn (DriverManager/getConnection jdbc-url)
+                    stmt (.createStatement conn)]
+          (.execute stmt "PRAGMA journal_mode=WAL"))
+        (let [sys (component/start
+                   (support/test-system
+                    :conf-overrides
+                    {[:connection :pool-maximum-size] 2
+                     [:connection :database :db-jdbc-url]
+                     jdbc-url}))]
+          {:sys sys :sqlite-db-file db-file}))
+      {:sys (component/start base-system)})))
+
+(defn- stop-race-system!
+  [{:keys [sys sqlite-db-file]}]
+  (try
+    (component/stop sys)
+    (finally
+      (when sqlite-db-file
+        (delete-sqlite-files! sqlite-db-file)))))
 
 (defn- request-options
   [{:keys [document-id-param query-params]} document-id header body]
@@ -94,15 +137,15 @@
                                         {"If-None-Match" "*"}
                                         initial-body)
                       "initial document PUT"))
-    (let [original-get lrs/get-document
-          read-done    (promise)
-          release-read (promise)
-          read-count   (atom 0)]
-      (with-redefs [lrs/get-document
+    (let [original-preconditions-met? doc-util/preconditions-met?
+          read-done                   (promise)
+          release-read                (promise)
+          read-count                  (atom 0)]
+      (with-redefs [doc-util/preconditions-met?
                     (fn [& args]
-                      (let [result (apply original-get args)]
-                        ;; Pause only the stale request, after its database read
-                        ;; has completed but before its precondition is applied.
+                      (let [result (apply original-preconditions-met? args)]
+                        ;; Pause only the stale request after LRSQL's
+                        ;; authoritative database read and validation.
                         (when (= 1 (swap! read-count inc))
                           (deliver read-done true)
                           (await! release-read "stale request release"))
@@ -140,7 +183,7 @@
         "the stale request must not modify the winning representation")))
 
 (deftest document-etag-precondition-is-atomic-test
-  (let [sys (component/start (support/test-system))]
+  (let [{:keys [sys] :as race-system} (start-race-system!)]
     (try
       (doseq [{:keys [label] :as resource} resource-cases
               [action precondition]
@@ -156,6 +199,93 @@
                                          "-"
                                          (name precondition))
                       :precondition precondition})))
+      (finally
+        (stop-race-system! race-system)))))
+
+(deftest authoritative-precondition-handoff-test
+  (let [sys (component/start (support/test-system))
+        lrs-impl (:lrs sys)]
+    (try
+      (is (true? (lrsp/atomic-document-preconditions? lrs-impl)))
+      (let [resource       (first resource-cases)
+            put-id         "handoff-put"
+            post-id        "handoff-post"
+            delete-id      "handoff-delete"
+            collection     (assoc-in resource
+                                     [:query-params "activityId"]
+                                     "https://example.org/etag-handoff/collection")
+            collection-ids ["alpha" "zeta"]
+            match-etag     (hash/sha-1 initial-body)
+            match-header   {"If-Match" (str "\"" match-etag "\"")}
+            observed       (atom [])]
+        (doseq [document-id [put-id post-id delete-id]]
+          (ensure-status! 204
+                          (document-request resource
+                                            :put
+                                            document-id
+                                            {"If-None-Match" "*"}
+                                            initial-body)
+                          "single document setup"))
+        (doseq [state-id collection-ids]
+          (ensure-status! 204
+                          (document-request collection
+                                            :put
+                                            state-id
+                                            {"If-None-Match" "*"}
+                                            initial-body)
+                          "collection setup"))
+        (let [original-preconditions doc-util/preconditions]
+          (with-redefs [lrs/get-document
+                        (fn [& _]
+                          (throw (ex-info "Unexpected preliminary document GET"
+                                          {})))
+                        lrs/get-document-ids
+                        (fn [& _]
+                          (throw (ex-info "Unexpected preliminary collection GET"
+                                          {})))
+                        doc-util/preconditions
+                        (fn [ctx]
+                          (let [preconditions (original-preconditions ctx)]
+                            (swap! observed conj preconditions)
+                            preconditions))]
+            (ensure-status! 204
+                            (document-request resource
+                                              :put
+                                              put-id
+                                              match-header
+                                              winner-body)
+                            "conditional PUT")
+            (ensure-status! 204
+                            (document-request resource
+                                              :post
+                                              post-id
+                                              match-header
+                                              stale-body)
+                            "conditional POST")
+            (ensure-status! 204
+                            (document-request resource
+                                              :delete
+                                              delete-id
+                                              match-header
+                                              nil)
+                            "conditional single DELETE")
+            (ensure-status!
+             204
+             (state-collection-request
+              collection
+              :delete
+              {"If-Match"
+               (str "\""
+                    (doc-util/state-document-ids-etag collection-ids)
+                    "\"")})
+             "conditional collection DELETE")))
+        (is (= [{:if-match #{match-etag}}
+                {:if-match #{match-etag}}
+                {:if-match #{match-etag}}
+                {:if-match
+                 #{(doc-util/state-document-ids-etag collection-ids)}}]
+               @observed)
+            "LRSQL receives each normalized precondition map unchanged"))
       (finally
         (component/stop sys)))))
 

--- a/src/test/lrsql/document_etag_race_test.clj
+++ b/src/test/lrsql/document_etag_race_test.clj
@@ -9,8 +9,23 @@
 (use-fixtures :once support/instrumentation-fixture)
 (use-fixtures :each support/fresh-db-fixture)
 
-(def endpoint
-  "http://localhost:8080/xapi/activities/profile")
+(def agent-param
+  "{\"mbox\":\"mailto:etag-race@example.org\"}")
+
+(def resource-cases
+  [{:label             "State"
+    :endpoint          "http://localhost:8080/xapi/activities/state"
+    :document-id-param "stateId"
+    :query-params      {"activityId" "https://example.org/etag-race"
+                        "agent"      agent-param}}
+   {:label             "Agent Profile"
+    :endpoint          "http://localhost:8080/xapi/agents/profile"
+    :document-id-param "profileId"
+    :query-params      {"agent" agent-param}}
+   {:label             "Activity Profile"
+    :endpoint          "http://localhost:8080/xapi/activities/profile"
+    :document-id-param "profileId"
+    :query-params      {"activityId" "https://example.org/etag-race"}}])
 
 (def base-headers
   {"Content-Type"             "application/json"
@@ -21,24 +36,22 @@
 (def stale-body   "{\"value\":\"stale\"}")
 
 (defn- request-options
-  [document-id header body]
+  [{:keys [document-id-param query-params]} document-id header body]
   (cond-> {:basic-auth  ["username" "password"]
            :headers     (cond-> base-headers header (merge header))
-           :query-params
-           {"activityId" "https://example.org/etag-race"
-            "profileId"  document-id}
+           :query-params (assoc query-params document-id-param document-id)
            :throw       false}
     body (assoc :body body)))
 
 (defn- document-request
-  [method document-id header body]
+  [{:keys [endpoint] :as resource} method document-id header body]
   ((case method
      :put    curl/put
      :post   curl/post
      :delete curl/delete
      :get    curl/get)
    endpoint
-   (request-options document-id header body)))
+   (request-options resource document-id header body)))
 
 (defn- await!
   [pending label]
@@ -55,14 +68,15 @@
                      :actual   response}))))
 
 (defn- run-race!
-  [{:keys [action document-id precondition]}]
+  [{:keys [resource action document-id precondition]}]
   (let [if-match? (= :if-match precondition)
         header    (if if-match?
                     {"If-Match" (str "\"" (hash/sha-1 initial-body) "\"")}
                     {"If-None-Match" "*"})]
     (when if-match?
       (ensure-status! 204
-                      (document-request :put
+                      (document-request resource
+                                        :put
                                         document-id
                                         {"If-None-Match" "*"}
                                         initial-body)
@@ -82,7 +96,8 @@
                         result))]
         (let [stale-request
               (future
-                (document-request action
+                (document-request resource
+                                  action
                                   document-id
                                   header
                                   (when-not (= :delete action) stale-body)))]
@@ -90,7 +105,8 @@
             (await! read-done "stale request precondition read")
             ;; This request legitimately wins using the same precondition.
             (ensure-status! 204
-                            (document-request :put
+                            (document-request resource
+                                              :put
                                               document-id
                                               header
                                               winner-body)
@@ -102,22 +118,30 @@
               (deliver release-read true)
               (future-cancel stale-request))))))
     (is (= {:status 200 :body winner-body}
-           (select-keys (document-request :get document-id nil nil)
+           (select-keys (document-request resource
+                                          :get
+                                          document-id
+                                          nil
+                                          nil)
                         [:status :body]))
         "the stale request must not modify the winning representation")))
 
 (deftest document-etag-precondition-is-atomic-test
   (let [sys (component/start (support/test-system))]
     (try
-      (doseq [[action precondition]
+      (doseq [{:keys [label] :as resource} resource-cases
+              [action precondition]
               [[:put    :if-match]
                [:post   :if-match]
                [:delete :if-match]
                [:put    :if-none-match]
                [:post   :if-none-match]]]
-        (testing (str (name action) " with " (name precondition))
-          (run-race! {:action       action
-                      :document-id  (str (name action) "-" (name precondition))
+        (testing (str label ": " (name action) " with " (name precondition))
+          (run-race! {:resource     resource
+                      :action       action
+                      :document-id  (str (name action)
+                                         "-"
+                                         (name precondition))
                       :precondition precondition})))
       (finally
         (component/stop sys)))))

--- a/src/test/lrsql/document_etag_race_test.clj
+++ b/src/test/lrsql/document_etag_race_test.clj
@@ -183,7 +183,7 @@
         "the stale request must not modify the winning representation")))
 
 (deftest document-etag-precondition-is-atomic-test
-  (let [{:keys [sys] :as race-system} (start-race-system!)]
+  (let [race-system (start-race-system!)]
     (try
       (doseq [{:keys [label] :as resource} resource-cases
               [action precondition]

--- a/src/test/lrsql/document_precondition_test.clj
+++ b/src/test/lrsql/document_precondition_test.clj
@@ -179,3 +179,60 @@
             (is (nil? (get-body lrs json-params))))))
       (finally
         (component/stop sys)))))
+
+(deftest document-delete-preconditions-test
+  (let [sys (component/start (support/test-system))
+        lrs (:lrs sys)]
+    (try
+      (doseq [{:keys [label] :as resource} resource-cases]
+        (testing label
+          (let [stale-params       (params-for resource "delete-stale")
+                match-params       (params-for resource "delete-match")
+                unconditional-params
+                (params-for resource "delete-unconditional")
+                absent-params      (params-for resource "delete-absent")
+                initial-etag       (hash/sha-1 initial-body)
+                match-ctx          (precondition-ctx
+                                    {:if-match #{initial-etag}})
+                stale-ctx          (precondition-ctx
+                                    {:if-match #{"stale"}})]
+            (is (= {} (lrsp/-set-document lrs tc/ctx tc/auth-ident
+                                           stale-params
+                                           (document initial-body)
+                                           false)))
+            (is (precondition-failed?
+                 (lrsp/-delete-document lrs stale-ctx tc/auth-ident
+                                        stale-params)))
+            (is (= initial-body (get-body lrs stale-params))
+                "stale DELETE leaves the current representation unchanged")
+
+            (is (= {} (lrsp/-set-document lrs tc/ctx tc/auth-ident
+                                           match-params
+                                           (document initial-body)
+                                           false)))
+            (is (= {} (lrsp/-delete-document lrs match-ctx tc/auth-ident
+                                              match-params)))
+            (is (nil? (get-body lrs match-params))
+                "matching DELETE removes the representation")
+
+            (is (= {} (lrsp/-set-document lrs tc/ctx tc/auth-ident
+                                           unconditional-params
+                                           (document initial-body)
+                                           false)))
+            (is (= {} (lrsp/-delete-document lrs tc/ctx tc/auth-ident
+                                              unconditional-params)))
+            (is (nil? (get-body lrs unconditional-params))
+                "unconditional DELETE removes the representation")
+            (is (= {} (lrsp/-delete-document lrs tc/ctx tc/auth-ident
+                                              unconditional-params))
+                "unconditional DELETE remains idempotent")
+
+            (is (precondition-failed?
+                 (lrsp/-delete-document
+                  lrs
+                  (precondition-ctx {:if-match :*})
+                  tc/auth-ident
+                  absent-params))
+                "If-Match fails for an absent document"))))
+      (finally
+        (component/stop sys)))))

--- a/src/test/lrsql/document_precondition_test.clj
+++ b/src/test/lrsql/document_precondition_test.clj
@@ -6,7 +6,8 @@
             [com.yetanalytics.lrs.xapi.document :as lrs-doc]
             [lrsql.test-constants :as tc]
             [lrsql.test-support :as support]
-            [lrsql.util :as u]))
+            [lrsql.util :as u]
+            [lrsql.util.document :as doc-util]))
 
 (use-fixtures :once support/instrumentation-fixture)
 (use-fixtures :each support/fresh-db-fixture)
@@ -234,5 +235,98 @@
                   tc/auth-ident
                   absent-params))
                 "If-Match fails for an absent document"))))
+      (finally
+        (component/stop sys)))))
+
+(defn- state-collection-params
+  [suffix]
+  {:activityId (str "https://example.org/precondition/collection/" suffix)
+   :agent      {"mbox" "mailto:state-collection@example.org"}})
+
+(defn- state-document-params
+  [collection-params state-id]
+  (assoc collection-params :stateId state-id))
+
+(defn- get-state-document-ids
+  [lrs params]
+  (lrsp/-get-document-ids lrs tc/ctx tc/auth-ident params))
+
+(defn- put-state-document!
+  [lrs params state-id]
+  (lrsp/-set-document lrs tc/ctx tc/auth-ident
+                      (state-document-params params state-id)
+                      (document initial-body)
+                      false))
+
+(deftest state-collection-delete-preconditions-test
+  (let [sys (component/start (support/test-system))
+        lrs (:lrs sys)]
+    (try
+      (testing "canonical response and ETag conditions"
+        (let [params (state-collection-params "conditional")]
+          (doseq [state-id ["zeta" "alpha" "middle"]]
+            (is (= {} (put-state-document! lrs params state-id))))
+          (let [ids  ["alpha" "middle" "zeta"]
+                etag (doc-util/state-document-ids-etag ids)]
+            (is (= {:document-ids ids}
+                   (get-state-document-ids lrs params))
+                "the public result stays sorted and contains no internal keys")
+            (doseq [ctx [(precondition-ctx {:if-match #{"stale"}})
+                         (precondition-ctx {:if-none-match #{etag}})
+                         (precondition-ctx {:if-none-match :*})]]
+              (is (precondition-failed?
+                   (lrsp/-delete-documents lrs ctx tc/auth-ident params)))
+              (is (= ids
+                     (:document-ids (get-state-document-ids lrs params)))
+                  "a failed collection condition leaves every row intact"))
+            (is (= {}
+                   (lrsp/-delete-documents
+                    lrs
+                    (precondition-ctx {:if-match #{etag}})
+                    tc/auth-ident
+                    params)))
+            (is (= {:document-ids []}
+                   (get-state-document-ids lrs params)))
+            (is (= {}
+                   (lrsp/-delete-documents
+                    lrs
+                    (precondition-ctx
+                     {:if-match
+                      #{(doc-util/state-document-ids-etag [])}})
+                    tc/auth-ident
+                    params))
+                "the empty collection has the ETag of its [] representation")
+            (is (= {}
+                   (lrsp/-delete-documents
+                    lrs
+                    (precondition-ctx {:if-match :*})
+                    tc/auth-ident
+                    params))
+                "the empty array representation still exists for If-Match"))))
+
+      (testing "wildcard and unconditional collection deletion"
+        (doseq [[suffix ctx]
+                [["wildcard" (precondition-ctx {:if-match :*})]
+                 ["unconditional" tc/ctx]]]
+          (let [params (state-collection-params suffix)]
+            (doseq [state-id ["one" "two"]]
+              (is (= {} (put-state-document! lrs params state-id))))
+            (is (= {} (lrsp/-delete-documents
+                       lrs ctx tc/auth-ident params)))
+            (is (= [] (:document-ids
+                       (get-state-document-ids lrs params)))))))
+
+      (testing "registration remains part of the collection scope"
+        (let [params       (state-collection-params "registration")
+              registration "00000000-0000-4000-8000-000000000001"
+              registered   (assoc params :registration registration)]
+          (is (= {} (put-state-document! lrs params "unregistered")))
+          (is (= {} (put-state-document! lrs registered "registered")))
+          (is (= {} (lrsp/-delete-documents
+                     lrs tc/ctx tc/auth-ident registered)))
+          (is (= {:document-ids ["unregistered"]}
+                 (get-state-document-ids lrs params)))
+          (is (= {:document-ids []}
+                 (get-state-document-ids lrs registered)))))
       (finally
         (component/stop sys)))))

--- a/src/test/lrsql/document_precondition_test.clj
+++ b/src/test/lrsql/document_precondition_test.clj
@@ -1,0 +1,181 @@
+(ns lrsql.document-precondition-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [com.stuartsierra.component :as component]
+            [com.yetanalytics.lrs.protocol :as lrsp]
+            [com.yetanalytics.lrs.util.hash :as hash]
+            [com.yetanalytics.lrs.xapi.document :as lrs-doc]
+            [lrsql.test-constants :as tc]
+            [lrsql.test-support :as support]
+            [lrsql.util :as u]))
+
+(use-fixtures :once support/instrumentation-fixture)
+(use-fixtures :each support/fresh-db-fixture)
+
+(def resource-cases
+  [{:label  "State"
+    :id-key :stateId
+    :params {:stateId    "state"
+             :activityId "https://example.org/precondition/activity"
+             :agent      {"mbox" "mailto:state@example.org"}}}
+   {:label  "Agent Profile"
+    :id-key :profileId
+    :params {:profileId "agent-profile"
+             :agent     {"mbox" "mailto:profile@example.org"}}}
+   {:label  "Activity Profile"
+    :id-key :profileId
+    :params {:profileId  "activity-profile"
+             :activityId "https://example.org/precondition/activity"}}])
+
+(def initial-body "{\"value\":\"initial\"}")
+(def replacement-body "{\"value\":\"replacement\"}")
+(def merge-body "{\"merged\":true}")
+
+(defn- document
+  [body]
+  {:contents       (.getBytes ^String body "UTF-8")
+   :content-type   "application/json"
+   :content-length (count (.getBytes ^String body "UTF-8"))})
+
+(defn- plain-document
+  [body]
+  {:contents       (.getBytes ^String body "UTF-8")
+   :content-type   "text/plain"
+   :content-length (count (.getBytes ^String body "UTF-8"))})
+
+(defn- precondition-ctx
+  [preconditions]
+  (assoc tc/ctx ::lrs-doc/preconditions preconditions))
+
+(defn- params-for
+  [{:keys [id-key params]} suffix]
+  (update params id-key str "-" suffix))
+
+(defn- get-body
+  [lrs params]
+  (some-> (lrsp/-get-document lrs tc/ctx tc/auth-ident params)
+          :document
+          :contents
+          u/bytes->str))
+
+(defn- precondition-failed?
+  [result]
+  (lrs-doc/precondition-failed? (:error result)))
+
+(deftest document-write-preconditions-test
+  (let [sys (component/start (support/test-system))
+        lrs (:lrs sys)]
+    (try
+      (doseq [{:keys [label] :as resource} resource-cases]
+        (testing label
+          (let [stale-params (params-for resource "stale")
+                match-params (params-for resource "match")
+                same-params  (params-for resource "same")
+                post-params  (params-for resource "post")
+                put-new-params  (params-for resource "put-new")
+                post-new-params (params-for resource "post-new")
+                initial-etag (hash/sha-1 initial-body)
+                match-ctx (precondition-ctx {:if-match #{initial-etag}})
+                stale-ctx (precondition-ctx {:if-match #{"stale"}})
+                create-ctx (precondition-ctx {:if-none-match :*})]
+            (is (= {} (lrsp/-set-document lrs tc/ctx tc/auth-ident
+                                           stale-params
+                                           (document initial-body)
+                                           false)))
+            (is (precondition-failed?
+                 (lrsp/-set-document lrs stale-ctx tc/auth-ident
+                                     stale-params
+                                     (document replacement-body)
+                                     false)))
+            (is (= initial-body (get-body lrs stale-params))
+                "stale PUT leaves the current representation unchanged")
+            (is (precondition-failed?
+                 (lrsp/-set-document lrs stale-ctx tc/auth-ident
+                                     stale-params
+                                     (document merge-body)
+                                     true)))
+            (is (= initial-body (get-body lrs stale-params))
+                "stale POST leaves the current representation unchanged")
+
+            (is (= {} (lrsp/-set-document lrs tc/ctx tc/auth-ident
+                                           match-params
+                                           (document initial-body)
+                                           false)))
+            (is (= {} (lrsp/-set-document lrs match-ctx tc/auth-ident
+                                           match-params
+                                           (document replacement-body)
+                                           false)))
+            (is (= replacement-body (get-body lrs match-params))
+                "matching PUT replaces the representation")
+
+            (is (= {} (lrsp/-set-document lrs tc/ctx tc/auth-ident
+                                           same-params
+                                           (document initial-body)
+                                           false)))
+            (is (= {} (lrsp/-set-document lrs match-ctx tc/auth-ident
+                                           same-params
+                                           (document initial-body)
+                                           false)))
+            (is (= initial-body (get-body lrs same-params))
+                "matching same-content PUT succeeds")
+
+            (is (= {} (lrsp/-set-document lrs tc/ctx tc/auth-ident
+                                           post-params
+                                           (document initial-body)
+                                           false)))
+            (is (= {} (lrsp/-set-document lrs match-ctx tc/auth-ident
+                                           post-params
+                                           (document merge-body)
+                                           true)))
+            (is (= {"value" "initial" "merged" true}
+                   (u/parse-json (get-body lrs post-params)))
+                "matching POST merges from the observed representation")
+
+            (is (= {} (lrsp/-set-document lrs create-ctx tc/auth-ident
+                                           put-new-params
+                                           (document initial-body)
+                                           false)))
+            (is (precondition-failed?
+                 (lrsp/-set-document lrs create-ctx tc/auth-ident
+                                     put-new-params
+                                     (document replacement-body)
+                                     false)))
+            (is (= initial-body (get-body lrs put-new-params))
+                "If-None-Match prevents PUT replacement")
+
+            (is (= {} (lrsp/-set-document lrs create-ctx tc/auth-ident
+                                           post-new-params
+                                           (document initial-body)
+                                           true)))
+            (is (precondition-failed?
+                 (lrsp/-set-document lrs create-ctx tc/auth-ident
+                                     post-new-params
+                                     (document merge-body)
+                                     true)))
+            (is (= initial-body (get-body lrs post-new-params))
+                "If-None-Match prevents POST replacement"))))
+
+      (testing "existing POST validation errors"
+        (let [resource (last resource-cases)
+              merge-params (params-for resource "invalid-merge")
+              json-params  (params-for resource "invalid-json")]
+          (is (= {} (lrsp/-set-document lrs tc/ctx tc/auth-ident
+                                         merge-params
+                                         (plain-document "plain")
+                                         false)))
+          (let [result (lrsp/-set-document lrs tc/ctx tc/auth-ident
+                                           merge-params
+                                           (document merge-body)
+                                           true)]
+            (is (= ::lrs-doc/invalid-merge
+                   (:type (ex-data (:error result)))))
+            (is (= "plain" (get-body lrs merge-params))))
+          (let [result (lrsp/-set-document
+                        lrs tc/ctx tc/auth-ident
+                        json-params
+                        (document "not-json")
+                        true)]
+            (is (= ::lrs-doc/json-read-error
+                   (:type (ex-data (:error result)))))
+            (is (nil? (get-body lrs json-params))))))
+      (finally
+        (component/stop sys)))))

--- a/src/test/lrsql/ops/command/document_test.clj
+++ b/src/test/lrsql/ops/command/document_test.clj
@@ -1,0 +1,138 @@
+(ns lrsql.ops.command.document-test
+  (:require [clojure.test :refer [deftest is]]
+            [com.yetanalytics.lrs.util.hash :as hash]
+            [com.yetanalytics.lrs.xapi.document :as lrs-doc]
+            [lrsql.backend.protocol :as bp]
+            [lrsql.ops.command.document :as command]
+            [lrsql.util :as u]
+            [lrsql.util.concurrency :as concurrency]
+            [lrsql.util.document :as document])
+  (:import [java.nio.charset StandardCharsets]
+           [java.util Arrays UUID]))
+
+(defn- utf8-bytes
+  [s]
+  (.getBytes ^String s StandardCharsets/UTF_8))
+
+(defn- raw-document
+  [body]
+  (let [contents (utf8-bytes body)]
+    {:contents       contents
+     :content_type   "application/json"
+     :content_length (count contents)
+     :last_modified  (u/current-time)}))
+
+(defn- document-input
+  [body]
+  (let [contents (utf8-bytes body)]
+    {:table          :activity-profile-document
+     :primary-key    (UUID/randomUUID)
+     :profile-id     "profile-id"
+     :activity-iri   "https://example.org/activity"
+     :last-modified  (u/current-time)
+     :content-type   "application/json"
+     :content-length (count contents)
+     :contents       contents}))
+
+(defn- conflicting-backend
+  [state winner-body query-count]
+  (let [first-update? (atom true)]
+    (reify
+      bp/BackendUtil
+      (-txn-retry? [_ _] false)
+
+      bp/ActivityProfileDocumentBackend
+      (-insert-activity-profile-document! [_ _ _] nil)
+      (-insert-activity-profile-document-if-absent! [_ _ _] false)
+      (-update-activity-profile-document! [_ _ _] nil)
+      (-update-activity-profile-document-if-contents! [_ _ input]
+        (if (compare-and-set! first-update? true false)
+          (do
+            (reset! state (raw-document winner-body))
+            false)
+          (if (Arrays/equals ^bytes (:expected-contents input)
+                             ^bytes (:contents @state))
+            (do
+              (swap! state assoc
+                     :contents (:contents input)
+                     :content_length (:content-length input)
+                     :last_modified (:last-modified input))
+              true)
+            false)))
+      (-delete-activity-profile-document! [_ _ _] nil)
+      (-delete-activity-profile-document-if-contents! [_ _ _] false)
+      (-query-activity-profile-document [_ _ _]
+        (swap! query-count inc)
+        @state)
+      (-query-activity-profile-document-ids [_ _ _] [])
+      (-query-activity-profile-document-exists [_ _ _] (some? @state)))))
+
+(defn- run-set-with-retries
+  [backend ctx input merge?]
+  (concurrency/rerunable-txn*
+   #(command/set-document-cas! backend ::tx ctx input merge?)
+   0
+   (assoc (document/document-retry-opts
+           backend
+           {:stmt-retry-limit  2
+            :stmt-retry-budget 1})
+          :j-range 0)))
+
+(deftest stale-precondition-after-cas-conflict-test
+  (let [initial-body "{\"value\":\"initial\"}"
+        winner-body  "{\"value\":\"winner\"}"
+        state        (atom (raw-document initial-body))
+        query-count  (atom 0)
+        backend      (conflicting-backend state winner-body query-count)
+        ctx          {::lrs-doc/preconditions
+                      {:if-match #{(hash/sha-1 initial-body)}}}
+        result       (run-set-with-retries backend
+                                           ctx
+                                           (document-input
+                                            "{\"value\":\"stale\"}")
+                                           false)]
+    (is (= 2 @query-count) "the CAS miss causes a fresh read")
+    (is (lrs-doc/precondition-failed? (:error result)))
+    (is (= {"value" "winner"}
+           (u/parse-json (:contents @state)))
+        "the stale retry cannot overwrite the winner")))
+
+(deftest post-merge-is-recomputed-after-cas-conflict-test
+  (let [state       (atom (raw-document "{\"initial\":true}"))
+        query-count (atom 0)
+        backend     (conflicting-backend state
+                                         "{\"winner\":true}"
+                                         query-count)
+        result      (run-set-with-retries backend
+                                          {}
+                                          (document-input
+                                           "{\"request\":true}")
+                                          true)]
+    (is (= {} result))
+    (is (= 2 @query-count) "the merge is retried from a fresh read")
+    (is (= {"winner" true "request" true}
+           (u/parse-json (:contents @state)))
+        "the retried merge includes the winning representation")))
+
+(deftest unexpected-exception-is-preserved-test
+  (let [state       (atom (raw-document "{\"value\":\"initial\"}"))
+        query-count (atom 0)
+        backend     (conflicting-backend state
+                                         "{\"value\":\"winner\"}"
+                                         query-count)
+        expected    (ex-info "Unexpected" {:type ::unexpected})
+        thrown      (try
+                      (with-redefs
+                        [bp/-query-activity-profile-document
+                         (fn [& _] (throw expected))]
+                        (run-set-with-retries backend
+                                              {}
+                                              (document-input
+                                               "{\"value\":\"new\"}")
+                                              false))
+                      nil
+                      (catch clojure.lang.ExceptionInfo ex
+                        ex))]
+    (is (identical? expected thrown))
+    (is (not (document/cas-conflict? thrown)))
+    (is (not (lrs-doc/precondition-failed? thrown)))))

--- a/src/test/lrsql/ops/command/document_test.clj
+++ b/src/test/lrsql/ops/command/document_test.clj
@@ -36,7 +36,8 @@
 
 (defn- conflicting-backend
   [state winner-body query-count]
-  (let [first-update? (atom true)]
+  (let [first-update? (atom true)
+        first-delete? (atom true)]
     (reify
       bp/BackendUtil
       (-txn-retry? [_ _] false)
@@ -60,7 +61,15 @@
               true)
             false)))
       (-delete-activity-profile-document! [_ _ _] nil)
-      (-delete-activity-profile-document-if-contents! [_ _ _] false)
+      (-delete-activity-profile-document-if-contents! [_ _ input]
+        (if (compare-and-set! first-delete? true false)
+          (do
+            (reset! state (raw-document winner-body))
+            false)
+          (if (Arrays/equals ^bytes (:expected-contents input)
+                             ^bytes (:contents @state))
+            (do (reset! state nil) true)
+            false)))
       (-query-activity-profile-document [_ _ _]
         (swap! query-count inc)
         @state)
@@ -71,6 +80,17 @@
   [backend ctx input merge?]
   (concurrency/rerunable-txn*
    #(command/set-document-cas! backend ::tx ctx input merge?)
+   0
+   (assoc (document/document-retry-opts
+           backend
+           {:stmt-retry-limit  2
+            :stmt-retry-budget 1})
+          :j-range 0)))
+
+(defn- run-delete-with-retries
+  [backend ctx input]
+  (concurrency/rerunable-txn*
+   #(command/delete-document-cas! backend ::tx ctx input)
    0
    (assoc (document/document-retry-opts
            backend
@@ -136,3 +156,20 @@
     (is (identical? expected thrown))
     (is (not (document/cas-conflict? thrown)))
     (is (not (lrs-doc/precondition-failed? thrown)))))
+
+(deftest stale-delete-precondition-after-cas-conflict-test
+  (let [initial-body "{\"value\":\"initial\"}"
+        winner-body  "{\"value\":\"winner\"}"
+        state        (atom (raw-document initial-body))
+        query-count  (atom 0)
+        backend      (conflicting-backend state winner-body query-count)
+        ctx          {::lrs-doc/preconditions
+                      {:if-match #{(hash/sha-1 initial-body)}}}
+        result       (run-delete-with-retries backend
+                                              ctx
+                                              (document-input initial-body))]
+    (is (= 2 @query-count) "the delete CAS miss causes a fresh read")
+    (is (lrs-doc/precondition-failed? (:error result)))
+    (is (= {"value" "winner"}
+           (u/parse-json (:contents @state)))
+        "the stale retry cannot delete the winner")))

--- a/src/test/lrsql/ops/command/document_test.clj
+++ b/src/test/lrsql/ops/command/document_test.clj
@@ -1,5 +1,5 @@
 (ns lrsql.ops.command.document-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [com.yetanalytics.lrs.util.hash :as hash]
             [com.yetanalytics.lrs.xapi.document :as lrs-doc]
             [lrsql.backend.protocol :as bp]
@@ -97,6 +97,142 @@
            {:stmt-retry-limit  2
             :stmt-retry-budget 1})
           :j-range 0)))
+
+(defn- state-collection-backend
+  [rows delete-calls]
+  (reify
+    bp/BackendUtil
+    (-txn-retry? [_ ex]
+      (= ::retryable-database-error (:type (ex-data ex))))
+
+    bp/StateDocumentBackend
+    (-insert-state-document! [_ _ _] nil)
+    (-insert-state-document-if-absent! [_ _ _] false)
+    (-update-state-document! [_ _ _] nil)
+    (-update-state-document-if-contents! [_ _ _] false)
+    (-delete-state-document! [_ _ _] nil)
+    (-delete-state-document-if-contents! [_ _ _] false)
+    (-delete-state-documents! [_ _ _] nil)
+    (-delete-state-documents-by-primary-keys! [_ _ input]
+      (swap! delete-calls conj input)
+      0)
+    (-query-state-document [_ _ _] nil)
+    (-query-state-document-ids [_ _ _] @rows)
+    (-query-state-document-exists [_ _ _] false)))
+
+(deftest state-collection-observed-primary-key-delete-test
+  (let [ids          (mapv #(format "state-%03d" %) (range 502))
+        primary-keys (mapv (fn [_] (UUID/randomUUID)) ids)
+        rows          (atom (mapv (fn [primary-key state-id]
+                                    {:id primary-key :state_id state-id})
+                                  (reverse primary-keys)
+                                  (reverse ids)))
+        delete-calls  (atom [])
+        backend       (state-collection-backend rows delete-calls)
+        input         {:table        :state-document
+                       :activity-iri "https://example.org/collection"
+                       :agent-ifi    "mbox::mailto:test@example.org"
+                       :registration nil}
+        ctx           {::lrs-doc/preconditions
+                       {:if-match
+                        #{(document/state-document-ids-etag ids)}}}]
+    (is (= {} (command/delete-documents-cas!
+               backend ::tx ctx input)))
+    (is (= [500 2] (mapv (comp count :primary-keys) @delete-calls))
+        "observed primary keys are deleted in 500-row batches")
+    (is (= (sort-by str primary-keys)
+           (mapcat :primary-keys @delete-calls))
+        "primary keys have a deterministic lock order")
+    (is (every? #(= (select-keys input [:activity-iri
+                                        :agent-ifi
+                                        :registration])
+                    (select-keys % [:activity-iri
+                                    :agent-ifi
+                                    :registration]))
+                @delete-calls)
+        "each batch retains its collection scope")))
+
+(deftest state-collection-precondition-and-retry-test
+  (let [initial-rows [{:id (UUID/randomUUID) :state_id "initial"}]
+        changed-rows [{:id (UUID/randomUUID) :state_id "initial"}
+                      {:id (UUID/randomUUID) :state_id "new"}]
+        input        {:table        :state-document
+                      :activity-iri "https://example.org/collection"
+                      :agent-ifi    "mbox::mailto:test@example.org"}]
+    (testing "stale and wildcard conditions do not delete"
+      (doseq [preconditions [{:if-match #{"stale"}}
+                             {:if-none-match :*}]]
+        (let [rows         (atom initial-rows)
+              delete-calls (atom [])
+              backend      (state-collection-backend rows delete-calls)
+              result       (command/delete-documents-cas!
+                            backend ::tx
+                            {::lrs-doc/preconditions preconditions}
+                            input)]
+          (is (lrs-doc/precondition-failed? (:error result)))
+          (is (empty? @delete-calls)))))
+
+    (testing "the empty collection validates against the [] representation"
+      (let [rows         (atom [])
+            delete-calls (atom [])
+            backend      (state-collection-backend rows delete-calls)]
+        (is (= {} (command/delete-documents-cas!
+                   backend ::tx
+                   {::lrs-doc/preconditions
+                    {:if-match
+                     #{(document/state-document-ids-etag [])}}}
+                   input)))
+        (is (empty? @delete-calls))))
+
+    (testing "a retried database conflict reevaluates the original condition"
+      (let [rows          (atom initial-rows)
+            delete-calls  (atom [])
+            base-backend  (state-collection-backend rows delete-calls)
+            first-delete? (atom true)
+            backend       (reify
+                            bp/BackendUtil
+                            (-txn-retry? [_ ex]
+                              (= ::retryable-database-error
+                                 (:type (ex-data ex))))
+                            bp/StateDocumentBackend
+                            (-insert-state-document! [_ _ _] nil)
+                            (-insert-state-document-if-absent! [_ _ _] false)
+                            (-update-state-document! [_ _ _] nil)
+                            (-update-state-document-if-contents! [_ _ _] false)
+                            (-delete-state-document! [_ _ _] nil)
+                            (-delete-state-document-if-contents! [_ _ _] false)
+                            (-delete-state-documents! [_ _ _] nil)
+                            (-delete-state-documents-by-primary-keys!
+                              [_ _ delete-input]
+                              (if (compare-and-set! first-delete? true false)
+                                (do
+                                  (reset! rows changed-rows)
+                                  (throw
+                                   (ex-info "Retry database error"
+                                            {:type
+                                             ::retryable-database-error})))
+                                (bp/-delete-state-documents-by-primary-keys!
+                                 base-backend ::tx delete-input)))
+                            (-query-state-document [_ _ _] nil)
+                            (-query-state-document-ids [_ _ _] @rows)
+                            (-query-state-document-exists [_ _ _] false))
+            ctx           {::lrs-doc/preconditions
+                           {:if-match
+                            #{(document/state-document-ids-etag
+                               ["initial"])}}}
+            result        (concurrency/rerunable-txn*
+                           #(command/delete-documents-cas!
+                             backend ::tx ctx input)
+                           0
+                           (assoc (document/document-retry-opts
+                                   backend
+                                   {:stmt-retry-limit  2
+                                    :stmt-retry-budget 1})
+                                  :j-range 0))]
+        (is (lrs-doc/precondition-failed? (:error result)))
+        (is (= changed-rows @rows))
+        (is (empty? @delete-calls)
+            "the stale retry cannot delete the changed collection")))))
 
 (deftest stale-precondition-after-cas-conflict-test
   (let [initial-body "{\"value\":\"initial\"}"

--- a/src/test/lrsql/util/document_test.clj
+++ b/src/test/lrsql/util/document_test.clj
@@ -5,7 +5,8 @@
             [lrsql.backend.protocol :as bp]
             [lrsql.util.concurrency :as concurrency]
             [lrsql.util.document :as document])
-  (:import [java.nio.charset StandardCharsets]))
+  (:import [java.nio.charset StandardCharsets]
+           [java.util Arrays]))
 
 (defn- utf8-bytes
   [s]
@@ -15,6 +16,19 @@
   (reify bp/BackendUtil
     (-txn-retry? [_ ex]
       (= ::retryable-database-error (:type (ex-data ex))))))
+
+(deftest state-document-id-representation-test
+  (let [canonical ["alpha" "middle" "zeta"]
+        json      "[\"alpha\",\"middle\",\"zeta\"]"]
+    (is (= canonical
+           (document/canonical-state-document-ids
+            ["zeta" "alpha" "middle"])))
+    (is (Arrays/equals (utf8-bytes json)
+                       (document/state-document-ids-contents canonical)))
+    (is (= (hash/sha-1 json)
+           (document/state-document-ids-etag canonical)))
+    (is (= (hash/sha-1 "[]")
+           (document/state-document-ids-etag [])))))
 
 (deftest normalized-preconditions-test
   (let [contents (utf8-bytes "{\"value\":\"current\"}")
@@ -106,6 +120,8 @@
                  :stmt-retry-budget 250})]
       (is (= 7 (:max-attempt opts)))
       (is (= 250 (:budget opts)))
+      (is (not (contains? opts :isolation))
+          "document CAS does not override transaction isolation")
       (is ((:retry-test opts) (document/cas-conflict-ex)))
       (is ((:retry-test opts)
            (ex-info "Retry database error"

--- a/src/test/lrsql/util/document_test.clj
+++ b/src/test/lrsql/util/document_test.clj
@@ -1,0 +1,148 @@
+(ns lrsql.util.document-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [com.yetanalytics.lrs.util.hash :as hash]
+            [com.yetanalytics.lrs.xapi.document :as lrs-doc]
+            [lrsql.backend.protocol :as bp]
+            [lrsql.util.concurrency :as concurrency]
+            [lrsql.util.document :as document])
+  (:import [java.nio.charset StandardCharsets]))
+
+(defn- utf8-bytes
+  [s]
+  (.getBytes ^String s StandardCharsets/UTF_8))
+
+(def retrying-backend
+  (reify bp/BackendUtil
+    (-txn-retry? [_ ex]
+      (= ::retryable-database-error (:type (ex-data ex))))))
+
+(deftest normalized-preconditions-test
+  (let [contents (utf8-bytes "{\"value\":\"current\"}")
+        etag     (hash/sha-1 contents)
+        current  {:contents contents}]
+    (testing "context contract"
+      (is (= {} (document/preconditions {})))
+      (is (= {:if-match #{etag}}
+             (document/preconditions
+              {::lrs-doc/preconditions {:if-match #{etag}}})))
+      (is (document/preconditions-met?
+           {::lrs-doc/preconditions {:if-match #{etag}}
+            :request {:headers {"if-match" "\"ignored-header\""}}}
+           current)
+          "only normalized context preconditions are used"))
+
+    (testing "observed representation state"
+      (is (= {:exists? false}
+             (document/current-document-state nil)))
+      (is (= {:exists? true :etag etag}
+             (document/current-document-state current))))
+
+    (testing "wildcards and tag sets"
+      (is (document/preconditions-met? {} nil))
+      (is (document/preconditions-met? {} current))
+      (is (document/preconditions-met?
+           {::lrs-doc/preconditions {:if-match :*}}
+           current))
+      (is (not (document/preconditions-met?
+                {::lrs-doc/preconditions {:if-match :*}}
+                nil)))
+      (is (document/preconditions-met?
+           {::lrs-doc/preconditions {:if-none-match :*}}
+           nil))
+      (is (not (document/preconditions-met?
+                {::lrs-doc/preconditions {:if-none-match :*}}
+                current)))
+      (is (document/preconditions-met?
+           {::lrs-doc/preconditions {:if-match #{"other" etag}}}
+           current))
+      (is (not (document/preconditions-met?
+                {::lrs-doc/preconditions {:if-match #{"other"}}}
+                current)))
+      (is (document/preconditions-met?
+           {::lrs-doc/preconditions {:if-none-match #{"other"}}}
+           current))
+      (is (not (document/preconditions-met?
+                {::lrs-doc/preconditions {:if-none-match #{etag}}}
+                current))))
+
+    (testing "standardized failure"
+      (is (nil? (document/precondition-error
+                 {::lrs-doc/preconditions {:if-match #{etag}}}
+                 current)))
+      (is (nil? (document/precondition-error
+                 {::lrs-doc/preconditions {:if-none-match :*}}
+                 nil)))
+      (is (lrs-doc/precondition-failed?
+           (:error
+            (document/precondition-error
+             {::lrs-doc/preconditions {:if-match :*}}
+             nil))))
+      (let [{:keys [error] :as result}
+            (document/precondition-error
+             {::lrs-doc/preconditions {:if-match #{"stale"}}}
+             current
+             {:operation :put})]
+        (is (some? result))
+        (is (lrs-doc/precondition-failed? error))
+        (is (= :put (:operation (ex-data error))))))))
+
+(deftest document-retry-orchestration-test
+  (testing "retry classification"
+    (let [cas-ex (document/cas-conflict-ex {:operation :post})
+          db-ex  (ex-info "Retry database error"
+                          {:type ::retryable-database-error})
+          bad-ex (ex-info "Unexpected error" {:type ::unexpected})]
+      (is (document/cas-conflict? cas-ex))
+      (is (= :post (:operation (ex-data cas-ex))))
+      (is (not (lrs-doc/precondition-failed? cas-ex)))
+      (is (document/document-txn-retry? retrying-backend cas-ex))
+      (is (document/document-txn-retry? retrying-backend db-ex))
+      (is (not (document/document-txn-retry? retrying-backend bad-ex)))))
+
+  (testing "existing retry configuration"
+    (let [opts (document/document-retry-opts
+                retrying-backend
+                {:stmt-retry-limit  7
+                 :stmt-retry-budget 250})]
+      (is (= 7 (:max-attempt opts)))
+      (is (= 250 (:budget opts)))
+      (is ((:retry-test opts) (document/cas-conflict-ex)))
+      (is ((:retry-test opts)
+           (ex-info "Retry database error"
+                    {:type ::retryable-database-error})))))
+
+  (testing "CAS retry obtains a fresh attempt"
+    (let [attempts (atom 0)
+          result   (concurrency/rerunable-txn*
+                    (fn []
+                      (if (= 1 (swap! attempts inc))
+                        (document/throw-cas-conflict!)
+                        :applied))
+                    0
+                    (assoc (document/document-retry-opts
+                            retrying-backend
+                            {:stmt-retry-limit  2
+                             :stmt-retry-budget 1})
+                           :j-range 0))]
+      (is (= :applied result))
+      (is (= 2 @attempts))))
+
+  (testing "retry exhaustion remains a CAS conflict, not a 412"
+    (let [attempts (atom 0)
+          thrown   (try
+                     (concurrency/rerunable-txn*
+                      (fn []
+                        (swap! attempts inc)
+                        (document/throw-cas-conflict!))
+                      0
+                      (assoc (document/document-retry-opts
+                              retrying-backend
+                              {:stmt-retry-limit  2
+                               :stmt-retry-budget 1})
+                             :j-range 0))
+                     nil
+                     (catch clojure.lang.ExceptionInfo ex
+                       ex))]
+      (is (= 3 @attempts))
+      (is (document/cas-conflict? thrown))
+      (is (not (lrs-doc/precondition-failed? thrown))))))


### PR DESCRIPTION
Support atomic updates to documents using etag-based compare and swap.

See also:
https://github.com/yetanalytics/lrs/pull/108
