### PR TITLE
fix deletion of documents with a registration

### DIFF
--- a/src/db/mariadb/lrsql/mariadb/sql/delete.sql
+++ b/src/db/mariadb/lrsql/mariadb/sql/delete.sql
@@ -7,7 +7,7 @@ WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
 AND state_hash = UNHEX(SHA2(:state-id,256))
 AND state_id = :state-id
---~ (when (:registration params) "AND registration = :registration" "AND registration IS NULL")
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
 ;
 
 -- :name delete-state-documents!
@@ -17,7 +17,7 @@ AND state_id = :state-id
 DELETE FROM state_document
 WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
---~ (when (:registration params) "AND registration = :registration" "AND registration IS NULL")
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
 ;
 
 -- :name delete-agent-profile-document!

--- a/src/db/mariadb/lrsql/mariadb/sql/query.sql
+++ b/src/db/mariadb/lrsql/mariadb/sql/query.sql
@@ -220,7 +220,7 @@ AND profile_id = :profile-id;
 SELECT state_id FROM state_document
 WHERE activity_hash = UNHEX(SHA2(:activity-iri,256))
 AND agent_hash = UNHEX(SHA2(:agent-ifi,256))
---~ (when (:registration params) "AND registration = :registration" "AND registration IS NULL")
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
 --~ (when (:since params) "AND last_modified > :since")
 ;
 

--- a/src/db/postgres/lrsql/postgres/sql/delete.sql
+++ b/src/db/postgres/lrsql/postgres/sql/delete.sql
@@ -6,7 +6,7 @@ DELETE FROM state_document
 WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
 AND state_id = :state-id
---~ (when (:registration params) "AND registration = :registration" "AND registration IS NULL")
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
 ;
 
 -- :name delete-state-documents!
@@ -16,7 +16,7 @@ AND state_id = :state-id
 DELETE FROM state_document
 WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
---~ (when (:registration params) "AND registration = :registration" "AND registration IS NULL")
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
 ;
 
 -- :name delete-agent-profile-document!

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -210,7 +210,7 @@ AND profile_id = :profile-id;
 SELECT state_id FROM state_document
 WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
---~ (when (:registration params) "AND registration = :registration" "AND registration IS NULL")
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
 --~ (when (:since params) "AND last_modified > :since")
 ;
 

--- a/src/db/sqlite/lrsql/sqlite/sql/delete.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/delete.sql
@@ -6,7 +6,7 @@ DELETE FROM state_document
 WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
 AND state_id = :state-id
---~ (when (:registration params) "AND registration = :registration" "AND registration ISNULL")
+--~ (if (:registration params) "AND registration = :registration" "AND registration ISNULL")
 
 -- :name delete-state-documents!
 -- :command :execute
@@ -15,7 +15,7 @@ AND state_id = :state-id
 DELETE FROM state_document
 WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
---~ (when (:registration params) "AND registration = :registration" "AND registration ISNULL")
+--~ (if (:registration params) "AND registration = :registration" "AND registration ISNULL")
 
 -- :name delete-agent-profile-document!
 -- :command :execute

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -190,7 +190,7 @@ AND profile_id = :profile-id
 SELECT state_id FROM state_document
 WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
---~ (when (:registration params) "AND registration = :registration" "AND registration ISNULL")
+--~ (if (:registration params) "AND registration = :registration" "AND registration ISNULL")
 --~ (when (:since params) "AND last_modified > :since")
 
 -- :name query-agent-profile-document-ids

--- a/src/test/lrsql/lrs_test.clj
+++ b/src/test/lrsql/lrs_test.clj
@@ -1450,6 +1450,39 @@
 
     (component/stop sys')))
 
+(deftest test-registered-state-document-deletion
+  (let [registration "00000000-0000-4000-8000-000000000001"
+        params-1     (assoc state-id-params :registration registration)
+        params-2     (assoc state-id-params-2 :registration registration)
+        sys          (component/start (support/test-system))
+        lrs          (:lrs sys)]
+    (try
+      (support/seq-is
+       {}
+       (lrsp/-set-document lrs tc/ctx auth-ident params-1 state-doc-1 false)
+       (lrsp/-set-document lrs tc/ctx auth-ident params-2 state-doc-2 false))
+
+      (is (= {:document-ids ["some-id" "some-other-id"]}
+             (lrsp/-get-document-ids lrs
+                                     tc/ctx
+                                     auth-ident
+                                     (dissoc params-1 :stateId))))
+
+      (is (= {}
+             (lrsp/-delete-document lrs tc/ctx auth-ident params-1)))
+      (is (= {:document nil}
+             (lrsp/-get-document lrs tc/ctx auth-ident params-1)))
+
+      (is (= {}
+             (lrsp/-delete-documents lrs
+                                     tc/ctx
+                                     auth-ident
+                                     (dissoc params-2 :stateId))))
+      (is (= {:document nil}
+             (lrsp/-get-document lrs tc/ctx auth-ident params-2)))
+      (finally
+        (component/stop sys)))))
+
 (deftest accept-version-test
   (let [lrs            (component/start (support/test-system))]
     (testing "Accepts versions 1.0.0-1.0.3"


### PR DESCRIPTION
Fixes a typo that was stopping any document with a registration from being deleted and adds test coverage to make me feel a little better about it.