### PR TITLE
implement atomic bulk delete using observed keys

### DIFF
--- a/src/db/mariadb/lrsql/mariadb/record.clj
+++ b/src/db/mariadb/lrsql/mariadb/record.clj
@@ -7,14 +7,15 @@
             [lrsql.backend.result :as br]
             [lrsql.init :refer [init-hugsql-adapter!]]
             [lrsql.mariadb.data :as md]
-            [clojure.string :refer [includes?]])
-  (:import [java.security MessageDigest]))
+            [clojure.string :as cstr])
+  (:import [java.security MessageDigest]
+           [java.sql SQLException]))
 
 (defn make-path-str [p]
   (as-> p path
     (map #(format "\"%s\"" %) path)
     (into [\$] path)
-    (clojure.string/join \. path)
+    (cstr/join \. path)
     (format "'%s'" path)))
 
 (defn sha256-bytes [^String s]
@@ -27,7 +28,7 @@
 (defn emit-binary-hashes [ifis]
   (->> ifis
        (map (comp bytes->sql-hex sha256-bytes))
-       (clojure.string/join ", "))) ;; emits: X'...', X'...', ...
+       (cstr/join ", "))) ;; emits: X'...', X'...', ...
 
 ;; Init HugSql functions
 
@@ -75,10 +76,13 @@
 
   bp/BackendUtil
   (-txn-retry? [_ ex]
-    (and (instance? java.sql.SQLException ex)
-         (let [msg (.getMessage ex)]
-           (or (includes? msg "Record has changed since last read")
-               (includes? msg "Deadlock found when trying to get lock")))))
+    (and (instance? SQLException ex)
+         (let [sql-ex ^SQLException ex]
+           (or (= "40001" (.getSQLState sql-ex))
+               (contains? #{1020  ; record changed since last read
+                            1205  ; lock wait timeout
+                            1213} ; deadlock / serialization conflict
+                          (.getErrorCode sql-ex))))))
 
   bp/StatementBackend
   (-insert-statement! [_ tx input]
@@ -145,6 +149,8 @@
     (br/affected->applied? (delete-state-document-if-contents! tx input)))
   (-delete-state-documents! [_ tx input]
     (delete-state-documents! tx input))
+  (-delete-state-documents-by-primary-keys! [_ tx input]
+    (delete-state-documents-by-primary-keys! tx input))
   (-query-state-document [_ tx input]
     (query-state-document tx input))
   (-query-state-document-ids [_ tx input]

--- a/src/db/mariadb/lrsql/mariadb/sql/delete.sql
+++ b/src/db/mariadb/lrsql/mariadb/sql/delete.sql
@@ -20,6 +20,19 @@ AND agent_ifi = :agent-ifi
 --~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
 ;
 
+-- :name delete-state-documents-by-primary-keys!
+-- :command :execute
+-- :result :affected
+-- :doc Delete observed State documents by physical primary key, retaining collection scoping predicates.
+DELETE FROM state_document
+WHERE activity_hash = UNHEX(SHA2(:activity-iri,256))
+AND agent_hash = UNHEX(SHA2(:agent-ifi,256))
+AND activity_iri = :activity-iri
+AND agent_ifi = :agent-ifi
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
+AND id IN (:v*:primary-keys)
+;
+
 -- :name delete-agent-profile-document!
 -- :command :execute
 -- :result :affected

--- a/src/db/mariadb/lrsql/mariadb/sql/query.sql
+++ b/src/db/mariadb/lrsql/mariadb/sql/query.sql
@@ -217,7 +217,7 @@ AND profile_id = :profile-id;
 -- :command :query
 -- :result :many
 -- :doc Query for one or more state document IDs using resource params. If `:registration` is missing then `registration` must be NULL.
-SELECT state_id FROM state_document
+SELECT id, state_id FROM state_document
 WHERE activity_hash = UNHEX(SHA2(:activity-iri,256))
 AND agent_hash = UNHEX(SHA2(:agent-ifi,256))
 --~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -6,8 +6,7 @@
             [lrsql.backend.protocol :as bp]
             [lrsql.backend.result :as br]
             [lrsql.init :refer [init-hugsql-adapter!]]
-            [lrsql.postgres.data :as pd]
-            [clojure.string :refer [includes?]])
+            [lrsql.postgres.data :as pd])
   (:import [org.postgresql.util PSQLException]))
 
 ;; Init HugSql functions
@@ -91,12 +90,11 @@
 
   bp/BackendUtil
   (-txn-retry? [_ ex]
-    ;; only retry PGExceptions with a specified phrase
+    ;; PostgreSQL reports transaction rollbacks by SQLSTATE.
     (and (instance? PSQLException ex)
-         (let [msg (.getMessage ^PSQLException ex)]
-           (or (includes? msg "ERROR: deadlock detected")
-               (includes? msg "ERROR: could not serialize access due to concurrent update")
-               (includes? msg "ERROR: could not serialize access due to read/write dependencies among transactions")))))
+         (contains? #{"40001" ; serialization_failure
+                      "40P01"} ; deadlock_detected
+                    (.getSQLState ^PSQLException ex))))
 
   bp/StatementBackend
   (-insert-statement! [_ tx input]
@@ -163,6 +161,8 @@
     (br/affected->applied? (delete-state-document-if-contents! tx input)))
   (-delete-state-documents! [_ tx input]
     (delete-state-documents! tx input))
+  (-delete-state-documents-by-primary-keys! [_ tx input]
+    (delete-state-documents-by-primary-keys! tx input))
   (-query-state-document [_ tx input]
     (query-state-document tx input))
   (-query-state-document-ids [_ tx input]

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -6,7 +6,8 @@
             [lrsql.backend.protocol :as bp]
             [lrsql.backend.result :as br]
             [lrsql.init :refer [init-hugsql-adapter!]]
-            [lrsql.postgres.data :as pd])
+            [lrsql.postgres.data :as pd]
+            [clojure.string :refer [includes?]])
   (:import [org.postgresql.util PSQLException]))
 
 ;; Init HugSql functions

--- a/src/db/postgres/lrsql/postgres/record.clj
+++ b/src/db/postgres/lrsql/postgres/record.clj
@@ -90,11 +90,17 @@
 
   bp/BackendUtil
   (-txn-retry? [_ ex]
-    ;; PostgreSQL reports transaction rollbacks by SQLSTATE.
     (and (instance? PSQLException ex)
-         (contains? #{"40001" ; serialization_failure
-                      "40P01"} ; deadlock_detected
-                    (.getSQLState ^PSQLException ex))))
+         (or
+          ;; PostgreSQL reports transaction rollbacks by SQLSTATE.
+          (contains? #{"40001" ; serialization_failure
+                       "40P01"} ; deadlock_detected
+                     (.getSQLState ^PSQLException ex))
+          ;; In the past we have seen scenarios where PG does not properly set SQLSTATE
+          (let [msg (.getMessage ^PSQLException ex)]
+            (or (includes? msg "ERROR: deadlock detected")
+                (includes? msg "ERROR: could not serialize access due to concurrent update")
+                (includes? msg "ERROR: could not serialize access due to read/write dependencies among transactions"))))))
 
   bp/StatementBackend
   (-insert-statement! [_ tx input]

--- a/src/db/postgres/lrsql/postgres/sql/delete.sql
+++ b/src/db/postgres/lrsql/postgres/sql/delete.sql
@@ -19,6 +19,17 @@ AND agent_ifi = :agent-ifi
 --~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
 ;
 
+-- :name delete-state-documents-by-primary-keys!
+-- :command :execute
+-- :result :affected
+-- :doc Delete observed State documents by physical primary key, retaining collection scoping predicates.
+DELETE FROM state_document
+WHERE activity_iri = :activity-iri
+AND agent_ifi = :agent-ifi
+--~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")
+AND id IN (:v*:primary-keys)
+;
+
 -- :name delete-agent-profile-document!
 -- :command :execute
 -- :result :affected

--- a/src/db/postgres/lrsql/postgres/sql/query.sql
+++ b/src/db/postgres/lrsql/postgres/sql/query.sql
@@ -207,7 +207,7 @@ AND profile_id = :profile-id;
 -- :command :query
 -- :result :many
 -- :doc Query for one or more state document IDs using resource params. If `:registration` is missing then `registration` must be NULL.
-SELECT state_id FROM state_document
+SELECT id, state_id FROM state_document
 WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
 --~ (if (:registration params) "AND registration = :registration" "AND registration IS NULL")

--- a/src/db/sqlite/lrsql/sqlite/record.clj
+++ b/src/db/sqlite/lrsql/sqlite/record.clj
@@ -131,9 +131,14 @@
                (:schema_version (query-schema-version tx))))
 
   bp/BackendUtil
-  (-txn-retry? [_ _ex]
-    ;; No known retry cases for SQLite
-    false)
+  (-txn-retry? [_ ex]
+    (and (instance? SQLiteException ex)
+         ;; Extended BUSY and LOCKED codes retain their primary result code in
+         ;; the low byte (e.g. SQLITE_BUSY_SNAPSHOT is 0x205).
+         (contains? #{5 6}
+                    (bit-and 0xff
+                             (.-code (.getResultCode
+                                      ^SQLiteException ex))))))
 
   bp/StatementBackend
   (-insert-statement! [_ tx input]
@@ -203,6 +208,8 @@
     (br/affected->applied? (delete-state-document-if-contents! tx input)))
   (-delete-state-documents! [_ tx input]
     (delete-state-documents! tx input))
+  (-delete-state-documents-by-primary-keys! [_ tx input]
+    (delete-state-documents-by-primary-keys! tx input))
   (-query-state-document [_ tx input]
     (query-state-document tx input))
   (-query-state-document-ids [_ tx input]

--- a/src/db/sqlite/lrsql/sqlite/sql/delete.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/delete.sql
@@ -17,6 +17,16 @@ WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
 --~ (if (:registration params) "AND registration = :registration" "AND registration ISNULL")
 
+-- :name delete-state-documents-by-primary-keys!
+-- :command :execute
+-- :result :affected
+-- :doc Delete observed State documents by physical primary key, retaining collection scoping predicates.
+DELETE FROM state_document
+WHERE activity_iri = :activity-iri
+AND agent_ifi = :agent-ifi
+--~ (if (:registration params) "AND registration = :registration" "AND registration ISNULL")
+AND id IN (:v*:primary-keys)
+
 -- :name delete-agent-profile-document!
 -- :command :execute
 -- :result :affected

--- a/src/db/sqlite/lrsql/sqlite/sql/query.sql
+++ b/src/db/sqlite/lrsql/sqlite/sql/query.sql
@@ -187,7 +187,7 @@ AND profile_id = :profile-id
 -- :command :query
 -- :result :many
 -- :doc Query for one or more state document IDs using resource params. If `:registration` is missing then `registration` must be NULL.
-SELECT state_id FROM state_document
+SELECT id, state_id FROM state_document
 WHERE activity_iri = :activity-iri
 AND agent_ifi = :agent-ifi
 --~ (if (:registration params) "AND registration = :registration" "AND registration ISNULL")

--- a/src/main/lrsql/backend/protocol.clj
+++ b/src/main/lrsql/backend/protocol.clj
@@ -69,6 +69,9 @@
   (-delete-state-document-if-contents! [this tx input]
     "Delete a state document only when its contents equal :expected-contents. Returns a boolean indicating whether the delete was applied.")
   (-delete-state-documents! [this tx input])
+  (-delete-state-documents-by-primary-keys! [this tx input]
+    "Delete State documents in the requested collection whose physical IDs
+     are present in :primary-keys. Returns the backend affected-row result.")
   ;; Queries
   (-query-state-document [this tx input])
   (-query-state-document-ids [this tx input])

--- a/src/main/lrsql/ops/command/document.clj
+++ b/src/main/lrsql/ops/command/document.clj
@@ -329,3 +329,50 @@
     ;; Else
     (throw-invalid-table-ex "delete-documents!" input))
   {})
+
+(def ^:private state-document-delete-batch-size 500)
+
+(defn- observed-primary-keys
+  [rows]
+  (->> rows
+       (map :id)
+       (sort-by str)
+       vec))
+
+(s/fdef delete-documents-cas!
+  :args (s/cat :bk ds/document-backend?
+               :tx transaction?
+               :ctx map?
+               :input ds/state-doc-multi-input-spec)
+  :ret ds/document-command-res-spec)
+
+(defn delete-documents-cas!
+  "Validate a State collection against the rows observed in this transaction,
+   then delete only those rows by immutable physical primary key. Rows added or
+   recreated after the observation are outside this operation's ordering point
+   and are not deleted."
+  [bk tx ctx {:keys [table] :as input}]
+  (case table
+    :state-document
+    (let [rows (bp/-query-state-document-ids bk tx input)
+          ids  (->> rows
+                    (map :state_id)
+                    du/canonical-state-document-ids)
+          collection-document
+          {:contents (du/state-document-ids-contents ids)}]
+      (if-some [error-result
+                (du/precondition-error ctx
+                                       collection-document
+                                       {:operation   :delete
+                                        :table       table
+                                        :collection? true})]
+        error-result
+        (do
+          (doseq [primary-keys (partition-all
+                                state-document-delete-batch-size
+                                (observed-primary-keys rows))]
+            (bp/-delete-state-documents-by-primary-keys!
+             bk tx (assoc input :primary-keys (vec primary-keys))))
+          {})))
+
+    (throw-invalid-table-ex "delete-documents-cas!" input)))

--- a/src/main/lrsql/ops/query/document.clj
+++ b/src/main/lrsql/ops/query/document.clj
@@ -5,6 +5,7 @@
             [lrsql.spec.common :refer [transaction?]]
             [lrsql.spec.document :as ds]
             [lrsql.util :as u]
+            [lrsql.util.document :as du]
             [lrsql.ops.util :refer [throw-invalid-table-ex]]))
 
 (s/fdef query-document
@@ -59,7 +60,8 @@
               :state-document
               (->> input
                    (bp/-query-state-document-ids bk tx)
-                   (map :state_id))
+                   (map :state_id)
+                   du/canonical-state-document-ids)
               :agent-profile-document
               (->> input
                    (bp/-query-agent-profile-document-ids bk tx)

--- a/src/main/lrsql/system/lrs.clj
+++ b/src/main/lrsql/system/lrs.clj
@@ -215,11 +215,12 @@
       (with-rerunable-txn [tx conn retry-opts]
         (doc-cmd/delete-document-cas! backend tx ctx input))))
   (-delete-documents
-    [lrs _ctx _auth-identity params]
+    [lrs ctx _auth-identity params]
     (let [conn  (lrs-conn lrs)
-          input (doc-input/document-multi-input params)]
-      (jdbc/with-transaction [tx conn]
-        (doc-cmd/delete-documents! backend tx input))))
+          input (doc-input/document-multi-input params)
+          retry-opts (doc-util/document-retry-opts backend config)]
+      (with-rerunable-txn [tx conn retry-opts]
+        (doc-cmd/delete-documents-cas! backend tx ctx input))))
 
   lrsp/AgentInfoResource
   (-get-person

--- a/src/main/lrsql/util/document.clj
+++ b/src/main/lrsql/util/document.clj
@@ -1,7 +1,25 @@
 (ns lrsql.util.document
   (:require [com.yetanalytics.lrs.util.hash :as hash]
             [com.yetanalytics.lrs.xapi.document :as lrs-doc]
-            [lrsql.backend.protocol :as bp]))
+            [lrsql.backend.protocol :as bp]
+            [lrsql.util :as u]))
+
+(defn canonical-state-document-ids
+  "Return State document IDs in the canonical order used by collection GET
+   responses and collection precondition validation."
+  [ids]
+  (->> ids sort vec))
+
+(defn state-document-ids-contents
+  "Canonicalize and serialize State document IDs exactly as the LRS document
+   route serializes its JSON response body."
+  [ids]
+  (u/write-json (canonical-state-document-ids ids)))
+
+(defn state-document-ids-etag
+  "Return the unquoted SHA-1 ETag for a canonical State document ID vector."
+  [ids]
+  (hash/sha-1 (state-document-ids-contents ids)))
 
 (defn preconditions
   "Return the normalized ETag preconditions supplied by the LRS library.

--- a/src/test/lrsql/backend/document_cas_test.clj
+++ b/src/test/lrsql/backend/document_cas_test.clj
@@ -1,10 +1,13 @@
 (ns lrsql.backend.document-cas-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [com.stuartsierra.component :as component]
+            [com.yetanalytics.lrs.xapi.document :as lrs-doc]
             [lrsql.backend.protocol :as bp]
             [lrsql.backend.result :as br]
+            [lrsql.ops.command.document :as command]
             [lrsql.test-support :as support]
             [lrsql.util :as u]
+            [lrsql.util.document :as document-util]
             [next.jdbc :as jdbc])
   (:import [java.nio.charset StandardCharsets]
            [java.util UUID]))
@@ -145,5 +148,79 @@
                     "a delete with current observed contents is applied")
                 (is (nil? (query bk tx initial-input))
                     "the matching delete removes the document"))))))
+      (finally
+        (component/stop sys)))))
+
+(defn- state-document-input
+  [collection-input state-id]
+  (merge collection-input
+         {:table          :state-document
+          :primary-key    (UUID/randomUUID)
+          :state-id       state-id
+          :last-modified  (u/current-time)
+          :content-type   "application/json"
+          :content-length 2
+          :contents       (utf8-bytes "{}")}))
+
+(deftest state-collection-observed-primary-key-primitives-test
+  (let [sys (component/start (support/test-system))]
+    (try
+      (let [bk         (:backend sys)
+            ds         (get-in sys [:lrs :connection :conn-pool])
+            collection {:activity-iri "https://example.org/observed-keys"
+                        :agent-ifi    "mbox::mailto:observed@example.org"
+                        :registration nil}]
+        (testing "the backend primitive deletes only observed, in-scope keys"
+          (let [observed   (state-document-input collection "observed")
+                unobserved (state-document-input collection "unobserved")
+                other      (state-document-input
+                            (assoc collection
+                                   :activity-iri
+                                   "https://example.org/other-collection")
+                            "other")]
+            (jdbc/with-transaction [tx ds]
+              (doseq [input [observed unobserved other]]
+                (bp/-insert-state-document! bk tx input))
+              (bp/-delete-state-documents-by-primary-keys!
+               bk tx
+               (assoc collection
+                      :primary-keys [(:primary-key observed)
+                                     (:primary-key other)
+                                     (UUID/randomUUID)]))
+              (is (nil? (bp/-query-state-document bk tx observed)))
+              (is (some? (bp/-query-state-document bk tx unobserved))
+                  "an unobserved row in the collection survives")
+              (is (some? (bp/-query-state-document bk tx other))
+                  "a supplied key outside the collection scope survives"))))
+
+        (testing "more than 500 observed keys are batched atomically"
+          (let [batch-collection
+                (assoc collection
+                       :activity-iri "https://example.org/batched-keys")
+                inputs (mapv #(state-document-input
+                               batch-collection
+                               (format "state-%03d" %))
+                             (range 501))
+                ids    (mapv :state-id inputs)
+                ctx    {::lrs-doc/preconditions
+                        {:if-match
+                         #{(document-util/state-document-ids-etag ids)}}}]
+            (jdbc/with-transaction [tx ds]
+              (doseq [input inputs]
+                (bp/-insert-state-document! bk tx input))
+              (is (= 501
+                     (count (bp/-query-state-document-ids
+                             bk tx
+                             (assoc batch-collection
+                                    :table :state-document))))
+                  "all rows are visible at the collection ordering point")
+              (is (= {}
+                     (command/delete-documents-cas!
+                      bk tx ctx
+                      (assoc batch-collection :table :state-document))))
+              (is (empty? (bp/-query-state-document-ids
+                           bk tx
+                           (assoc batch-collection
+                                  :table :state-document))))))))
       (finally
         (component/stop sys)))))

--- a/src/test/lrsql/backend/retry_test.clj
+++ b/src/test/lrsql/backend/retry_test.clj
@@ -1,0 +1,50 @@
+(ns lrsql.backend.retry-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [lrsql.backend.protocol :as bp]
+            [lrsql.mariadb.record :as mariadb]
+            [lrsql.postgres.record :as postgres]
+            [lrsql.sqlite.record :as sqlite])
+  (:import [java.sql SQLException]
+           [org.postgresql.util PSQLException PSQLState]
+           [org.sqlite SQLiteErrorCode SQLiteException]))
+
+(deftest postgres-transaction-retry-classification-test
+  (let [backend (postgres/map->PostgresBackend {})]
+    (is (bp/-txn-retry?
+         backend
+         (PSQLException. "serialization" PSQLState/SERIALIZATION_FAILURE)))
+    (is (bp/-txn-retry?
+         backend
+         (PSQLException. "deadlock" PSQLState/DEADLOCK_DETECTED)))
+    (is (not (bp/-txn-retry?
+              backend
+              (PSQLException. "unique" PSQLState/UNIQUE_VIOLATION))))))
+
+(deftest mariadb-and-mysql-transaction-retry-classification-test
+  (let [backend (mariadb/map->MariadbBackend {})]
+    (testing "SQLSTATE transaction rollbacks"
+      (is (bp/-txn-retry?
+           backend
+           (SQLException. "serialization" "40001" 0))))
+    (testing "vendor lock and concurrency error codes"
+      (doseq [code [1020 1205 1213]]
+        (is (bp/-txn-retry?
+             backend
+             (SQLException. "retryable" "HY000" code)))))
+    (is (not (bp/-txn-retry?
+              backend
+              (SQLException. "unique" "23000" 1062))))))
+
+(deftest sqlite-transaction-retry-classification-test
+  (let [backend (sqlite/map->SQLiteBackend {})]
+    (doseq [code [SQLiteErrorCode/SQLITE_BUSY
+                  SQLiteErrorCode/SQLITE_BUSY_SNAPSHOT
+                  SQLiteErrorCode/SQLITE_LOCKED
+                  SQLiteErrorCode/SQLITE_LOCKED_SHAREDCACHE]]
+      (is (bp/-txn-retry?
+           backend
+           (SQLiteException. "retryable" code))))
+    (is (not (bp/-txn-retry?
+              backend
+              (SQLiteException. "constraint"
+                                SQLiteErrorCode/SQLITE_CONSTRAINT))))))

--- a/src/test/lrsql/document_etag_race_test.clj
+++ b/src/test/lrsql/document_etag_race_test.clj
@@ -4,7 +4,9 @@
             [com.stuartsierra.component :as component]
             [com.yetanalytics.lrs :as lrs]
             [com.yetanalytics.lrs.util.hash :as hash]
-            [lrsql.test-support :as support]))
+            [lrsql.test-support :as support]
+            [lrsql.util :as u]
+            [lrsql.util.document :as doc-util]))
 
 (use-fixtures :once support/instrumentation-fixture)
 (use-fixtures :each support/fresh-db-fixture)
@@ -52,6 +54,17 @@
      :get    curl/get)
    endpoint
    (request-options resource document-id header body)))
+
+(defn- state-collection-request
+  [{:keys [endpoint query-params]} method header]
+  ((case method
+     :delete curl/delete
+     :get    curl/get)
+   endpoint
+   {:basic-auth   ["username" "password"]
+    :headers      (cond-> base-headers header (merge header))
+    :query-params query-params
+    :throw        false}))
 
 (defn- await!
   [pending label]
@@ -143,5 +156,136 @@
                                          "-"
                                          (name precondition))
                       :precondition precondition})))
+      (finally
+        (component/stop sys)))))
+
+(defn- run-state-collection-race!
+  [membership-change]
+  (let [suffix   (name membership-change)
+        resource (-> (first resource-cases)
+                     (assoc-in [:query-params "activityId"]
+                               (str "https://example.org/etag-race/collection/"
+                                    suffix)))
+        initial-ids ["alpha" "zeta"]]
+    (doseq [state-id initial-ids]
+      (ensure-status! 204
+                      (document-request resource
+                                        :put
+                                        state-id
+                                        {"If-None-Match" "*"}
+                                        initial-body)
+                      "initial State document PUT"))
+    (let [header {"If-Match"
+                  (str "\""
+                       (doc-util/state-document-ids-etag initial-ids)
+                       "\"")}
+          original-preconditions-met? doc-util/preconditions-met?
+          collection-read             (promise)
+          release-read                (promise)
+          read-count                  (atom 0)]
+      (with-redefs [doc-util/preconditions-met?
+                    (fn [& args]
+                      (let [result (apply original-preconditions-met? args)]
+                        ;; This hook is used only by LRSQL's authoritative
+                        ;; validation, not by the preliminary LRS interceptor.
+                        (when (= 1 (swap! read-count inc))
+                          (deliver collection-read true)
+                          (await! release-read "collection DELETE release"))
+                        result))]
+        (let [collection-delete
+              (future (state-collection-request resource :delete header))]
+          (try
+            (await! collection-read "collection DELETE validation")
+            (let [membership-request
+                  (future
+                    (case membership-change
+                      :addition
+                      [(document-request resource
+                                         :put
+                                         "new"
+                                         nil
+                                         winner-body)]
+
+                      :removal
+                      [(document-request resource
+                                         :delete
+                                         "zeta"
+                                         nil
+                                         nil)]
+
+                      :recreation
+                      [(document-request resource
+                                         :delete
+                                         "zeta"
+                                         nil
+                                         nil)
+                       (document-request resource
+                                         :put
+                                         "zeta"
+                                         nil
+                                         winner-body)]))]
+              (try
+                ;; Let the membership operation and the collection deletion
+                ;; establish whichever ordering the backend permits.
+                (deliver release-read true)
+                (let [delete-response (await! collection-delete
+                                              "collection DELETE")
+                      membership-responses
+                      (await! membership-request "membership change")
+                      final-response (state-collection-request resource
+                                                               :get
+                                                               nil)
+                      final-ids      (u/parse-json (:body final-response)
+                                                   :object? false)]
+                  (is (every? #(= 204 (:status %)) membership-responses))
+                  (is (contains? #{204 412} (:status delete-response))
+                      "a backend retry may expose the membership change and return 412")
+                  (is (= 200 (:status final-response)))
+                  (case membership-change
+                    :addition
+                    (do
+                      (is (some #{"new"} final-ids)
+                          "a concurrent addition is never deleted")
+                      (is (= (if (= 412 (:status delete-response))
+                               ["alpha" "new" "zeta"]
+                               ["new"])
+                             final-ids)))
+
+                    :removal
+                    (do
+                      (is (not-any? #{"zeta"} final-ids)
+                          "a concurrent removal remains absent")
+                      (is (= (if (= 412 (:status delete-response))
+                               ["alpha"]
+                               [])
+                             final-ids)))
+
+                    :recreation
+                    (do
+                      (is (some #{"zeta"} final-ids)
+                          "a recreated logical document has a new physical key and survives")
+                      (is (= winner-body
+                             (:body (document-request resource
+                                                      :get
+                                                      "zeta"
+                                                      nil
+                                                      nil))))
+                      (is (= (if (= 412 (:status delete-response))
+                               ["alpha" "zeta"]
+                               ["zeta"])
+                             final-ids)))))
+                (finally
+                  (future-cancel membership-request))))
+            (finally
+              (deliver release-read true)
+              (future-cancel collection-delete))))))))
+
+(deftest state-collection-etag-precondition-is-atomic-test
+  (let [sys (component/start (support/test-system))]
+    (try
+      (doseq [membership-change [:addition :removal :recreation]]
+        (testing (str "concurrent State document "
+                      (name membership-change))
+          (run-state-collection-race! membership-change)))
       (finally
         (component/stop sys)))))

--- a/src/test/lrsql/document_precondition_test.clj
+++ b/src/test/lrsql/document_precondition_test.clj
@@ -6,7 +6,8 @@
             [com.yetanalytics.lrs.xapi.document :as lrs-doc]
             [lrsql.test-constants :as tc]
             [lrsql.test-support :as support]
-            [lrsql.util :as u]))
+            [lrsql.util :as u]
+            [lrsql.util.document :as doc-util]))
 
 (use-fixtures :once support/instrumentation-fixture)
 (use-fixtures :each support/fresh-db-fixture)
@@ -234,5 +235,98 @@
                   tc/auth-ident
                   absent-params))
                 "If-Match fails for an absent document"))))
+      (finally
+        (component/stop sys)))))
+
+(defn- state-collection-params
+  [suffix]
+  {:activityId (str "https://example.org/precondition/collection/" suffix)
+   :agent      {"mbox" "mailto:state-collection@example.org"}})
+
+(defn- state-document-params
+  [collection-params state-id]
+  (assoc collection-params :stateId state-id))
+
+(defn- get-state-document-ids
+  [lrs params]
+  (lrsp/-get-document-ids lrs tc/ctx tc/auth-ident params))
+
+(defn- put-state-document!
+  [lrs params state-id]
+  (lrsp/-set-document lrs tc/ctx tc/auth-ident
+                      (state-document-params params state-id)
+                      (document initial-body)
+                      false))
+
+(deftest state-collection-delete-preconditions-test
+  (let [sys (component/start (support/test-system))
+        lrs (:lrs sys)]
+    (try
+      (testing "canonical response and ETag conditions"
+        (let [params (state-collection-params "conditional")]
+          (doseq [state-id ["zeta" "alpha" "middle"]]
+            (is (= {} (put-state-document! lrs params state-id))))
+          (let [ids  ["alpha" "middle" "zeta"]
+                etag (doc-util/state-document-ids-etag ids)]
+            (is (= {:document-ids ids}
+                   (get-state-document-ids lrs params))
+                "the public result stays sorted and contains no internal keys")
+            (doseq [ctx [(precondition-ctx {:if-match #{"stale"}})
+                         (precondition-ctx {:if-none-match #{etag}})
+                         (precondition-ctx {:if-none-match :*})]]
+              (is (precondition-failed?
+                   (lrsp/-delete-documents lrs ctx tc/auth-ident params)))
+              (is (= ids
+                     (:document-ids (get-state-document-ids lrs params)))
+                  "a failed collection condition leaves every row intact"))
+            (is (= {}
+                   (lrsp/-delete-documents
+                    lrs
+                    (precondition-ctx {:if-match #{etag}})
+                    tc/auth-ident
+                    params)))
+            (is (= {:document-ids []}
+                   (get-state-document-ids lrs params)))
+            (is (= {}
+                   (lrsp/-delete-documents
+                    lrs
+                    (precondition-ctx
+                     {:if-match
+                      #{(doc-util/state-document-ids-etag [])}})
+                    tc/auth-ident
+                    params))
+                "the empty collection has the ETag of its [] representation")
+            (is (= {}
+                   (lrsp/-delete-documents
+                    lrs
+                    (precondition-ctx {:if-match :*})
+                    tc/auth-ident
+                    params))
+                "the empty array representation still exists for If-Match"))))
+
+      (testing "wildcard and unconditional collection deletion"
+        (doseq [[suffix ctx]
+                [["wildcard" (precondition-ctx {:if-match :*})]
+                 ["unconditional" tc/ctx]]]
+          (let [params (state-collection-params suffix)]
+            (doseq [state-id ["one" "two"]]
+              (is (= {} (put-state-document! lrs params state-id))))
+            (is (= {} (lrsp/-delete-documents
+                       lrs ctx tc/auth-ident params)))
+            (is (= [] (:document-ids
+                       (get-state-document-ids lrs params)))))))
+
+      (testing "registration remains part of the collection scope"
+        (let [params       (state-collection-params "registration")
+              registration "00000000-0000-4000-8000-000000000001"
+              registered   (assoc params :registration registration)]
+          (is (= {} (put-state-document! lrs params "unregistered")))
+          (is (= {} (put-state-document! lrs registered "registered")))
+          (is (= {} (lrsp/-delete-documents
+                     lrs tc/ctx tc/auth-ident registered)))
+          (is (= {:document-ids ["unregistered"]}
+                 (get-state-document-ids lrs params)))
+          (is (= {:document-ids []}
+                 (get-state-document-ids lrs registered)))))
       (finally
         (component/stop sys)))))

--- a/src/test/lrsql/ops/command/document_test.clj
+++ b/src/test/lrsql/ops/command/document_test.clj
@@ -1,5 +1,5 @@
 (ns lrsql.ops.command.document-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [com.yetanalytics.lrs.util.hash :as hash]
             [com.yetanalytics.lrs.xapi.document :as lrs-doc]
             [lrsql.backend.protocol :as bp]
@@ -97,6 +97,142 @@
            {:stmt-retry-limit  2
             :stmt-retry-budget 1})
           :j-range 0)))
+
+(defn- state-collection-backend
+  [rows delete-calls]
+  (reify
+    bp/BackendUtil
+    (-txn-retry? [_ ex]
+      (= ::retryable-database-error (:type (ex-data ex))))
+
+    bp/StateDocumentBackend
+    (-insert-state-document! [_ _ _] nil)
+    (-insert-state-document-if-absent! [_ _ _] false)
+    (-update-state-document! [_ _ _] nil)
+    (-update-state-document-if-contents! [_ _ _] false)
+    (-delete-state-document! [_ _ _] nil)
+    (-delete-state-document-if-contents! [_ _ _] false)
+    (-delete-state-documents! [_ _ _] nil)
+    (-delete-state-documents-by-primary-keys! [_ _ input]
+      (swap! delete-calls conj input)
+      0)
+    (-query-state-document [_ _ _] nil)
+    (-query-state-document-ids [_ _ _] @rows)
+    (-query-state-document-exists [_ _ _] false)))
+
+(deftest state-collection-observed-primary-key-delete-test
+  (let [ids          (mapv #(format "state-%03d" %) (range 502))
+        primary-keys (mapv (fn [_] (UUID/randomUUID)) ids)
+        rows          (atom (mapv (fn [primary-key state-id]
+                                    {:id primary-key :state_id state-id})
+                                  (reverse primary-keys)
+                                  (reverse ids)))
+        delete-calls  (atom [])
+        backend       (state-collection-backend rows delete-calls)
+        input         {:table        :state-document
+                       :activity-iri "https://example.org/collection"
+                       :agent-ifi    "mbox::mailto:test@example.org"
+                       :registration nil}
+        ctx           {::lrs-doc/preconditions
+                       {:if-match
+                        #{(document/state-document-ids-etag ids)}}}]
+    (is (= {} (command/delete-documents-cas!
+               backend ::tx ctx input)))
+    (is (= [500 2] (mapv (comp count :primary-keys) @delete-calls))
+        "observed primary keys are deleted in 500-row batches")
+    (is (= (sort-by str primary-keys)
+           (mapcat :primary-keys @delete-calls))
+        "primary keys have a deterministic lock order")
+    (is (every? #(= (select-keys input [:activity-iri
+                                        :agent-ifi
+                                        :registration])
+                    (select-keys % [:activity-iri
+                                    :agent-ifi
+                                    :registration]))
+                @delete-calls)
+        "each batch retains its collection scope")))
+
+(deftest state-collection-precondition-and-retry-test
+  (let [initial-rows [{:id (UUID/randomUUID) :state_id "initial"}]
+        changed-rows [{:id (UUID/randomUUID) :state_id "initial"}
+                      {:id (UUID/randomUUID) :state_id "new"}]
+        input        {:table        :state-document
+                      :activity-iri "https://example.org/collection"
+                      :agent-ifi    "mbox::mailto:test@example.org"}]
+    (testing "stale and wildcard conditions do not delete"
+      (doseq [preconditions [{:if-match #{"stale"}}
+                             {:if-none-match :*}]]
+        (let [rows         (atom initial-rows)
+              delete-calls (atom [])
+              backend      (state-collection-backend rows delete-calls)
+              result       (command/delete-documents-cas!
+                            backend ::tx
+                            {::lrs-doc/preconditions preconditions}
+                            input)]
+          (is (lrs-doc/precondition-failed? (:error result)))
+          (is (empty? @delete-calls)))))
+
+    (testing "the empty collection validates against the [] representation"
+      (let [rows         (atom [])
+            delete-calls (atom [])
+            backend      (state-collection-backend rows delete-calls)]
+        (is (= {} (command/delete-documents-cas!
+                   backend ::tx
+                   {::lrs-doc/preconditions
+                    {:if-match
+                     #{(document/state-document-ids-etag [])}}}
+                   input)))
+        (is (empty? @delete-calls))))
+
+    (testing "a retried database conflict reevaluates the original condition"
+      (let [rows          (atom initial-rows)
+            delete-calls  (atom [])
+            base-backend  (state-collection-backend rows delete-calls)
+            first-delete? (atom true)
+            backend       (reify
+                            bp/BackendUtil
+                            (-txn-retry? [_ ex]
+                              (= ::retryable-database-error
+                                 (:type (ex-data ex))))
+                            bp/StateDocumentBackend
+                            (-insert-state-document! [_ _ _] nil)
+                            (-insert-state-document-if-absent! [_ _ _] false)
+                            (-update-state-document! [_ _ _] nil)
+                            (-update-state-document-if-contents! [_ _ _] false)
+                            (-delete-state-document! [_ _ _] nil)
+                            (-delete-state-document-if-contents! [_ _ _] false)
+                            (-delete-state-documents! [_ _ _] nil)
+                            (-delete-state-documents-by-primary-keys!
+                              [_ _ delete-input]
+                              (if (compare-and-set! first-delete? true false)
+                                (do
+                                  (reset! rows changed-rows)
+                                  (throw
+                                   (ex-info "Retry database error"
+                                            {:type
+                                             ::retryable-database-error})))
+                                (bp/-delete-state-documents-by-primary-keys!
+                                 base-backend ::tx delete-input)))
+                            (-query-state-document [_ _ _] nil)
+                            (-query-state-document-ids [_ _ _] @rows)
+                            (-query-state-document-exists [_ _ _] false))
+            ctx           {::lrs-doc/preconditions
+                           {:if-match
+                            #{(document/state-document-ids-etag
+                               ["initial"])}}}
+            result        (concurrency/rerunable-txn*
+                           #(command/delete-documents-cas!
+                             backend ::tx ctx input)
+                           0
+                           (assoc (document/document-retry-opts
+                                   backend
+                                   {:stmt-retry-limit  2
+                                    :stmt-retry-budget 1})
+                                  :j-range 0))]
+        (is (lrs-doc/precondition-failed? (:error result)))
+        (is (= changed-rows @rows))
+        (is (empty? @delete-calls)
+            "the stale retry cannot delete the changed collection")))))
 
 (deftest stale-precondition-after-cas-conflict-test
   (let [initial-body "{\"value\":\"initial\"}"

--- a/src/test/lrsql/util/document_test.clj
+++ b/src/test/lrsql/util/document_test.clj
@@ -5,7 +5,8 @@
             [lrsql.backend.protocol :as bp]
             [lrsql.util.concurrency :as concurrency]
             [lrsql.util.document :as document])
-  (:import [java.nio.charset StandardCharsets]))
+  (:import [java.nio.charset StandardCharsets]
+           [java.util Arrays]))
 
 (defn- utf8-bytes
   [s]
@@ -15,6 +16,19 @@
   (reify bp/BackendUtil
     (-txn-retry? [_ ex]
       (= ::retryable-database-error (:type (ex-data ex))))))
+
+(deftest state-document-id-representation-test
+  (let [canonical ["alpha" "middle" "zeta"]
+        json      "[\"alpha\",\"middle\",\"zeta\"]"]
+    (is (= canonical
+           (document/canonical-state-document-ids
+            ["zeta" "alpha" "middle"])))
+    (is (Arrays/equals (utf8-bytes json)
+                       (document/state-document-ids-contents canonical)))
+    (is (= (hash/sha-1 json)
+           (document/state-document-ids-etag canonical)))
+    (is (= (hash/sha-1 "[]")
+           (document/state-document-ids-etag [])))))
 
 (deftest normalized-preconditions-test
   (let [contents (utf8-bytes "{\"value\":\"current\"}")
@@ -106,6 +120,8 @@
                  :stmt-retry-budget 250})]
       (is (= 7 (:max-attempt opts)))
       (is (= 250 (:budget opts)))
+      (is (not (contains? opts :isolation))
+          "document CAS does not override transaction isolation")
       (is ((:retry-test opts) (document/cas-conflict-ex)))
       (is ((:retry-test opts)
            (ex-info "Retry database error"


### PR DESCRIPTION
This approach to bulk document delete uses the observed keys of listed documents to delete them. Compare to the serializable tx approach here: https://github.com/yetanalytics/lrsql/pull/522